### PR TITLE
Add models configuration with default settings middleware

### DIFF
--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -1,10 +1,8 @@
 import {
   ToolLoopAgent,
-  gateway,
   stepCountIs,
   wrapLanguageModel,
   type TypedToolResult,
-  type InferUITools,
 } from "ai";
 import { z } from "zod";
 import {
@@ -16,16 +14,13 @@ import {
   globTool,
   bashTool,
   taskTool,
-  memorySaveTool,
-  memoryRecallTool,
 } from "./tools";
 import { buildSystemPrompt } from "./system-prompt";
 import { formatTodosForContext, formatScratchpadForContext } from "./state";
 import type { TodoItem, ScratchpadEntry } from "./types";
 import { todoItemSchema } from "./types";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 import { addCacheControl, compactContext } from "./utils";
-import { anthropic } from "@ai-sdk/anthropic";
+import { gateway } from "../models";
 
 const callOptionsSchema = z.object({
   workingDirectory: z.string(),
@@ -47,17 +42,14 @@ const callOptionsSchema = z.object({
 
 export type DeepAgentCallOptions = z.infer<typeof callOptionsSchema>;
 
-const model = gateway("anthropic/claude-haiku-4.5");
-// const model = anthropic("claude-haiku-4-5");
+const model = gateway("anthropic/claude-haiku-4.5", {
+  devtools: true,
+});
 
 export const deepAgentModelId = model.modelId;
 
 export const deepAgent = new ToolLoopAgent({
-  model: wrapLanguageModel({
-    middleware: devToolsMiddleware(),
-    model,
-  }),
-  // model, // non dev-tools model
+  model,
   instructions: buildSystemPrompt({}),
   tools: addCacheControl({
     tools: {

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,57 @@
+import {
+  defaultSettingsMiddleware,
+  gateway as aiGateway,
+  wrapLanguageModel,
+  type GatewayModelId,
+  type LanguageModel,
+} from "ai";
+import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
+import { devToolsMiddleware } from "@ai-sdk/devtools";
+
+type LanguageModelV3 = LanguageModel & { specificationVersion: "v3" };
+
+const anthropicMiddleware = defaultSettingsMiddleware({
+  settings: {
+    providerOptions: {
+      anthropic: {
+        thinking: { type: "enabled", budgetTokens: 12000 },
+      } satisfies AnthropicProviderOptions,
+    },
+  },
+});
+
+const languageModels = {
+  "anthropic/claude-opus-4.5": wrapLanguageModel({
+    model: aiGateway("anthropic/claude-opus-4.5"),
+    middleware: anthropicMiddleware,
+  }),
+  "anthropic/claude-sonnet-4.5": wrapLanguageModel({
+    model: aiGateway("anthropic/claude-sonnet-4.5"),
+    middleware: anthropicMiddleware,
+  }),
+  "anthropic/claude-haiku-4.5": wrapLanguageModel({
+    model: aiGateway("anthropic/claude-haiku-4.5"),
+    middleware: anthropicMiddleware,
+  }),
+};
+
+export function gateway(
+  modelId: GatewayModelId,
+  { devtools }: { devtools: boolean },
+) {
+  let model: LanguageModelV3;
+  if (modelId in languageModels) {
+    model = languageModels[modelId as keyof typeof languageModels];
+  } else {
+    model = aiGateway(modelId);
+  }
+
+  if (devtools) {
+    model = wrapLanguageModel({
+      model,
+      middleware: devToolsMiddleware(),
+    });
+  }
+
+  return model;
+}


### PR DESCRIPTION
Create a centralized models.ts file with pre-configured Anthropic models (opus, sonnet, haiku) that automatically apply default settings including thinking mode with 12k token budget. The `gateway()` function accepts any GatewayModelId and returns configured models from the registry or falls back to plain gateway for unconfigured models. Optionally enables devtools middleware for debugging.

🤖 Generated with Claude Code