### PR TITLE
fix alignment of messages

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -32,7 +32,10 @@ const TextPart = memo(function TextPart({ text }: { text: string }) {
 
   return (
     <Box>
-      <Text>● {rendered}</Text>
+      <Text>● </Text>
+      <Box flexShrink={1}>
+        <Text>{rendered}</Text>
+      </Box>
     </Box>
   );
 });


### PR DESCRIPTION
The fix separates the bullet point `●` from the text content. By putting the text in its own `Box` with `flexShrink={1}`, it will wrap properly and stay aligned to the right of the bullet point, rather than wrapping back to the left edge.

The key changes:
1. The bullet `● ` is now in its own `<Text>` element
2. The actual rendered content is wrapped in a `<Box flexShrink={1}>` which allows the text to wrap while staying in its column
3. This creates proper alignment where wrapped text stays indented past the bullet point