### PR TITLE
Implement sandbox adapter pattern for file system operations

### DIFF
--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -90,7 +90,10 @@ export const deepAgent = new ToolLoopAgent({
     const todos = options?.todos ?? [];
     const scratchpad =
       options?.scratchpad ?? new Map<string, ScratchpadEntry>();
-    const sandbox = options?.sandbox ?? createLocalSandbox();
+
+    // Use provided sandbox, or create a local sandbox with the working directory
+    const sandbox =
+      options?.sandbox ?? createLocalSandbox(workingDirectory);
 
     const todosContext = formatTodosForContext(todos);
     const scratchpadContext = formatScratchpadForContext(scratchpad);
@@ -99,12 +102,12 @@ export const deepAgent = new ToolLoopAgent({
       ...settings,
       model,
       instructions: buildSystemPrompt({
-        cwd: workingDirectory,
+        cwd: sandbox.workingDirectory,
         customInstructions,
         todosContext,
         scratchpadContext,
       }),
-      experimental_context: { workingDirectory, sandbox },
+      experimental_context: { sandbox },
     };
   },
 });

--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -26,6 +26,7 @@ import { todoItemSchema } from "./types";
 import { devToolsMiddleware } from "@ai-sdk/devtools";
 import { addCacheControl, compactContext } from "./utils";
 import { anthropic } from "@ai-sdk/anthropic";
+import { createLocalSandbox, type Sandbox } from "./sandbox";
 
 const callOptionsSchema = z.object({
   workingDirectory: z.string(),
@@ -43,6 +44,7 @@ const callOptionsSchema = z.object({
       }),
     )
     .optional(),
+  sandbox: z.custom<Sandbox>().optional(),
 });
 
 export type DeepAgentCallOptions = z.infer<typeof callOptionsSchema>;
@@ -88,6 +90,7 @@ export const deepAgent = new ToolLoopAgent({
     const todos = options?.todos ?? [];
     const scratchpad =
       options?.scratchpad ?? new Map<string, ScratchpadEntry>();
+    const sandbox = options?.sandbox ?? createLocalSandbox();
 
     const todosContext = formatTodosForContext(todos);
     const scratchpadContext = formatScratchpadForContext(scratchpad);
@@ -101,7 +104,7 @@ export const deepAgent = new ToolLoopAgent({
         todosContext,
         scratchpadContext,
       }),
-      experimental_context: { workingDirectory },
+      experimental_context: { workingDirectory, sandbox },
     };
   },
 });

--- a/src/agent/sandbox/index.ts
+++ b/src/agent/sandbox/index.ts
@@ -1,0 +1,2 @@
+export type { Sandbox, SandboxStats, ExecResult } from "./interface";
+export { LocalSandbox, createLocalSandbox } from "./local";

--- a/src/agent/sandbox/interface.ts
+++ b/src/agent/sandbox/interface.ts
@@ -33,6 +33,11 @@ export interface ExecResult {
  */
 export interface Sandbox {
   /**
+   * The working directory for this sandbox.
+   * All path validations should be relative to this directory.
+   */
+  readonly workingDirectory: string;
+  /**
    * Read file contents as UTF-8 string
    */
   readFile(path: string, encoding: "utf-8"): Promise<string>;

--- a/src/agent/sandbox/interface.ts
+++ b/src/agent/sandbox/interface.ts
@@ -1,0 +1,72 @@
+import type { Dirent } from "fs";
+
+/**
+ * File stats returned by sandbox.stat()
+ * Mirrors the subset of fs.Stats used by the tools
+ */
+export interface SandboxStats {
+  isDirectory(): boolean;
+  isFile(): boolean;
+  size: number;
+  mtimeMs: number;
+}
+
+/**
+ * Result of shell command execution
+ */
+export interface ExecResult {
+  success: boolean;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+}
+
+/**
+ * Sandbox interface for file system and shell operations.
+ *
+ * Mirrors the fs/promises API for easy implementation with local fs,
+ * but can be implemented by remote sandboxes (Docker, E2B, etc.).
+ *
+ * Security note: The sandbox does NOT enforce path boundaries.
+ * Tools are responsible for validating paths before calling sandbox methods.
+ */
+export interface Sandbox {
+  /**
+   * Read file contents as UTF-8 string
+   */
+  readFile(path: string, encoding: "utf-8"): Promise<string>;
+
+  /**
+   * Write content to a file (creates or overwrites)
+   */
+  writeFile(path: string, content: string, encoding: "utf-8"): Promise<void>;
+
+  /**
+   * Get file/directory stats
+   */
+  stat(path: string): Promise<SandboxStats>;
+
+  /**
+   * Check if path is accessible (throws if not)
+   */
+  access(path: string): Promise<void>;
+
+  /**
+   * Create directory (optionally recursive)
+   */
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+
+  /**
+   * Read directory contents with file type info
+   */
+  readdir(path: string, options: { withFileTypes: true }): Promise<Dirent[]>;
+
+  /**
+   * Execute a shell command
+   * @param command - The command to execute
+   * @param cwd - Working directory for the command
+   * @param timeoutMs - Timeout in milliseconds
+   */
+  exec(command: string, cwd: string, timeoutMs: number): Promise<ExecResult>;
+}

--- a/src/agent/sandbox/local.ts
+++ b/src/agent/sandbox/local.ts
@@ -10,6 +10,12 @@ const MAX_OUTPUT_LENGTH = 50_000;
  * This is the default sandbox used when no custom sandbox is provided.
  */
 export class LocalSandbox implements Sandbox {
+  readonly workingDirectory: string;
+
+  constructor(workingDirectory: string) {
+    this.workingDirectory = workingDirectory;
+  }
+
   async readFile(path: string, encoding: "utf-8"): Promise<string> {
     return fs.readFile(path, encoding);
   }
@@ -109,7 +115,9 @@ export class LocalSandbox implements Sandbox {
 /**
  * Create a new local sandbox instance.
  * Use this as the default when no custom sandbox is provided.
+ *
+ * @param workingDirectory - The root directory for sandbox operations
  */
-export function createLocalSandbox(): Sandbox {
-  return new LocalSandbox();
+export function createLocalSandbox(workingDirectory: string): Sandbox {
+  return new LocalSandbox(workingDirectory);
 }

--- a/src/agent/sandbox/local.ts
+++ b/src/agent/sandbox/local.ts
@@ -1,0 +1,115 @@
+import * as fs from "fs/promises";
+import { spawn } from "child_process";
+import type { Dirent } from "fs";
+import type { Sandbox, SandboxStats, ExecResult } from "./interface";
+
+const MAX_OUTPUT_LENGTH = 50_000;
+
+/**
+ * Local sandbox implementation using Node.js fs/promises and child_process.
+ * This is the default sandbox used when no custom sandbox is provided.
+ */
+export class LocalSandbox implements Sandbox {
+  async readFile(path: string, encoding: "utf-8"): Promise<string> {
+    return fs.readFile(path, encoding);
+  }
+
+  async writeFile(
+    path: string,
+    content: string,
+    encoding: "utf-8"
+  ): Promise<void> {
+    await fs.writeFile(path, content, encoding);
+  }
+
+  async stat(path: string): Promise<SandboxStats> {
+    const stats = await fs.stat(path);
+    return {
+      isDirectory: () => stats.isDirectory(),
+      isFile: () => stats.isFile(),
+      size: stats.size,
+      mtimeMs: stats.mtimeMs,
+    };
+  }
+
+  async access(path: string): Promise<void> {
+    await fs.access(path);
+  }
+
+  async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+    await fs.mkdir(path, options);
+  }
+
+  async readdir(
+    path: string,
+    options: { withFileTypes: true }
+  ): Promise<Dirent[]> {
+    return fs.readdir(path, options);
+  }
+
+  async exec(
+    command: string,
+    cwd: string,
+    timeoutMs: number
+  ): Promise<ExecResult> {
+    return new Promise((resolve) => {
+      const child = spawn("bash", ["-c", command], {
+        cwd,
+        env: { ...process.env },
+        timeout: timeoutMs,
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let truncated = false;
+
+      child.stdout.on("data", (data) => {
+        const chunk = data.toString();
+        if (stdout.length + chunk.length > MAX_OUTPUT_LENGTH) {
+          stdout += chunk.slice(0, MAX_OUTPUT_LENGTH - stdout.length);
+          truncated = true;
+        } else {
+          stdout += chunk;
+        }
+      });
+
+      child.stderr.on("data", (data) => {
+        const chunk = data.toString();
+        if (stderr.length + chunk.length > MAX_OUTPUT_LENGTH) {
+          stderr += chunk.slice(0, MAX_OUTPUT_LENGTH - stderr.length);
+          truncated = true;
+        } else {
+          stderr += chunk;
+        }
+      });
+
+      child.on("close", (code) => {
+        resolve({
+          success: code === 0,
+          exitCode: code,
+          stdout,
+          stderr,
+          truncated,
+        });
+      });
+
+      child.on("error", (error) => {
+        resolve({
+          success: false,
+          exitCode: null,
+          stdout,
+          stderr: error.message,
+          truncated,
+        });
+      });
+    });
+  }
+}
+
+/**
+ * Create a new local sandbox instance.
+ * Use this as the default when no custom sandbox is provided.
+ */
+export function createLocalSandbox(): Sandbox {
+  return new LocalSandbox();
+}

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -134,8 +134,8 @@ EXAMPLES:
   inputSchema: bashInputSchema,
   execute: async ({ command, cwd }, { experimental_context }) => {
     const context = experimental_context as AgentContext | undefined;
-    const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const sandbox = context?.sandbox ?? createLocalSandbox();
+    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const workingDirectory = sandbox.workingDirectory;
 
     // Resolve the working directory
     const workingDir = cwd

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
 import { isPathWithinDirectory } from "../../utils";
+import { createLocalSandbox } from "../../sandbox";
 
 const TIMEOUT_MS = 120_000;
 
@@ -132,9 +133,9 @@ EXAMPLES:
 - List files in src: command: "ls -la", cwd: "/Users/username/project/src"`,
   inputSchema: bashInputSchema,
   execute: async ({ command, cwd }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
+    const context = experimental_context as AgentContext | undefined;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const { sandbox } = context;
+    const sandbox = context?.sandbox ?? createLocalSandbox();
 
     // Resolve the working directory
     const workingDir = cwd

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
 import { isPathWithinDirectory } from "../../utils";
-import { createLocalSandbox } from "../../sandbox";
 
 const TIMEOUT_MS = 120_000;
 
@@ -133,8 +132,8 @@ EXAMPLES:
 - List files in src: command: "ls -la", cwd: "/Users/username/project/src"`,
   inputSchema: bashInputSchema,
   execute: async ({ command, cwd }, { experimental_context }) => {
-    const context = experimental_context as AgentContext | undefined;
-    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const context = experimental_context as AgentContext;
+    const sandbox = context.sandbox;
     const workingDirectory = sandbox.workingDirectory;
 
     // Resolve the working directory

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -1,8 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import type { AgentContext } from "../../types";
-import { isPathWithinDirectory } from "../../utils";
+import { isPathWithinDirectory, getSandbox } from "../../utils";
 
 const TIMEOUT_MS = 120_000;
 
@@ -132,8 +131,7 @@ EXAMPLES:
 - List files in src: command: "ls -la", cwd: "/Users/username/project/src"`,
   inputSchema: bashInputSchema,
   execute: async ({ command, cwd }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
-    const sandbox = context.sandbox;
+    const sandbox = getSandbox(experimental_context);
     const workingDirectory = sandbox.workingDirectory;
 
     // Resolve the working directory

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -1,83 +1,10 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { spawn } from "child_process";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-
-function isPathWithinDirectory(filePath: string, directory: string): boolean {
-  const resolvedPath = path.resolve(filePath);
-  const resolvedDir = path.resolve(directory);
-  return resolvedPath.startsWith(resolvedDir + path.sep) || resolvedPath === resolvedDir;
-}
+import { isPathWithinDirectory } from "../../utils";
 
 const TIMEOUT_MS = 120_000;
-const MAX_OUTPUT_LENGTH = 50_000;
-
-interface BashResult {
-  success: boolean;
-  exitCode: number | null;
-  stdout: string;
-  stderr: string;
-  truncated: boolean;
-}
-
-async function executeCommand(
-  command: string,
-  cwd: string,
-  timeoutMs: number
-): Promise<BashResult> {
-  return new Promise((resolve) => {
-    const child = spawn("bash", ["-c", command], {
-      cwd,
-      env: { ...process.env },
-      timeout: timeoutMs,
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let truncated = false;
-
-    child.stdout.on("data", (data) => {
-      const chunk = data.toString();
-      if (stdout.length + chunk.length > MAX_OUTPUT_LENGTH) {
-        stdout += chunk.slice(0, MAX_OUTPUT_LENGTH - stdout.length);
-        truncated = true;
-      } else {
-        stdout += chunk;
-      }
-    });
-
-    child.stderr.on("data", (data) => {
-      const chunk = data.toString();
-      if (stderr.length + chunk.length > MAX_OUTPUT_LENGTH) {
-        stderr += chunk.slice(0, MAX_OUTPUT_LENGTH - stderr.length);
-        truncated = true;
-      } else {
-        stderr += chunk;
-      }
-    });
-
-    child.on("close", (code) => {
-      resolve({
-        success: code === 0,
-        exitCode: code,
-        stdout,
-        stderr,
-        truncated,
-      });
-    });
-
-    child.on("error", (error) => {
-      resolve({
-        success: false,
-        exitCode: null,
-        stdout,
-        stderr: error.message,
-        truncated,
-      });
-    });
-  });
-}
 
 const bashInputSchema = z.object({
   command: z.string().describe("The bash command to execute"),
@@ -207,6 +134,7 @@ EXAMPLES:
   execute: async ({ command, cwd }, { experimental_context }) => {
     const context = experimental_context as AgentContext;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
+    const { sandbox } = context;
 
     // Resolve the working directory
     const workingDir = cwd
@@ -223,7 +151,7 @@ EXAMPLES:
       };
     }
 
-    const result = await executeCommand(command, workingDir, TIMEOUT_MS);
+    const result = await sandbox.exec(command, workingDir, TIMEOUT_MS);
 
     return {
       success: result.success,

--- a/src/agent/tools/file-system/glob.ts
+++ b/src/agent/tools/file-system/glob.ts
@@ -133,8 +133,8 @@ EXAMPLES:
   }),
   execute: async ({ pattern, path: basePath, limit = 100 }, { experimental_context }) => {
     const context = experimental_context as AgentContext | undefined;
-    const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const sandbox = context?.sandbox ?? createLocalSandbox();
+    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const workingDirectory = sandbox.workingDirectory;
 
     try {
       // Resolve search directory relative to working directory

--- a/src/agent/tools/file-system/glob.ts
+++ b/src/agent/tools/file-system/glob.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-import type { Sandbox } from "../../sandbox";
+import { createLocalSandbox, type Sandbox } from "../../sandbox";
 import { isPathWithinDirectory } from "../../utils";
 
 interface FileInfo {
@@ -132,9 +132,9 @@ EXAMPLES:
       .describe("Maximum number of results. Default: 100"),
   }),
   execute: async ({ pattern, path: basePath, limit = 100 }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
+    const context = experimental_context as AgentContext | undefined;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const { sandbox } = context;
+    const sandbox = context?.sandbox ?? createLocalSandbox();
 
     try {
       // Resolve search directory relative to working directory

--- a/src/agent/tools/file-system/glob.ts
+++ b/src/agent/tools/file-system/glob.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-import { createLocalSandbox, type Sandbox } from "../../sandbox";
+import type { Sandbox } from "../../sandbox";
 import { isPathWithinDirectory } from "../../utils";
 
 interface FileInfo {
@@ -132,8 +132,8 @@ EXAMPLES:
       .describe("Maximum number of results. Default: 100"),
   }),
   execute: async ({ pattern, path: basePath, limit = 100 }, { experimental_context }) => {
-    const context = experimental_context as AgentContext | undefined;
-    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const context = experimental_context as AgentContext;
+    const sandbox = context.sandbox;
     const workingDirectory = sandbox.workingDirectory;
 
     try {

--- a/src/agent/tools/file-system/glob.ts
+++ b/src/agent/tools/file-system/glob.ts
@@ -1,9 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import type { AgentContext } from "../../types";
 import type { Sandbox } from "../../sandbox";
-import { isPathWithinDirectory } from "../../utils";
+import { isPathWithinDirectory, getSandbox } from "../../utils";
 
 interface FileInfo {
   path: string;
@@ -132,8 +131,7 @@ EXAMPLES:
       .describe("Maximum number of results. Default: 100"),
   }),
   execute: async ({ pattern, path: basePath, limit = 100 }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
-    const sandbox = context.sandbox;
+    const sandbox = getSandbox(experimental_context);
     const workingDirectory = sandbox.workingDirectory;
 
     try {

--- a/src/agent/tools/file-system/glob.ts
+++ b/src/agent/tools/file-system/glob.ts
@@ -1,14 +1,9 @@
 import { tool } from "ai";
 import { z } from "zod";
-import * as fs from "fs/promises";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-
-function isPathWithinDirectory(filePath: string, directory: string): boolean {
-  const resolvedPath = path.resolve(filePath);
-  const resolvedDir = path.resolve(directory);
-  return resolvedPath.startsWith(resolvedDir + path.sep) || resolvedPath === resolvedDir;
-}
+import type { Sandbox } from "../../sandbox";
+import { isPathWithinDirectory } from "../../utils";
 
 interface FileInfo {
   path: string;
@@ -20,7 +15,8 @@ interface FileInfo {
 async function findFiles(
   baseDir: string,
   pattern: string,
-  limit: number
+  limit: number,
+  sandbox: Sandbox
 ): Promise<FileInfo[]> {
   const results: FileInfo[] = [];
 
@@ -51,7 +47,7 @@ async function findFiles(
     if (results.length >= limit) return;
 
     try {
-      const entries = await fs.readdir(currentDir, { withFileTypes: true });
+      const entries = await sandbox.readdir(currentDir, { withFileTypes: true });
 
       for (const entry of entries) {
         if (results.length >= limit) break;
@@ -70,7 +66,7 @@ async function findFiles(
           const matches = await matchesPattern(fullPath, entry.name);
           if (matches) {
             try {
-              const stats = await fs.stat(fullPath);
+              const stats = await sandbox.stat(fullPath);
               results.push({
                 path: fullPath,
                 isDirectory: false,
@@ -138,6 +134,7 @@ EXAMPLES:
   execute: async ({ pattern, path: basePath, limit = 100 }, { experimental_context }) => {
     const context = experimental_context as AgentContext;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
+    const { sandbox } = context;
 
     try {
       // Resolve search directory relative to working directory
@@ -158,7 +155,7 @@ EXAMPLES:
         };
       }
 
-      const files = await findFiles(searchDir, pattern, limit);
+      const files = await findFiles(searchDir, pattern, limit, sandbox);
 
       return {
         success: true,

--- a/src/agent/tools/file-system/grep.ts
+++ b/src/agent/tools/file-system/grep.ts
@@ -130,8 +130,8 @@ EXAMPLES:
     caseSensitive = true,
   }, { experimental_context }) => {
     const context = experimental_context as AgentContext | undefined;
-    const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const sandbox = context?.sandbox ?? createLocalSandbox();
+    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const workingDirectory = sandbox.workingDirectory;
 
     try {
       const flags = caseSensitive ? "g" : "gi";

--- a/src/agent/tools/file-system/grep.ts
+++ b/src/agent/tools/file-system/grep.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-import type { Sandbox } from "../../sandbox";
+import { createLocalSandbox, type Sandbox } from "../../sandbox";
 import { isPathWithinDirectory } from "../../utils";
 
 interface GrepMatch {
@@ -129,9 +129,9 @@ EXAMPLES:
     glob,
     caseSensitive = true,
   }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
+    const context = experimental_context as AgentContext | undefined;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const { sandbox } = context;
+    const sandbox = context?.sandbox ?? createLocalSandbox();
 
     try {
       const flags = caseSensitive ? "g" : "gi";

--- a/src/agent/tools/file-system/grep.ts
+++ b/src/agent/tools/file-system/grep.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-import { createLocalSandbox, type Sandbox } from "../../sandbox";
+import type { Sandbox } from "../../sandbox";
 import { isPathWithinDirectory } from "../../utils";
 
 interface GrepMatch {
@@ -129,8 +129,8 @@ EXAMPLES:
     glob,
     caseSensitive = true,
   }, { experimental_context }) => {
-    const context = experimental_context as AgentContext | undefined;
-    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const context = experimental_context as AgentContext;
+    const sandbox = context.sandbox;
     const workingDirectory = sandbox.workingDirectory;
 
     try {

--- a/src/agent/tools/file-system/grep.ts
+++ b/src/agent/tools/file-system/grep.ts
@@ -1,9 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import type { AgentContext } from "../../types";
 import type { Sandbox } from "../../sandbox";
-import { isPathWithinDirectory } from "../../utils";
+import { isPathWithinDirectory, getSandbox } from "../../utils";
 
 interface GrepMatch {
   file: string;
@@ -129,8 +128,7 @@ EXAMPLES:
     glob,
     caseSensitive = true,
   }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
-    const sandbox = context.sandbox;
+    const sandbox = getSandbox(experimental_context);
     const workingDirectory = sandbox.workingDirectory;
 
     try {

--- a/src/agent/tools/file-system/grep.ts
+++ b/src/agent/tools/file-system/grep.ts
@@ -1,14 +1,9 @@
 import { tool } from "ai";
 import { z } from "zod";
-import * as fs from "fs/promises";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-
-function isPathWithinDirectory(filePath: string, directory: string): boolean {
-  const resolvedPath = path.resolve(filePath);
-  const resolvedDir = path.resolve(directory);
-  return resolvedPath.startsWith(resolvedDir + path.sep) || resolvedPath === resolvedDir;
-}
+import type { Sandbox } from "../../sandbox";
+import { isPathWithinDirectory } from "../../utils";
 
 interface GrepMatch {
   file: string;
@@ -19,10 +14,11 @@ interface GrepMatch {
 async function grepFile(
   filePath: string,
   pattern: RegExp,
-  maxMatchesPerFile: number
+  maxMatchesPerFile: number,
+  sandbox: Sandbox
 ): Promise<GrepMatch[]> {
   try {
-    const content = await fs.readFile(filePath, "utf-8");
+    const content = await sandbox.readFile(filePath, "utf-8");
     const lines = content.split("\n");
     const matches: GrepMatch[] = [];
 
@@ -45,13 +41,14 @@ async function grepFile(
 
 async function walkDirectory(
   dir: string,
-  glob?: string
+  glob: string | undefined,
+  sandbox: Sandbox
 ): Promise<string[]> {
   const files: string[] = [];
 
   async function walk(currentDir: string) {
     try {
-      const entries = await fs.readdir(currentDir, { withFileTypes: true });
+      const entries = await sandbox.readdir(currentDir, { withFileTypes: true });
 
       for (const entry of entries) {
         const fullPath = path.join(currentDir, entry.name);
@@ -134,6 +131,7 @@ EXAMPLES:
   }, { experimental_context }) => {
     const context = experimental_context as AgentContext;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
+    const { sandbox } = context;
 
     try {
       const flags = caseSensitive ? "g" : "gi";
@@ -151,11 +149,11 @@ EXAMPLES:
         };
       }
 
-      const stats = await fs.stat(absolutePath);
+      const stats = await sandbox.stat(absolutePath);
       let files: string[];
 
       if (stats.isDirectory()) {
-        files = await walkDirectory(absolutePath, glob);
+        files = await walkDirectory(absolutePath, glob, sandbox);
       } else {
         files = [absolutePath];
       }
@@ -169,7 +167,7 @@ EXAMPLES:
 
         const remaining = maxTotal - allMatches.length;
         const limit = Math.min(maxPerFile, remaining);
-        const matches = await grepFile(file, regex, limit);
+        const matches = await grepFile(file, regex, limit, sandbox);
         allMatches.push(...matches);
       }
 

--- a/src/agent/tools/file-system/read.ts
+++ b/src/agent/tools/file-system/read.ts
@@ -42,8 +42,8 @@ EXAMPLES:
   }),
   execute: async ({ filePath, offset = 1, limit = 2000 }, { experimental_context }) => {
     const context = experimental_context as AgentContext | undefined;
-    const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const sandbox = context?.sandbox ?? createLocalSandbox();
+    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const workingDirectory = sandbox.workingDirectory;
 
     try {
       if (filePath.startsWith("/scratchpad/")) {

--- a/src/agent/tools/file-system/read.ts
+++ b/src/agent/tools/file-system/read.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
 import { isPathWithinDirectory } from "../../utils";
+import { createLocalSandbox } from "../../sandbox";
 
 export const readFileTool = tool({
   description: `Read a file from the filesystem.
@@ -40,9 +41,9 @@ EXAMPLES:
       .describe("Maximum number of lines to read. Default: 2000"),
   }),
   execute: async ({ filePath, offset = 1, limit = 2000 }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
+    const context = experimental_context as AgentContext | undefined;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const { sandbox } = context;
+    const sandbox = context?.sandbox ?? createLocalSandbox();
 
     try {
       if (filePath.startsWith("/scratchpad/")) {

--- a/src/agent/tools/file-system/read.ts
+++ b/src/agent/tools/file-system/read.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
 import { isPathWithinDirectory } from "../../utils";
-import { createLocalSandbox } from "../../sandbox";
 
 export const readFileTool = tool({
   description: `Read a file from the filesystem.
@@ -41,8 +40,8 @@ EXAMPLES:
       .describe("Maximum number of lines to read. Default: 2000"),
   }),
   execute: async ({ filePath, offset = 1, limit = 2000 }, { experimental_context }) => {
-    const context = experimental_context as AgentContext | undefined;
-    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const context = experimental_context as AgentContext;
+    const sandbox = context.sandbox;
     const workingDirectory = sandbox.workingDirectory;
 
     try {

--- a/src/agent/tools/file-system/read.ts
+++ b/src/agent/tools/file-system/read.ts
@@ -1,8 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import type { AgentContext } from "../../types";
-import { isPathWithinDirectory } from "../../utils";
+import { isPathWithinDirectory, getSandbox } from "../../utils";
 
 export const readFileTool = tool({
   description: `Read a file from the filesystem.
@@ -40,8 +39,7 @@ EXAMPLES:
       .describe("Maximum number of lines to read. Default: 2000"),
   }),
   execute: async ({ filePath, offset = 1, limit = 2000 }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
-    const sandbox = context.sandbox;
+    const sandbox = getSandbox(experimental_context);
     const workingDirectory = sandbox.workingDirectory;
 
     try {

--- a/src/agent/tools/file-system/read.ts
+++ b/src/agent/tools/file-system/read.ts
@@ -1,14 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod";
-import * as fs from "fs/promises";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-
-function isPathWithinDirectory(filePath: string, directory: string): boolean {
-  const resolvedPath = path.resolve(filePath);
-  const resolvedDir = path.resolve(directory);
-  return resolvedPath.startsWith(resolvedDir + path.sep) || resolvedPath === resolvedDir;
-}
+import { isPathWithinDirectory } from "../../utils";
 
 export const readFileTool = tool({
   description: `Read a file from the filesystem.
@@ -48,6 +42,7 @@ EXAMPLES:
   execute: async ({ filePath, offset = 1, limit = 2000 }, { experimental_context }) => {
     const context = experimental_context as AgentContext;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
+    const { sandbox } = context;
 
     try {
       if (filePath.startsWith("/scratchpad/")) {
@@ -69,7 +64,7 @@ EXAMPLES:
       // If the path doesn't exist and looks like a root-relative path (e.g., /README.md),
       // try resolving it relative to the working directory
       try {
-        await fs.access(absolutePath);
+        await sandbox.access(absolutePath);
       } catch {
         // Path doesn't exist - check if it's a root-relative path that should be workspace-relative
         if (
@@ -79,7 +74,7 @@ EXAMPLES:
         ) {
           const workspaceRelativePath = path.join(workingDirectory, filePath);
           try {
-            await fs.access(workspaceRelativePath);
+            await sandbox.access(workspaceRelativePath);
             absolutePath = workspaceRelativePath;
           } catch {
             // Neither path exists - let it fall through to the original error handling
@@ -95,7 +90,7 @@ EXAMPLES:
         };
       }
 
-      const stats = await fs.stat(absolutePath);
+      const stats = await sandbox.stat(absolutePath);
       if (stats.isDirectory()) {
         return {
           success: false,
@@ -103,7 +98,7 @@ EXAMPLES:
         };
       }
 
-      const content = await fs.readFile(absolutePath, "utf-8");
+      const content = await sandbox.readFile(absolutePath, "utf-8");
       const lines = content.split("\n");
       const startLine = Math.max(1, offset) - 1;
       const endLine = Math.min(lines.length, startLine + limit);

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
 import { isPathWithinDirectory } from "../../utils";
+import { createLocalSandbox } from "../../sandbox";
 
 const writeInputSchema = z.object({
   filePath: z.string().describe("Absolute path to the file to write"),
@@ -66,9 +67,9 @@ EXAMPLES:
 - Replace a script after reading it: filePath: "/Users/username/project/scripts/build.sh", content: "<entire updated script>"`,
   inputSchema: writeInputSchema,
   execute: async ({ filePath, content }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
+    const context = experimental_context as AgentContext | undefined;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const { sandbox } = context;
+    const sandbox = context?.sandbox ?? createLocalSandbox();
 
     try {
       const absolutePath = path.isAbsolute(filePath)
@@ -135,9 +136,9 @@ EXAMPLES:
 - Rename a variable throughout a file: filePath: "/Users/username/project/src/api.ts", oldString: "oldApiClient", newString: "newApiClient", replaceAll: true`,
   inputSchema: editInputSchema,
   execute: async ({ filePath, oldString, newString, replaceAll = false }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
+    const context = experimental_context as AgentContext | undefined;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const { sandbox } = context;
+    const sandbox = context?.sandbox ?? createLocalSandbox();
 
     try {
       if (oldString === newString) {

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -68,8 +68,8 @@ EXAMPLES:
   inputSchema: writeInputSchema,
   execute: async ({ filePath, content }, { experimental_context }) => {
     const context = experimental_context as AgentContext | undefined;
-    const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const sandbox = context?.sandbox ?? createLocalSandbox();
+    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const workingDirectory = sandbox.workingDirectory;
 
     try {
       const absolutePath = path.isAbsolute(filePath)
@@ -137,8 +137,8 @@ EXAMPLES:
   inputSchema: editInputSchema,
   execute: async ({ filePath, oldString, newString, replaceAll = false }, { experimental_context }) => {
     const context = experimental_context as AgentContext | undefined;
-    const workingDirectory = context?.workingDirectory ?? process.cwd();
-    const sandbox = context?.sandbox ?? createLocalSandbox();
+    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const workingDirectory = sandbox.workingDirectory;
 
     try {
       if (oldString === newString) {

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -1,8 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import type { AgentContext } from "../../types";
-import { isPathWithinDirectory } from "../../utils";
+import { isPathWithinDirectory, getSandbox } from "../../utils";
 
 const writeInputSchema = z.object({
   filePath: z.string().describe("Absolute path to the file to write"),
@@ -66,8 +65,7 @@ EXAMPLES:
 - Replace a script after reading it: filePath: "/Users/username/project/scripts/build.sh", content: "<entire updated script>"`,
   inputSchema: writeInputSchema,
   execute: async ({ filePath, content }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
-    const sandbox = context.sandbox;
+    const sandbox = getSandbox(experimental_context);
     const workingDirectory = sandbox.workingDirectory;
 
     try {
@@ -135,8 +133,7 @@ EXAMPLES:
 - Rename a variable throughout a file: filePath: "/Users/username/project/src/api.ts", oldString: "oldApiClient", newString: "newApiClient", replaceAll: true`,
   inputSchema: editInputSchema,
   execute: async ({ filePath, oldString, newString, replaceAll = false }, { experimental_context }) => {
-    const context = experimental_context as AgentContext;
-    const sandbox = context.sandbox;
+    const sandbox = getSandbox(experimental_context);
     const workingDirectory = sandbox.workingDirectory;
 
     try {

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import * as path from "path";
 import type { AgentContext } from "../../types";
 import { isPathWithinDirectory } from "../../utils";
-import { createLocalSandbox } from "../../sandbox";
 
 const writeInputSchema = z.object({
   filePath: z.string().describe("Absolute path to the file to write"),
@@ -67,8 +66,8 @@ EXAMPLES:
 - Replace a script after reading it: filePath: "/Users/username/project/scripts/build.sh", content: "<entire updated script>"`,
   inputSchema: writeInputSchema,
   execute: async ({ filePath, content }, { experimental_context }) => {
-    const context = experimental_context as AgentContext | undefined;
-    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const context = experimental_context as AgentContext;
+    const sandbox = context.sandbox;
     const workingDirectory = sandbox.workingDirectory;
 
     try {
@@ -136,8 +135,8 @@ EXAMPLES:
 - Rename a variable throughout a file: filePath: "/Users/username/project/src/api.ts", oldString: "oldApiClient", newString: "newApiClient", replaceAll: true`,
   inputSchema: editInputSchema,
   execute: async ({ filePath, oldString, newString, replaceAll = false }, { experimental_context }) => {
-    const context = experimental_context as AgentContext | undefined;
-    const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+    const context = experimental_context as AgentContext;
+    const sandbox = context.sandbox;
     const workingDirectory = sandbox.workingDirectory;
 
     try {

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -1,14 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod";
-import * as fs from "fs/promises";
 import * as path from "path";
 import type { AgentContext } from "../../types";
-
-function isPathWithinDirectory(filePath: string, directory: string): boolean {
-  const resolvedPath = path.resolve(filePath);
-  const resolvedDir = path.resolve(directory);
-  return resolvedPath.startsWith(resolvedDir + path.sep) || resolvedPath === resolvedDir;
-}
+import { isPathWithinDirectory } from "../../utils";
 
 const writeInputSchema = z.object({
   filePath: z.string().describe("Absolute path to the file to write"),
@@ -74,6 +68,7 @@ EXAMPLES:
   execute: async ({ filePath, content }, { experimental_context }) => {
     const context = experimental_context as AgentContext;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
+    const { sandbox } = context;
 
     try {
       const absolutePath = path.isAbsolute(filePath)
@@ -89,10 +84,10 @@ EXAMPLES:
       }
 
       const dir = path.dirname(absolutePath);
-      await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(absolutePath, content, "utf-8");
+      await sandbox.mkdir(dir, { recursive: true });
+      await sandbox.writeFile(absolutePath, content, "utf-8");
 
-      const stats = await fs.stat(absolutePath);
+      const stats = await sandbox.stat(absolutePath);
 
       return {
         success: true,
@@ -142,6 +137,7 @@ EXAMPLES:
   execute: async ({ filePath, oldString, newString, replaceAll = false }, { experimental_context }) => {
     const context = experimental_context as AgentContext;
     const workingDirectory = context?.workingDirectory ?? process.cwd();
+    const { sandbox } = context;
 
     try {
       if (oldString === newString) {
@@ -163,7 +159,7 @@ EXAMPLES:
         };
       }
 
-      const content = await fs.readFile(absolutePath, "utf-8");
+      const content = await sandbox.readFile(absolutePath, "utf-8");
 
       if (!content.includes(oldString)) {
         return {
@@ -185,7 +181,7 @@ EXAMPLES:
         ? content.replaceAll(oldString, newString)
         : content.replace(oldString, newString);
 
-      await fs.writeFile(absolutePath, newContent, "utf-8");
+      await sandbox.writeFile(absolutePath, newContent, "utf-8");
 
       return {
         success: true,

--- a/src/agent/tools/memory/recall.ts
+++ b/src/agent/tools/memory/recall.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { searchMemory, getRecentMemories } from "../../state/memory-store";
 import type { AgentContext } from "../../types";
+import { createLocalSandbox } from "../../sandbox";
 
 export const memoryRecallTool = tool({
   description: `Retrieve information from long-term memory for the current workspace/project.
@@ -43,8 +44,9 @@ EXAMPLES:
   }),
   execute: async ({ query, tags, limit = 10 }, { experimental_context }) => {
     try {
-      const context = experimental_context as AgentContext;
-      const workingDirectory = context.workingDirectory ?? process.cwd();
+      const context = experimental_context as AgentContext | undefined;
+      const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+      const workingDirectory = sandbox.workingDirectory;
 
       let entries;
 

--- a/src/agent/tools/memory/recall.ts
+++ b/src/agent/tools/memory/recall.ts
@@ -2,7 +2,6 @@ import { tool } from "ai";
 import { z } from "zod";
 import { searchMemory, getRecentMemories } from "../../state/memory-store";
 import type { AgentContext } from "../../types";
-import { createLocalSandbox } from "../../sandbox";
 
 export const memoryRecallTool = tool({
   description: `Retrieve information from long-term memory for the current workspace/project.
@@ -44,8 +43,8 @@ EXAMPLES:
   }),
   execute: async ({ query, tags, limit = 10 }, { experimental_context }) => {
     try {
-      const context = experimental_context as AgentContext | undefined;
-      const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+      const context = experimental_context as AgentContext;
+      const sandbox = context.sandbox;
       const workingDirectory = sandbox.workingDirectory;
 
       let entries;

--- a/src/agent/tools/memory/recall.ts
+++ b/src/agent/tools/memory/recall.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { searchMemory, getRecentMemories } from "../../state/memory-store";
-import type { AgentContext } from "../../types";
+import { getSandbox } from "../../utils";
 
 export const memoryRecallTool = tool({
   description: `Retrieve information from long-term memory for the current workspace/project.
@@ -43,8 +43,7 @@ EXAMPLES:
   }),
   execute: async ({ query, tags, limit = 10 }, { experimental_context }) => {
     try {
-      const context = experimental_context as AgentContext;
-      const sandbox = context.sandbox;
+      const sandbox = getSandbox(experimental_context);
       const workingDirectory = sandbox.workingDirectory;
 
       let entries;

--- a/src/agent/tools/memory/save.ts
+++ b/src/agent/tools/memory/save.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { addMemoryEntry } from "../../state/memory-store";
 import type { AgentContext } from "../../types";
+import { createLocalSandbox } from "../../sandbox";
 
 export const memorySaveTool = tool({
   description: `Save information to long-term memory for recall in future conversations (per workspace/project).
@@ -42,8 +43,9 @@ EXAMPLES:
   }),
   execute: async ({ content, tags, metadata }, { experimental_context }) => {
     try {
-      const context = experimental_context as AgentContext;
-      const workingDirectory = context.workingDirectory ?? process.cwd();
+      const context = experimental_context as AgentContext | undefined;
+      const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+      const workingDirectory = sandbox.workingDirectory;
 
       const entry = await addMemoryEntry(workingDirectory, {
         content,

--- a/src/agent/tools/memory/save.ts
+++ b/src/agent/tools/memory/save.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { addMemoryEntry } from "../../state/memory-store";
-import type { AgentContext } from "../../types";
+import { getSandbox } from "../../utils";
 
 export const memorySaveTool = tool({
   description: `Save information to long-term memory for recall in future conversations (per workspace/project).
@@ -42,8 +42,7 @@ EXAMPLES:
   }),
   execute: async ({ content, tags, metadata }, { experimental_context }) => {
     try {
-      const context = experimental_context as AgentContext;
-      const sandbox = context.sandbox;
+      const sandbox = getSandbox(experimental_context);
       const workingDirectory = sandbox.workingDirectory;
 
       const entry = await addMemoryEntry(workingDirectory, {

--- a/src/agent/tools/memory/save.ts
+++ b/src/agent/tools/memory/save.ts
@@ -2,7 +2,6 @@ import { tool } from "ai";
 import { z } from "zod";
 import { addMemoryEntry } from "../../state/memory-store";
 import type { AgentContext } from "../../types";
-import { createLocalSandbox } from "../../sandbox";
 
 export const memorySaveTool = tool({
   description: `Save information to long-term memory for recall in future conversations (per workspace/project).
@@ -43,8 +42,8 @@ EXAMPLES:
   }),
   execute: async ({ content, tags, metadata }, { experimental_context }) => {
     try {
-      const context = experimental_context as AgentContext | undefined;
-      const sandbox = context?.sandbox ?? createLocalSandbox(process.cwd());
+      const context = experimental_context as AgentContext;
+      const sandbox = context.sandbox;
       const workingDirectory = sandbox.workingDirectory;
 
       const entry = await addMemoryEntry(workingDirectory, {

--- a/src/agent/tools/task-delegation/subagents/executor.ts
+++ b/src/agent/tools/task-delegation/subagents/executor.ts
@@ -5,7 +5,7 @@ import { writeFileTool, editFileTool } from "../../file-system/write";
 import { grepTool } from "../../file-system/grep";
 import { globTool } from "../../file-system/glob";
 import { bashTool, commandNeedsApproval } from "../../file-system/bash";
-import { createLocalSandbox } from "../../../sandbox";
+import { createLocalSandbox, type Sandbox } from "../../../sandbox";
 
 const EXECUTOR_SYSTEM_PROMPT = `You are an executor agent - a fire-and-forget subagent that completes specific, well-defined implementation tasks autonomously.
 
@@ -47,6 +47,7 @@ const callOptionsSchema = z.object({
   task: z.string().describe("Short description of the task"),
   cwd: z.string().describe("Working directory for the subagent"),
   instructions: z.string().describe("Detailed instructions for the task"),
+  sandbox: z.custom<Sandbox>().optional().describe("Sandbox for file system and shell operations"),
 });
 
 export type ExecutorCallOptions = z.infer<typeof callOptionsSchema>;
@@ -86,7 +87,7 @@ ${options.instructions}
 - Your final message MUST include both a **Summary** of what you did AND the **Answer** to the task`,
     experimental_context: {
       workingDirectory: options.cwd,
-      sandbox: createLocalSandbox(),
+      sandbox: options.sandbox ?? createLocalSandbox(),
     },
   }),
 });

--- a/src/agent/tools/task-delegation/subagents/executor.ts
+++ b/src/agent/tools/task-delegation/subagents/executor.ts
@@ -69,11 +69,13 @@ export const executorSubagent = new ToolLoopAgent({
   },
   stopWhen: stepCountIs(30),
   callOptionsSchema,
-  prepareCall: ({ options, ...settings }) => ({
-    ...settings,
-    instructions: `${EXECUTOR_SYSTEM_PROMPT}
+  prepareCall: ({ options, ...settings }) => {
+    const sandbox = options.sandbox ?? createLocalSandbox(options.cwd);
+    return {
+      ...settings,
+      instructions: `${EXECUTOR_SYSTEM_PROMPT}
 
-Working directory: ${options.cwd}
+Working directory: ${sandbox.workingDirectory}
 
 ## Your Task
 ${options.task}
@@ -85,9 +87,7 @@ ${options.instructions}
 - You CANNOT ask questions - no one will respond
 - Complete the task fully before returning
 - Your final message MUST include both a **Summary** of what you did AND the **Answer** to the task`,
-    experimental_context: {
-      workingDirectory: options.cwd,
-      sandbox: options.sandbox ?? createLocalSandbox(),
-    },
-  }),
+      experimental_context: { sandbox },
+    };
+  },
 });

--- a/src/agent/tools/task-delegation/subagents/executor.ts
+++ b/src/agent/tools/task-delegation/subagents/executor.ts
@@ -5,7 +5,7 @@ import { writeFileTool, editFileTool } from "../../file-system/write";
 import { grepTool } from "../../file-system/grep";
 import { globTool } from "../../file-system/glob";
 import { bashTool, commandNeedsApproval } from "../../file-system/bash";
-import { createLocalSandbox, type Sandbox } from "../../../sandbox";
+import type { Sandbox } from "../../../sandbox";
 
 const EXECUTOR_SYSTEM_PROMPT = `You are an executor agent - a fire-and-forget subagent that completes specific, well-defined implementation tasks autonomously.
 
@@ -45,9 +45,8 @@ You have full access to file operations (read, write, edit, grep, glob) and bash
 
 const callOptionsSchema = z.object({
   task: z.string().describe("Short description of the task"),
-  cwd: z.string().describe("Working directory for the subagent"),
   instructions: z.string().describe("Detailed instructions for the task"),
-  sandbox: z.custom<Sandbox>().optional().describe("Sandbox for file system and shell operations"),
+  sandbox: z.custom<Sandbox>().describe("Sandbox for file system and shell operations"),
 });
 
 export type ExecutorCallOptions = z.infer<typeof callOptionsSchema>;
@@ -70,7 +69,7 @@ export const executorSubagent = new ToolLoopAgent({
   stopWhen: stepCountIs(30),
   callOptionsSchema,
   prepareCall: ({ options, ...settings }) => {
-    const sandbox = options.sandbox ?? createLocalSandbox(options.cwd);
+    const sandbox = options.sandbox;
     return {
       ...settings,
       instructions: `${EXECUTOR_SYSTEM_PROMPT}

--- a/src/agent/tools/task-delegation/subagents/executor.ts
+++ b/src/agent/tools/task-delegation/subagents/executor.ts
@@ -5,6 +5,7 @@ import { writeFileTool, editFileTool } from "../../file-system/write";
 import { grepTool } from "../../file-system/grep";
 import { globTool } from "../../file-system/glob";
 import { bashTool, commandNeedsApproval } from "../../file-system/bash";
+import { createLocalSandbox } from "../../../sandbox";
 
 const EXECUTOR_SYSTEM_PROMPT = `You are an executor agent - a fire-and-forget subagent that completes specific, well-defined implementation tasks autonomously.
 
@@ -83,5 +84,9 @@ ${options.instructions}
 - You CANNOT ask questions - no one will respond
 - Complete the task fully before returning
 - Your final message MUST include both a **Summary** of what you did AND the **Answer** to the task`,
+    experimental_context: {
+      workingDirectory: options.cwd,
+      sandbox: createLocalSandbox(),
+    },
   }),
 });

--- a/src/agent/tools/task-delegation/subagents/explorer.ts
+++ b/src/agent/tools/task-delegation/subagents/explorer.ts
@@ -4,7 +4,7 @@ import { readFileTool } from "../../file-system/read";
 import { grepTool } from "../../file-system/grep";
 import { globTool } from "../../file-system/glob";
 import { bashTool, commandNeedsApproval } from "../../file-system/bash";
-import { createLocalSandbox } from "../../../sandbox";
+import { createLocalSandbox, type Sandbox } from "../../../sandbox";
 
 const EXPLORER_SYSTEM_PROMPT = `You are an explorer agent - a fast, read-only subagent specialized for exploring codebases.
 
@@ -58,6 +58,7 @@ const callOptionsSchema = z.object({
   task: z.string().describe("Short description of the exploration task"),
   cwd: z.string().describe("Working directory for the subagent"),
   instructions: z.string().describe("Detailed instructions for the exploration"),
+  sandbox: z.custom<Sandbox>().optional().describe("Sandbox for file system and shell operations"),
 });
 
 export type ExplorerCallOptions = z.infer<typeof callOptionsSchema>;
@@ -95,7 +96,7 @@ ${options.instructions}
 - Your final message MUST include both a **Summary** of what you searched AND the **Answer** to the task`,
     experimental_context: {
       workingDirectory: options.cwd,
-      sandbox: createLocalSandbox(),
+      sandbox: options.sandbox ?? createLocalSandbox(),
     },
   }),
 });

--- a/src/agent/tools/task-delegation/subagents/explorer.ts
+++ b/src/agent/tools/task-delegation/subagents/explorer.ts
@@ -78,11 +78,13 @@ export const explorerSubagent = new ToolLoopAgent({
   },
   stopWhen: stepCountIs(30),
   callOptionsSchema,
-  prepareCall: ({ options, ...settings }) => ({
-    ...settings,
-    instructions: `${EXPLORER_SYSTEM_PROMPT}
+  prepareCall: ({ options, ...settings }) => {
+    const sandbox = options.sandbox ?? createLocalSandbox(options.cwd);
+    return {
+      ...settings,
+      instructions: `${EXPLORER_SYSTEM_PROMPT}
 
-Working directory: ${options.cwd}
+Working directory: ${sandbox.workingDirectory}
 
 ## Your Task
 ${options.task}
@@ -94,9 +96,7 @@ ${options.instructions}
 - You CANNOT ask questions - no one will respond
 - This is READ-ONLY - do NOT create, modify, or delete any files
 - Your final message MUST include both a **Summary** of what you searched AND the **Answer** to the task`,
-    experimental_context: {
-      workingDirectory: options.cwd,
-      sandbox: options.sandbox ?? createLocalSandbox(),
-    },
-  }),
+      experimental_context: { sandbox },
+    };
+  },
 });

--- a/src/agent/tools/task-delegation/subagents/explorer.ts
+++ b/src/agent/tools/task-delegation/subagents/explorer.ts
@@ -4,7 +4,7 @@ import { readFileTool } from "../../file-system/read";
 import { grepTool } from "../../file-system/grep";
 import { globTool } from "../../file-system/glob";
 import { bashTool, commandNeedsApproval } from "../../file-system/bash";
-import { createLocalSandbox, type Sandbox } from "../../../sandbox";
+import type { Sandbox } from "../../../sandbox";
 
 const EXPLORER_SYSTEM_PROMPT = `You are an explorer agent - a fast, read-only subagent specialized for exploring codebases.
 
@@ -56,9 +56,8 @@ You have access to: read, grep, glob, bash (read-only commands only)
 
 const callOptionsSchema = z.object({
   task: z.string().describe("Short description of the exploration task"),
-  cwd: z.string().describe("Working directory for the subagent"),
   instructions: z.string().describe("Detailed instructions for the exploration"),
-  sandbox: z.custom<Sandbox>().optional().describe("Sandbox for file system and shell operations"),
+  sandbox: z.custom<Sandbox>().describe("Sandbox for file system and shell operations"),
 });
 
 export type ExplorerCallOptions = z.infer<typeof callOptionsSchema>;
@@ -79,7 +78,7 @@ export const explorerSubagent = new ToolLoopAgent({
   stopWhen: stepCountIs(30),
   callOptionsSchema,
   prepareCall: ({ options, ...settings }) => {
-    const sandbox = options.sandbox ?? createLocalSandbox(options.cwd);
+    const sandbox = options.sandbox;
     return {
       ...settings,
       instructions: `${EXPLORER_SYSTEM_PROMPT}

--- a/src/agent/tools/task-delegation/subagents/explorer.ts
+++ b/src/agent/tools/task-delegation/subagents/explorer.ts
@@ -4,6 +4,7 @@ import { readFileTool } from "../../file-system/read";
 import { grepTool } from "../../file-system/grep";
 import { globTool } from "../../file-system/glob";
 import { bashTool, commandNeedsApproval } from "../../file-system/bash";
+import { createLocalSandbox } from "../../../sandbox";
 
 const EXPLORER_SYSTEM_PROMPT = `You are an explorer agent - a fast, read-only subagent specialized for exploring codebases.
 
@@ -92,5 +93,9 @@ ${options.instructions}
 - You CANNOT ask questions - no one will respond
 - This is READ-ONLY - do NOT create, modify, or delete any files
 - Your final message MUST include both a **Summary** of what you searched AND the **Answer** to the task`,
+    experimental_context: {
+      workingDirectory: options.cwd,
+      sandbox: createLocalSandbox(),
+    },
   }),
 });

--- a/src/agent/tools/task-delegation/task.ts
+++ b/src/agent/tools/task-delegation/task.ts
@@ -83,8 +83,10 @@ NOTE: The executor subagent requires user approval before running because it has
   inputSchema: taskInputSchema,
   execute: async function* ({ subagentType, task, instructions, workingDirectory }, { experimental_context }) {
     const context = experimental_context as AgentContext | undefined;
-    const cwd = workingDirectory ?? context?.workingDirectory ?? process.cwd();
-    const sandbox = context?.sandbox ?? createLocalSandbox();
+    // Use provided workingDirectory, or get from sandbox, or default to cwd
+    const cwd = workingDirectory ?? context?.sandbox?.workingDirectory ?? process.cwd();
+    // Use existing sandbox if provided, or create a new one with the resolved cwd
+    const sandbox = context?.sandbox ?? createLocalSandbox(cwd);
 
     const subagent = subagentType === "explorer" ? explorerSubagent : executorSubagent;
 

--- a/src/agent/tools/task-delegation/task.ts
+++ b/src/agent/tools/task-delegation/task.ts
@@ -2,6 +2,8 @@ import { tool, readUIMessageStream } from "ai";
 import { z } from "zod";
 import { explorerSubagent } from "./subagents/explorer";
 import { executorSubagent } from "./subagents/executor";
+import type { AgentContext } from "../../types";
+import { createLocalSandbox } from "../../sandbox";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
 
@@ -79,14 +81,16 @@ IMPORTANT:
 
 NOTE: The executor subagent requires user approval before running because it has full write access.`,
   inputSchema: taskInputSchema,
-  execute: async function* ({ subagentType, task, instructions, workingDirectory }) {
-    const cwd = workingDirectory ?? process.cwd();
+  execute: async function* ({ subagentType, task, instructions, workingDirectory }, { experimental_context }) {
+    const context = experimental_context as AgentContext | undefined;
+    const cwd = workingDirectory ?? context?.workingDirectory ?? process.cwd();
+    const sandbox = context?.sandbox ?? createLocalSandbox();
 
     const subagent = subagentType === "explorer" ? explorerSubagent : executorSubagent;
 
     const result = await subagent.stream({
       prompt: "Complete this task and provide a summary of what you accomplished.",
-      options: { task, cwd, instructions },
+      options: { task, cwd, instructions, sandbox },
     });
 
     for await (const message of readUIMessageStream({

--- a/src/agent/tools/task-delegation/task.ts
+++ b/src/agent/tools/task-delegation/task.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { explorerSubagent } from "./subagents/explorer";
 import { executorSubagent } from "./subagents/executor";
 import type { AgentContext } from "../../types";
-import { createLocalSandbox } from "../../sandbox";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
 
@@ -21,10 +20,6 @@ const taskInputSchema = z.object({
 - Constraints and patterns to follow
 - How to verify the work`
   ),
-  workingDirectory: z
-    .string()
-    .optional()
-    .describe("Working directory for the subagent"),
 });
 
 export const taskTool = tool({
@@ -72,7 +67,6 @@ HOW TO USE:
 - Choose the appropriate subagentType based on whether you need read-only or write access
 - Provide a short task string (for display) summarizing the goal
 - Provide detailed instructions including goals, steps, constraints, and verification criteria
-- Optionally set workingDirectory to scope the subagent's operations
 
 IMPORTANT:
 - Be explicit and concrete - subagents cannot ask clarifying questions
@@ -81,18 +75,15 @@ IMPORTANT:
 
 NOTE: The executor subagent requires user approval before running because it has full write access.`,
   inputSchema: taskInputSchema,
-  execute: async function* ({ subagentType, task, instructions, workingDirectory }, { experimental_context }) {
-    const context = experimental_context as AgentContext | undefined;
-    // Use provided workingDirectory, or get from sandbox, or default to cwd
-    const cwd = workingDirectory ?? context?.sandbox?.workingDirectory ?? process.cwd();
-    // Use existing sandbox if provided, or create a new one with the resolved cwd
-    const sandbox = context?.sandbox ?? createLocalSandbox(cwd);
+  execute: async function* ({ subagentType, task, instructions }, { experimental_context }) {
+    const context = experimental_context as AgentContext;
+    const sandbox = context.sandbox;
 
     const subagent = subagentType === "explorer" ? explorerSubagent : executorSubagent;
 
     const result = await subagent.stream({
       prompt: "Complete this task and provide a summary of what you accomplished.",
-      options: { task, cwd, instructions, sandbox },
+      options: { task, instructions, sandbox },
     });
 
     for await (const message of readUIMessageStream({

--- a/src/agent/tools/task-delegation/task.ts
+++ b/src/agent/tools/task-delegation/task.ts
@@ -2,7 +2,7 @@ import { tool, readUIMessageStream } from "ai";
 import { z } from "zod";
 import { explorerSubagent } from "./subagents/explorer";
 import { executorSubagent } from "./subagents/executor";
-import type { AgentContext } from "../../types";
+import { getSandbox } from "../../utils";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
 
@@ -76,8 +76,7 @@ IMPORTANT:
 NOTE: The executor subagent requires user approval before running because it has full write access.`,
   inputSchema: taskInputSchema,
   execute: async function* ({ subagentType, task, instructions }, { experimental_context }) {
-    const context = experimental_context as AgentContext;
-    const sandbox = context.sandbox;
+    const sandbox = getSandbox(experimental_context);
 
     const subagent = subagentType === "explorer" ? explorerSubagent : executorSubagent;
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -42,7 +42,6 @@ export interface MemoryStore {
 }
 
 export interface AgentContext {
-  workingDirectory: string;
   sandbox: Sandbox;
 }
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { Sandbox } from "./sandbox";
 
 export const todoStatusSchema = z.enum(["pending", "in_progress", "completed"]);
 export type TodoStatus = z.infer<typeof todoStatusSchema>;
@@ -42,6 +43,7 @@ export interface MemoryStore {
 
 export interface AgentContext {
   workingDirectory: string;
+  sandbox: Sandbox;
 }
 
 export const EVICTION_THRESHOLD_BYTES = 80 * 1024;

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -1,3 +1,3 @@
 export { addCacheControl } from "./cache-control/add-cache-control";
 export { compactContext } from "./compact-context";
-export { isPathWithinDirectory } from "./path";
+export { isPathWithinDirectory, getSandbox } from "./path";

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -1,2 +1,3 @@
 export { addCacheControl } from "./cache-control/add-cache-control";
 export { compactContext } from "./compact-context";
+export { isPathWithinDirectory } from "./path";

--- a/src/agent/utils/path.ts
+++ b/src/agent/utils/path.ts
@@ -1,4 +1,6 @@
 import * as path from "path";
+import type { AgentContext } from "../types";
+import type { Sandbox } from "../sandbox";
 
 /**
  * Check if a file path is within a given directory.
@@ -18,4 +20,22 @@ export function isPathWithinDirectory(
     resolvedPath.startsWith(resolvedDir + path.sep) ||
     resolvedPath === resolvedDir
   );
+}
+
+/**
+ * Get sandbox from experimental context with null safety.
+ * Throws a descriptive error if sandbox is not initialized.
+ *
+ * @param experimental_context - The context passed to tool execute functions
+ * @returns The sandbox instance
+ * @throws Error if sandbox is not available in context
+ */
+export function getSandbox(experimental_context: unknown): Sandbox {
+  const context = experimental_context as AgentContext | undefined;
+  if (!context?.sandbox) {
+    throw new Error(
+      "Sandbox not initialized in context. Ensure the agent is configured with a sandbox."
+    );
+  }
+  return context.sandbox;
 }

--- a/src/agent/utils/path.ts
+++ b/src/agent/utils/path.ts
@@ -1,0 +1,21 @@
+import * as path from "path";
+
+/**
+ * Check if a file path is within a given directory.
+ * Used as a security boundary to prevent path traversal attacks.
+ *
+ * @param filePath - The path to check
+ * @param directory - The directory that should contain the path
+ * @returns true if filePath is within or equal to directory
+ */
+export function isPathWithinDirectory(
+  filePath: string,
+  directory: string
+): boolean {
+  const resolvedPath = path.resolve(filePath);
+  const resolvedDir = path.resolve(directory);
+  return (
+    resolvedPath.startsWith(resolvedDir + path.sep) ||
+    resolvedPath === resolvedDir
+  );
+}


### PR DESCRIPTION
## Summary
Abstracts file system and shell operations behind a pluggable `Sandbox` interface, enabling tools to work with different execution environments (local fs, remote sandboxes, containers, etc.) without code changes.

## Changes
- Add `Sandbox` interface with file operations (readFile, writeFile, stat, etc.) and shell execution
- Implement `LocalSandbox` using Node.js fs/promises and child_process
- Extract duplicated `isPathWithinDirectory` to shared utility
- Update all tools to use sandbox via experimental_context
- Support custom sandbox implementations via call options with `z.custom<Sandbox>()`
- Update subagents to include sandbox in their context

## Benefits
- **Extensibility**: Easy to implement E2B, Docker, or other sandbox providers
- **Flexibility**: Swap implementations without changing tool code
- **Testability**: Mock sandbox for testing without filesystem access