### PR TITLE
Implement Claude Code-style task group UI with approval handling

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -8,6 +8,7 @@ import { useChat } from "@ai-sdk/react";
 import { renderMarkdown } from "./lib/markdown.js";
 import { useChatContext } from "./chat-context.js";
 import { ToolCall } from "./components/tool-call.js";
+import { TaskGroupView } from "./components/task-group-view.js";
 import { StatusBar } from "./components/status-bar.js";
 import { InputBox } from "./components/input-box.js";
 import { Header } from "./components/header.js";
@@ -100,6 +101,11 @@ const UserMessage = memo(function UserMessage({
   );
 });
 
+// Group consecutive task parts together while preserving order
+type RenderGroup =
+  | { type: "part"; part: TUIAgentUIMessagePart; index: number }
+  | { type: "task-group"; tasks: TUIAgentUIToolPart[]; startIndex: number };
+
 const AssistantMessage = memo(function AssistantMessage({
   message,
   activeApprovalId,
@@ -107,11 +113,64 @@ const AssistantMessage = memo(function AssistantMessage({
   message: TUIAgentUIMessage;
   activeApprovalId: string | null;
 }) {
+  // Group consecutive task parts together, keeping them in linear order
+  const renderGroups = useMemo(() => {
+    const groups: RenderGroup[] = [];
+    let currentTaskGroup: TUIAgentUIToolPart[] = [];
+    let taskGroupStartIndex = 0;
+
+    message.parts.forEach((part, index) => {
+      const isTask = isToolUIPart(part) && part.type === "tool-task";
+
+      if (isTask) {
+        if (currentTaskGroup.length === 0) {
+          taskGroupStartIndex = index;
+        }
+        currentTaskGroup.push(part);
+      } else {
+        // Flush any pending task group
+        if (currentTaskGroup.length > 0) {
+          groups.push({
+            type: "task-group",
+            tasks: currentTaskGroup,
+            startIndex: taskGroupStartIndex,
+          });
+          currentTaskGroup = [];
+        }
+        groups.push({ type: "part", part, index });
+      }
+    });
+
+    // Flush remaining task group
+    if (currentTaskGroup.length > 0) {
+      groups.push({
+        type: "task-group",
+        tasks: currentTaskGroup,
+        startIndex: taskGroupStartIndex,
+      });
+    }
+
+    return groups;
+  }, [message.parts]);
+
   return (
     <Box flexDirection="column">
-      {message.parts.map((part, index) =>
-        renderPart(part, `${message.id}-${index}`, activeApprovalId),
-      )}
+      {renderGroups.map((group) => {
+        if (group.type === "task-group") {
+          return (
+            <TaskGroupView
+              key={`task-group-${group.startIndex}`}
+              taskParts={group.tasks}
+              activeApprovalId={activeApprovalId}
+            />
+          );
+        }
+        return renderPart(
+          group.part,
+          `${message.id}-${group.index}`,
+          activeApprovalId
+        );
+      })}
     </Box>
   );
 });

--- a/src/tui/components/task-group-view.tsx
+++ b/src/tui/components/task-group-view.tsx
@@ -1,0 +1,322 @@
+import React, { useState, useEffect, useRef, useMemo } from "react";
+import { Box, Text } from "ink";
+import { getToolName, isToolUIPart, isTextUIPart } from "ai";
+import type { TUIAgentUIToolPart } from "../types.js";
+import { ApprovalButtons } from "./tool-call.js";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+function TaskSpinner() {
+  const [frame, setFrame] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setFrame((prev) => (prev + 1) % SPINNER_FRAMES.length);
+    }, 80);
+    return () => clearInterval(timer);
+  }, []);
+
+  return <Text color="gray">{SPINNER_FRAMES[frame]}</Text>;
+}
+
+function FlashingDot() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setVisible((prev) => !prev);
+    }, 500);
+    return () => clearInterval(timer);
+  }, []);
+
+  return <Text color="gray">{visible ? "●" : " "}</Text>;
+}
+
+function formatTime(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}m ${secs}s`;
+}
+
+function useTaskTiming(isRunning: boolean) {
+  const startTimeRef = useRef<number | null>(null);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  useEffect(() => {
+    if (isRunning && !startTimeRef.current) {
+      startTimeRef.current = Date.now();
+    }
+
+    if (!isRunning) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (startTimeRef.current) {
+        setElapsedSeconds(
+          Math.floor((Date.now() - startTimeRef.current) / 1000)
+        );
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isRunning]);
+
+  return elapsedSeconds;
+}
+
+type TaskStatus =
+  | "pending"
+  | "running"
+  | "complete"
+  | "error"
+  | "approval-requested"
+  | "denied";
+
+function getTaskStatus(part: TUIAgentUIToolPart): TaskStatus {
+  if (part.state === "approval-requested") return "approval-requested";
+  if (part.state === "output-denied") return "denied";
+  if (part.state === "output-error") return "error";
+  if (part.state === "output-available" && !part.preliminary) return "complete";
+  if (
+    part.state === "input-streaming" ||
+    part.state === "input-available" ||
+    (part.state === "output-available" && part.preliminary)
+  ) {
+    return "running";
+  }
+  return "pending";
+}
+
+// Type for task output which contains parts from sub-agent
+type TaskOutputPart = Parameters<typeof isToolUIPart>[0];
+type TaskOutput = { parts?: TaskOutputPart[] };
+
+function countTaskTools(part: TUIAgentUIToolPart): number {
+  const message = part.output as TaskOutput | undefined;
+  if (!message?.parts) {
+    return 0;
+  }
+  return message.parts.filter(isToolUIPart).length;
+}
+
+function getLastToolInfo(
+  part: TUIAgentUIToolPart
+): { name: string; summary: string } | null {
+  const message = part.output as TaskOutput | undefined;
+  if (!message?.parts) return null;
+
+  const toolParts = message.parts.filter(isToolUIPart);
+  if (toolParts.length === 0) return null;
+
+  const lastTool = toolParts[toolParts.length - 1];
+  if (!lastTool) return null;
+
+  const toolName = getToolName(lastTool);
+  const input = lastTool.input as Record<string, unknown> | undefined;
+
+  let summary = "";
+  if (input?.filePath) {
+    summary = String(input.filePath);
+  } else if (input?.pattern) {
+    summary = `"${input.pattern}"`;
+  } else if (input?.command) {
+    const cmd = String(input.command);
+    summary = cmd.length > 40 ? cmd.slice(0, 40) + "..." : cmd;
+  }
+
+  const displayName = toolName.charAt(0).toUpperCase() + toolName.slice(1);
+  return { name: displayName, summary };
+}
+
+function TaskStatusIndicator({ status }: { status: TaskStatus }) {
+  switch (status) {
+    case "running":
+      return <TaskSpinner />;
+    case "pending":
+      return <FlashingDot />;
+    case "approval-requested":
+      // Static white circle for approval needed
+      return <Text color="white">●</Text>;
+    case "complete":
+      return <Text color="green">✓</Text>;
+    case "error":
+    case "denied":
+      return <Text color="red">✗</Text>;
+    default:
+      return <Text color="gray">●</Text>;
+  }
+}
+
+function TaskItem({
+  part,
+  isLast,
+  activeApprovalId,
+}: {
+  part: TUIAgentUIToolPart;
+  isLast: boolean;
+  activeApprovalId: string | null;
+}) {
+  const status = getTaskStatus(part);
+  const isRunning = status === "running" || status === "pending";
+  const elapsedSeconds = useTaskTiming(isRunning);
+  const toolCount = countTaskTools(part);
+  const lastTool = getLastToolInfo(part);
+
+  const desc =
+    (part.input as { description?: string })?.description ??
+    (part.input as { task?: string })?.task ??
+    "Task";
+
+  const subagentType = (part.input as { subagentType?: string })?.subagentType;
+
+  // Handle approval state
+  const approvalRequested = part.state === "approval-requested";
+  const approvalId = approvalRequested
+    ? (part as { approval?: { id: string } }).approval?.id
+    : undefined;
+  const isActiveApproval = approvalId != null && approvalId === activeApprovalId;
+
+  // Handle denial
+  const denied = part.state === "output-denied";
+  const denialReason = denied
+    ? (part as { approval?: { reason?: string } }).approval?.reason
+    : undefined;
+
+  const treeChar = isLast ? "└─" : "├─";
+  const continueChar = isLast ? "   " : "│  ";
+
+  // Determine nested status line
+  let nestedStatus = "";
+  if (status === "complete") {
+    nestedStatus = "Done";
+  } else if (denied) {
+    nestedStatus = denialReason ? `Denied: ${denialReason}` : "Denied";
+  } else if (approvalRequested) {
+    nestedStatus = "Awaiting approval...";
+  } else if (status === "pending" || (status === "running" && toolCount === 0)) {
+    nestedStatus = "Initializing...";
+  } else if (lastTool) {
+    nestedStatus = lastTool.summary
+      ? `${lastTool.name}(${lastTool.summary})`
+      : lastTool.name;
+  }
+
+  return (
+    <Box flexDirection="column">
+      {/* Task row */}
+      <Box>
+        <Text color="gray">{treeChar} </Text>
+        <TaskStatusIndicator status={status} />
+        <Text> </Text>
+        <Text
+          color={
+            status === "error" || status === "denied"
+              ? "red"
+              : "white"
+          }
+        >
+          {desc}
+        </Text>
+        <Text color="gray">
+          {" "}
+          - {toolCount} tool{toolCount !== 1 ? "s" : ""}
+        </Text>
+        {approvalRequested && (
+          <Text color="yellow"> [NEEDS APPROVAL]</Text>
+        )}
+        {isRunning && elapsedSeconds > 0 && (
+          <Text color="gray"> - {formatTime(elapsedSeconds)}</Text>
+        )}
+      </Box>
+
+      {/* Executor approval warning */}
+      {approvalRequested && subagentType === "executor" && (
+        <Box paddingLeft={4}>
+          <Text color="yellow">
+            This executor has full write access and can create, modify, and delete files.
+          </Text>
+        </Box>
+      )}
+
+      {/* Approval buttons */}
+      {isActiveApproval && approvalId && (
+        <ApprovalButtons approvalId={approvalId} />
+      )}
+
+      {/* Nested status line - only show if not showing approval buttons */}
+      {nestedStatus && !isActiveApproval && (
+        <Box>
+          <Text color="gray">{continueChar}└ </Text>
+          <Text color={denied ? "red" : "gray"}>{nestedStatus}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+type TaskGroupViewProps = {
+  taskParts: TUIAgentUIToolPart[];
+  activeApprovalId: string | null;
+};
+
+export function TaskGroupView({ taskParts, activeApprovalId }: TaskGroupViewProps) {
+  if (taskParts.length === 0) return null;
+
+  // Count different states
+  const hasApprovalPending = taskParts.some(
+    (p) => getTaskStatus(p) === "approval-requested"
+  );
+  const runningCount = taskParts.filter((p) => {
+    const status = getTaskStatus(p);
+    return status === "running" || status === "pending";
+  }).length;
+  const allComplete =
+    runningCount === 0 && !hasApprovalPending;
+
+  // Determine header text
+  let headerText: string;
+  if (allComplete) {
+    headerText = `Completed ${taskParts.length} Task agent${taskParts.length > 1 ? "s" : ""}`;
+  } else if (hasApprovalPending && runningCount === 0) {
+    headerText = `${taskParts.length} Task agent${taskParts.length > 1 ? "s" : ""} (approval needed)`;
+  } else {
+    headerText = `Running ${taskParts.length} Task agent${taskParts.length > 1 ? "s" : ""}...`;
+  }
+
+  return (
+    <Box flexDirection="column" marginTop={1} marginBottom={1}>
+      {/* Header */}
+      <Box>
+        {allComplete ? (
+          <Text color="green">● </Text>
+        ) : hasApprovalPending && runningCount === 0 ? (
+          <Text color="white">● </Text>
+        ) : (
+          <>
+            <TaskSpinner />
+            <Text> </Text>
+          </>
+        )}
+        <Text bold color="white">
+          {headerText}
+        </Text>
+      </Box>
+
+      {/* Task list */}
+      <Box flexDirection="column">
+        {taskParts.map((part, index) => (
+          <TaskItem
+            key={part.toolCallId}
+            part={part}
+            isLast={index === taskParts.length - 1}
+            activeApprovalId={activeApprovalId}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -13,7 +13,7 @@ type DiffLine = {
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
-function ToolSpinner() {
+export function ToolSpinner() {
   const [frame, setFrame] = useState(0);
 
   useEffect(() => {
@@ -26,7 +26,7 @@ function ToolSpinner() {
   return <Text color="yellow">{SPINNER_FRAMES[frame]} </Text>;
 }
 
-function ApprovalButtons({ approvalId }: { approvalId: string }) {
+export function ApprovalButtons({ approvalId }: { approvalId: string }) {
   const { chat } = useChatContext();
   const { addToolApprovalResponse } = useChat({
     chat,
@@ -418,7 +418,7 @@ function createEditDiffLines(
 
 // Simplified tool call renderer for subagent tool parts
 // Uses a looser type since these come from a different agent's tool set
-function SubagentToolCall({
+export function SubagentToolCall({
   part,
 }: {
   part: Parameters<typeof getToolName>[0];


### PR DESCRIPTION
## Summary
Adds a new TaskGroupView component that groups consecutive task parts and renders them with a Claude Code-style interface. Includes proper approval flow handling with clear visual indicators for approval-pending states.

## Changes
- New `task-group-view.tsx` component with grouped task rendering
- Tasks are displayed linearly in conversation (not grouped at end)
- Approval state shows static white dot and [NEEDS APPROVAL] label
- Header shows "(approval needed)" when tasks await approval
- Proper approval button integration with ApprovalButtons component
- Exports ApprovalButtons and SubagentToolCall for reuse

🤖 Generated with Claude Code