### PR TITLE
Implement reasoning UI with ctrl+p toggle

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -7,11 +7,13 @@ import {
 import { useChat } from "@ai-sdk/react";
 import { renderMarkdown } from "./lib/markdown.js";
 import { useChatContext } from "./chat-context.js";
+import { useReasoningContext } from "./reasoning-context.js";
 import { ToolCall } from "./components/tool-call.js";
 import { TaskGroupView } from "./components/task-group-view.js";
 import { StatusBar } from "./components/status-bar.js";
 import { InputBox } from "./components/input-box.js";
 import { Header } from "./components/header.js";
+import { ReasoningBlock } from "./components/reasoning-block.js";
 import { pasteCollapseLineThreshold, tuiAgentModelId } from "./config.js";
 import type {
   TUIOptions,
@@ -34,13 +36,42 @@ const TextPart = memo(function TextPart({ text }: { text: string }) {
   );
 });
 
-const ReasoningPart = memo(function ReasoningPart({ text }: { text: string }) {
+type ReasoningPartWrapperProps = {
+  text: string;
+  messageId: string;
+  isStreaming: boolean;
+};
+
+const ReasoningPartWrapper = memo(function ReasoningPartWrapper({
+  text,
+  messageId,
+  isStreaming,
+}: ReasoningPartWrapperProps) {
+  const { isExpanded, startReasoning, endReasoning, getReasoningDuration } =
+    useReasoningContext();
+
+  // Track reasoning timing
+  useEffect(() => {
+    if (text) {
+      startReasoning(messageId);
+    }
+  }, [messageId, text, startReasoning]);
+
+  // Mark reasoning as ended when no longer streaming
+  useEffect(() => {
+    if (!isStreaming && text) {
+      endReasoning(messageId);
+    }
+  }, [isStreaming, messageId, text, endReasoning]);
+
+  const durationSeconds = getReasoningDuration(messageId);
+
   return (
-    <Box marginLeft={2}>
-      <Text color="gray" dimColor wrap="wrap">
-        {text}
-      </Text>
-    </Box>
+    <ReasoningBlock
+      text={text}
+      durationSeconds={durationSeconds}
+      isExpanded={isExpanded}
+    />
   );
 });
 
@@ -54,11 +85,19 @@ function ToolPartWrapper({
   return <ToolCall part={part} activeApprovalId={activeApprovalId} />;
 }
 
+type RenderPartOptions = {
+  activeApprovalId: string | null;
+  messageId: string;
+  isStreaming: boolean;
+};
+
 function renderPart(
   part: TUIAgentUIMessagePart,
   key: string,
-  activeApprovalId: string | null,
+  options: RenderPartOptions,
 ) {
+  const { activeApprovalId, messageId, isStreaming } = options;
+
   if (isToolUIPart(part)) {
     return (
       <ToolPartWrapper key={key} part={part} activeApprovalId={activeApprovalId} />
@@ -72,7 +111,14 @@ function renderPart(
 
     case "reasoning":
       if (!part.text) return null;
-      return <ReasoningPart key={key} text={part.text} />;
+      return (
+        <ReasoningPartWrapper
+          key={key}
+          text={part.text}
+          messageId={messageId}
+          isStreaming={isStreaming}
+        />
+      );
 
     default:
       return null;
@@ -109,9 +155,11 @@ type RenderGroup =
 const AssistantMessage = memo(function AssistantMessage({
   message,
   activeApprovalId,
+  isStreaming,
 }: {
   message: TUIAgentUIMessage;
   activeApprovalId: string | null;
+  isStreaming: boolean;
 }) {
   // Group consecutive task parts together, keeping them in linear order
   const renderGroups = useMemo(() => {
@@ -165,11 +213,11 @@ const AssistantMessage = memo(function AssistantMessage({
             />
           );
         }
-        return renderPart(
-          group.part,
-          `${message.id}-${group.index}`,
-          activeApprovalId
-        );
+        return renderPart(group.part, `${message.id}-${group.index}`, {
+          activeApprovalId,
+          messageId: message.id,
+          isStreaming,
+        });
       })}
     </Box>
   );
@@ -178,16 +226,22 @@ const AssistantMessage = memo(function AssistantMessage({
 const Message = memo(function Message({
   message,
   activeApprovalId,
+  isStreaming,
 }: {
   message: TUIAgentUIMessage;
   activeApprovalId: string | null;
+  isStreaming: boolean;
 }) {
   if (message.role === "user") {
     return <UserMessage message={message} />;
   }
   if (message.role === "assistant") {
     return (
-      <AssistantMessage message={message} activeApprovalId={activeApprovalId} />
+      <AssistantMessage
+        message={message}
+        activeApprovalId={activeApprovalId}
+        isStreaming={isStreaming}
+      />
     );
   }
   return null;
@@ -196,17 +250,20 @@ const Message = memo(function Message({
 const MessagesList = memo(function MessagesList({
   messages,
   activeApprovalId,
+  isStreaming,
 }: {
   messages: TUIAgentUIMessage[];
   activeApprovalId: string | null;
+  isStreaming: boolean;
 }) {
   return (
     <Box flexDirection="column">
-      {messages.map((message) => (
+      {messages.map((message, index) => (
         <Message
           key={message.id}
           message={message}
           activeApprovalId={activeApprovalId}
+          isStreaming={isStreaming && index === messages.length - 1}
         />
       ))}
     </Box>
@@ -285,9 +342,10 @@ const InterruptedIndicator = memo(function InterruptedIndicator() {
   );
 });
 
-export function App({ options }: AppProps) {
+function AppContent({ options }: AppProps) {
   const { exit } = useApp();
   const { chat, state, cycleAutoAcceptMode } = useChatContext();
+  const { toggleExpanded } = useReasoningContext();
   const [startTime, setStartTime] = useState<number | null>(null);
   const [wasInterrupted, setWasInterrupted] = useState(false);
 
@@ -329,6 +387,10 @@ export function App({ options }: AppProps) {
       stop();
       exit();
     }
+    // Toggle reasoning visibility with ctrl+p
+    if (input === "p" && key.ctrl) {
+      toggleExpanded();
+    }
   });
 
   useEffect(() => {
@@ -357,7 +419,11 @@ export function App({ options }: AppProps) {
         cwd={state.workingDirectory}
       />
 
-      <MessagesList messages={messages} activeApprovalId={activeApprovalId} />
+      <MessagesList
+        messages={messages}
+        activeApprovalId={activeApprovalId}
+        isStreaming={isStreaming}
+      />
 
       {wasInterrupted && !isStreaming && <InterruptedIndicator />}
 
@@ -380,4 +446,8 @@ export function App({ options }: AppProps) {
       )}
     </Box>
   );
+}
+
+export function App({ options }: AppProps) {
+  return <AppContent options={options} />;
 }

--- a/src/tui/components/index.ts
+++ b/src/tui/components/index.ts
@@ -4,3 +4,4 @@ export { StatusBar } from "./status-bar.js";
 export { InputBox } from "./input-box.js";
 export { DiffView, parseEditOutput } from "./diff-view.js";
 export { Header } from "./header.js";
+export { ReasoningBlock } from "./reasoning-block.js";

--- a/src/tui/components/reasoning-block.tsx
+++ b/src/tui/components/reasoning-block.tsx
@@ -1,0 +1,51 @@
+import React, { memo } from "react";
+import { Box, Text } from "ink";
+
+type ReasoningBlockProps = {
+  text: string;
+  durationSeconds: number;
+  isExpanded: boolean;
+};
+
+export const ReasoningBlock = memo(function ReasoningBlock({
+  text,
+  durationSeconds,
+  isExpanded,
+}: ReasoningBlockProps) {
+  if (isExpanded) {
+    return (
+      <Box flexDirection="column" marginLeft={2} marginBottom={1}>
+        <Box>
+          <Text color="gray">┌ </Text>
+          <Text color="gray" dimColor>
+            Thought for {durationSeconds}s
+          </Text>
+        </Box>
+        <Box marginLeft={2}>
+          <Text color="gray" dimColor wrap="wrap">
+            {text}
+          </Text>
+        </Box>
+        <Box>
+          <Text color="gray">└ </Text>
+          <Text color="gray" dimColor>
+            (ctrl+p to hide thinking)
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box marginLeft={2} marginBottom={1}>
+      <Text color="gray">○ </Text>
+      <Text color="gray" dimColor>
+        Thought for {durationSeconds}s
+      </Text>
+      <Text color="gray" dimColor>
+        {" "}
+        (ctrl+p to show thinking)
+      </Text>
+    </Box>
+  );
+});

--- a/src/tui/components/text-input.tsx
+++ b/src/tui/components/text-input.tsx
@@ -275,7 +275,8 @@ export function TextInput({
 
       // Handle Ctrl+P - let parent intercept if needed
       if (key.ctrl && input === "p") {
-        if (onCtrlP?.()) return;
+        onCtrlP?.();
+        return; // Always consume ctrl+p to prevent inserting 'p'
       }
 
       // Ignore certain key combinations

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { render } from "ink";
 import { App } from "./app.js";
 import { ChatProvider } from "./chat-context.js";
+import { ReasoningProvider } from "./reasoning-context.js";
 import { tuiAgentModelId, createDefaultAgentOptions } from "./config.js";
 import type { TUIOptions } from "./types.js";
 
 export type { TUIOptions, AutoAcceptMode } from "./types.js";
 export { useChatContext, ChatProvider } from "./chat-context.js";
+export { useReasoningContext, ReasoningProvider } from "./reasoning-context.js";
 export {
   tuiAgent,
   tuiAgentModelId,
@@ -43,7 +45,9 @@ export async function createTUI(options: TUIOptions): Promise<void> {
       model={options.header?.model ?? tuiAgentModelId}
       workingDirectory={options.workingDirectory}
     >
-      <App options={options} />
+      <ReasoningProvider>
+        <App options={options} />
+      </ReasoningProvider>
     </ChatProvider>,
   );
 
@@ -65,7 +69,9 @@ export function renderTUI(options: TUIOptions) {
       model={options.header?.model ?? tuiAgentModelId}
       workingDirectory={options.workingDirectory}
     >
-      <App options={options} />
+      <ReasoningProvider>
+        <App options={options} />
+      </ReasoningProvider>
     </ChatProvider>,
   );
 }

--- a/src/tui/reasoning-context.tsx
+++ b/src/tui/reasoning-context.tsx
@@ -1,0 +1,78 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  type ReactNode,
+} from "react";
+
+type ReasoningDuration = {
+  startTime: number;
+  endTime?: number;
+};
+
+type ReasoningContextValue = {
+  isExpanded: boolean;
+  toggleExpanded: () => void;
+  startReasoning: (messageId: string) => void;
+  endReasoning: (messageId: string) => void;
+  getReasoningDuration: (messageId: string) => number;
+};
+
+const ReasoningContext = createContext<ReasoningContextValue | undefined>(
+  undefined
+);
+
+export function ReasoningProvider({ children }: { children: ReactNode }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const durationsRef = useRef<Map<string, ReasoningDuration>>(new Map());
+
+  const toggleExpanded = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  const startReasoning = useCallback((messageId: string) => {
+    if (!durationsRef.current.has(messageId)) {
+      durationsRef.current.set(messageId, { startTime: Date.now() });
+    }
+  }, []);
+
+  const endReasoning = useCallback((messageId: string) => {
+    const duration = durationsRef.current.get(messageId);
+    if (duration && !duration.endTime) {
+      duration.endTime = Date.now();
+    }
+  }, []);
+
+  const getReasoningDuration = useCallback((messageId: string): number => {
+    const duration = durationsRef.current.get(messageId);
+    if (!duration) return 0;
+    const endTime = duration.endTime ?? Date.now();
+    return Math.max(1, Math.round((endTime - duration.startTime) / 1000));
+  }, []);
+
+  return (
+    <ReasoningContext.Provider
+      value={{
+        isExpanded,
+        toggleExpanded,
+        startReasoning,
+        endReasoning,
+        getReasoningDuration,
+      }}
+    >
+      {children}
+    </ReasoningContext.Provider>
+  );
+}
+
+export function useReasoningContext() {
+  const context = useContext(ReasoningContext);
+  if (!context) {
+    throw new Error(
+      "useReasoningContext must be used within a ReasoningProvider"
+    );
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
Adds a reasoning UI that displays AI thinking state with a collapsible indicator and keyboard shortcut (ctrl+p) to toggle visibility. Fixes keyboard event handling to prevent ctrl+p from inserting 'p' into the chat input.

## Changes
- Created ReasoningBlock component for displaying reasoning state
- Added ReasoningContext for global reasoning state management
- Integrated reasoning display into message flow with duration tracking
- Fixed ctrl+p keyboard shortcut to be properly consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)