### PR TITLE
Add todo list visibility toggle and display

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -10,12 +10,14 @@ import { renderMarkdown } from "./lib/markdown.js";
 import { useChatContext } from "./chat-context.js";
 import { useReasoningContext } from "./reasoning-context.js";
 import { useExpandedView } from "./expanded-view-context.js";
+import { useTodoView } from "./todo-view-context.js";
 import { ToolCall } from "./components/tool-call.js";
 import { TaskGroupView } from "./components/task-group-view.js";
 import { StatusBar } from "./components/status-bar.js";
 import { InputBox } from "./components/input-box.js";
 import { Header } from "./components/header.js";
 import { pasteCollapseLineThreshold, tuiAgentModelId } from "./config.js";
+import { extractTodosFromLastAssistantMessage } from "./utils/extract-todos.js";
 import type {
   TUIOptions,
   TUIAgentUIMessagePart,
@@ -95,11 +97,13 @@ const ReasoningTracker = memo(function ReasoningTracker({
 function ToolPartWrapper({
   part,
   activeApprovalId,
+  isExpanded,
 }: {
   part: TUIAgentUIToolPart;
   activeApprovalId: string | null;
+  isExpanded: boolean;
 }) {
-  return <ToolCall part={part} activeApprovalId={activeApprovalId} />;
+  return <ToolCall part={part} activeApprovalId={activeApprovalId} isExpanded={isExpanded} />;
 }
 
 type RenderPartOptions = {
@@ -141,7 +145,7 @@ function renderPart(
 
   if (isToolUIPart(part)) {
     return (
-      <ToolPartWrapper key={key} part={part} activeApprovalId={activeApprovalId} />
+      <ToolPartWrapper key={key} part={part} activeApprovalId={activeApprovalId} isExpanded={isExpanded} />
     );
   }
 
@@ -420,6 +424,7 @@ const StreamingStatusBar = memo(function StreamingStatusBar({
   messages: TUIAgentUIMessage[];
 }) {
   const { getThinkingState } = useReasoningContext();
+  const { isTodoVisible } = useTodoView();
   const statusText = useStatusText(messages);
   const [, forceUpdate] = useState(0);
 
@@ -427,6 +432,12 @@ const StreamingStatusBar = memo(function StreamingStatusBar({
   const lastMessage = messages[messages.length - 1];
   const messageId = lastMessage?.id ?? "";
   const thinkingState = getThinkingState(messageId);
+
+  // Extract todos from the most recent assistant message in the current exchange
+  const todos = useMemo(
+    () => extractTodosFromLastAssistantMessage(messages),
+    [messages]
+  );
 
   // Force re-render periodically to update thinking duration while thinking
   useEffect(() => {
@@ -444,6 +455,8 @@ const StreamingStatusBar = memo(function StreamingStatusBar({
       isStreaming={true}
       status={statusText}
       thinkingState={thinkingState}
+      todos={todos}
+      isTodoVisible={isTodoVisible}
     />
   );
 });
@@ -470,6 +483,7 @@ function AppContent({ options }: AppProps) {
   const { exit } = useApp();
   const { chat, state, cycleAutoAcceptMode } = useChatContext();
   const { isExpanded, toggleExpanded } = useExpandedView();
+  const { toggleTodoView } = useTodoView();
   const [wasInterrupted, setWasInterrupted] = useState(false);
 
   const { messages, sendMessage, status, stop, error } = useChat({
@@ -512,6 +526,9 @@ function AppContent({ options }: AppProps) {
     }
     if (input === "o" && key.ctrl) {
       toggleExpanded();
+    }
+    if (input === "t" && key.ctrl) {
+      toggleTodoView();
     }
   });
 

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Box, Text } from "ink";
 import type { ThinkingState } from "../reasoning-context.js";
+import type { TodoItem } from "../../agent/types.js";
 
 const SILLY_WORDS = [
   "Thinking",
@@ -38,6 +39,8 @@ type StatusBarProps = {
   isStreaming: boolean;
   status?: string;
   thinkingState: ThinkingState;
+  todos?: TodoItem[] | null;
+  isTodoVisible?: boolean;
 };
 
 function getThinkingMeta(thinkingState: ThinkingState): string {
@@ -86,23 +89,83 @@ function StatusIndicator({
   return <Text color="green">✓ {status || "Done"}</Text>;
 }
 
+function getTodoIcon(status: TodoItem["status"]): string {
+  switch (status) {
+    case "completed":
+      return "☒";
+    case "in_progress":
+      return "◎";
+    case "pending":
+    default:
+      return "☐";
+  }
+}
+
+function getTodoColor(status: TodoItem["status"]): string {
+  switch (status) {
+    case "completed":
+      return "gray";
+    case "in_progress":
+      return "yellow";
+    case "pending":
+    default:
+      return "white";
+  }
+}
+
+function TodoList({ todos }: { todos: TodoItem[] }) {
+  const hasIncompleteTodos = todos.some((t) => t.status !== "completed");
+  if (!hasIncompleteTodos) return null;
+
+  return (
+    <Box flexDirection="column" marginLeft={2}>
+      {todos.map((todo) => (
+        <Box key={todo.id}>
+          <Text color={getTodoColor(todo.status)}>
+            {getTodoIcon(todo.status)}{" "}
+            {todo.status === "completed" ? (
+              <Text strikethrough>{todo.content}</Text>
+            ) : (
+              todo.content
+            )}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
 // Not memoized to allow animation
 export function StatusBar({
   isStreaming,
   status,
   thinkingState,
+  todos,
+  isTodoVisible = true,
 }: StatusBarProps) {
   if (!isStreaming && !status) {
     return null;
   }
 
+  const hasTodos = todos && todos.length > 0;
+  const hasIncompleteTodos = hasTodos && todos.some((t) => t.status !== "completed");
+  const showTodos = isTodoVisible && hasIncompleteTodos;
+
+  const todoHint = hasTodos && hasIncompleteTodos
+    ? ` · ctrl+t to ${isTodoVisible ? "hide" : "show"} todos`
+    : "";
+
   return (
-    <Box marginTop={1}>
-      <StatusIndicator
-        isStreaming={isStreaming}
-        status={status}
-        thinkingState={thinkingState}
-      />
+    <Box flexDirection="column" marginTop={1}>
+      <Box>
+        <StatusIndicator
+          isStreaming={isStreaming}
+          status={status}
+          thinkingState={thinkingState}
+        />
+        {hasTodos && <Text color="gray">{todoHint}</Text>}
+      </Box>
+      {showTodos && <TodoList todos={todos} />}
     </Box>
   );
 }

--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -467,9 +467,11 @@ export function SubagentToolCall({
 export function ToolCall({
   part,
   activeApprovalId,
+  isExpanded = false,
 }: {
   part: TUIAgentUIToolPart;
   activeApprovalId: string | null;
+  isExpanded?: boolean;
 }) {
   const running =
     part.state === "input-streaming" || part.state === "input-available";
@@ -625,18 +627,57 @@ export function ToolCall({
     }
 
     case "tool-todo_write": {
+      const todos = part.input?.todos as Array<{ id: string; content: string; status: string }> | undefined;
+      const todoCount = todos?.length ?? 0;
+      const completedCount = todos?.filter(t => t.status === "completed").length ?? 0;
+      const inProgressCount = todos?.filter(t => t.status === "in_progress").length ?? 0;
+      
+      const getTodoIcon = (status: string) => {
+        switch (status) {
+          case "completed": return "☒";
+          case "in_progress": return "◎";
+          default: return "☐";
+        }
+      };
+      
+      const getTodoColor = (status: string) => {
+        switch (status) {
+          case "completed": return "gray";
+          case "in_progress": return "yellow";
+          default: return "white";
+        }
+      };
+      
       return (
-        <ToolLayout
-          name="TodoWrite"
-          summary="Updating tasks"
-          output={
-            part.state === "output-available" && (
-              <Text color="white">Tasks updated</Text>
-            )
-          }
-          error={error}
-          running={running}
-        />
+        <Box flexDirection="column">
+          <ToolLayout
+            name="TodoWrite"
+            summary={`${todoCount} tasks (${completedCount} done, ${inProgressCount} in progress)`}
+            output={
+              part.state === "output-available" && (
+                <Text color="white">Tasks updated</Text>
+              )
+            }
+            error={error}
+            running={running}
+          />
+          {isExpanded && todos && todos.length > 0 && (
+            <Box flexDirection="column" paddingLeft={3}>
+              {todos.map((todo) => (
+                <Box key={todo.id}>
+                  <Text color={getTodoColor(todo.status)}>
+                    {getTodoIcon(todo.status)}{" "}
+                    {todo.status === "completed" ? (
+                      <Text strikethrough>{todo.content}</Text>
+                    ) : (
+                      todo.content
+                    )}
+                  </Text>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
       );
     }
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -4,6 +4,7 @@ import { App } from "./app.js";
 import { ChatProvider } from "./chat-context.js";
 import { ReasoningProvider } from "./reasoning-context.js";
 import { ExpandedViewProvider } from "./expanded-view-context.js";
+import { TodoViewProvider } from "./todo-view-context.js";
 import { tuiAgentModelId, createDefaultAgentOptions } from "./config.js";
 import type { TUIOptions } from "./types.js";
 
@@ -11,6 +12,7 @@ export type { TUIOptions, AutoAcceptMode } from "./types.js";
 export { useChatContext, ChatProvider } from "./chat-context.js";
 export { useReasoningContext, ReasoningProvider } from "./reasoning-context.js";
 export { useExpandedView, ExpandedViewProvider } from "./expanded-view-context.js";
+export { useTodoView, TodoViewProvider } from "./todo-view-context.js";
 export {
   tuiAgent,
   tuiAgentModelId,
@@ -49,7 +51,9 @@ export async function createTUI(options: TUIOptions): Promise<void> {
     >
       <ReasoningProvider>
         <ExpandedViewProvider>
-          <App options={options} />
+          <TodoViewProvider>
+            <App options={options} />
+          </TodoViewProvider>
         </ExpandedViewProvider>
       </ReasoningProvider>
     </ChatProvider>,
@@ -75,7 +79,9 @@ export function renderTUI(options: TUIOptions) {
     >
       <ReasoningProvider>
         <ExpandedViewProvider>
-          <App options={options} />
+          <TodoViewProvider>
+            <App options={options} />
+          </TodoViewProvider>
         </ExpandedViewProvider>
       </ReasoningProvider>
     </ChatProvider>,

--- a/src/tui/todo-view-context.tsx
+++ b/src/tui/todo-view-context.tsx
@@ -1,0 +1,43 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  type ReactNode,
+} from "react";
+
+type TodoViewContextValue = {
+  isTodoVisible: boolean;
+  toggleTodoView: () => void;
+};
+
+const TodoViewContext = createContext<TodoViewContextValue | undefined>(
+  undefined
+);
+
+export function TodoViewProvider({ children }: { children: ReactNode }) {
+  const [isTodoVisible, setIsTodoVisible] = useState(false);
+
+  const toggleTodoView = useCallback(() => {
+    setIsTodoVisible((prev) => !prev);
+  }, []);
+
+  return (
+    <TodoViewContext.Provider
+      value={{
+        isTodoVisible,
+        toggleTodoView,
+      }}
+    >
+      {children}
+    </TodoViewContext.Provider>
+  );
+}
+
+export function useTodoView() {
+  const context = useContext(TodoViewContext);
+  if (!context) {
+    throw new Error("useTodoView must be used within a TodoViewProvider");
+  }
+  return context;
+}

--- a/src/tui/utils/extract-todos.ts
+++ b/src/tui/utils/extract-todos.ts
@@ -1,0 +1,45 @@
+import { isToolUIPart } from "ai";
+import type { TodoItem } from "../../agent/types.js";
+import type { TUIAgentUIMessage, TUIAgentUIToolPart } from "../types.js";
+
+function isTodoWritePart(
+  part: TUIAgentUIToolPart
+): part is TUIAgentUIToolPart & { type: "tool-todo_write" } {
+  return part.type === "tool-todo_write";
+}
+
+export function extractTodosFromMessage(
+  message: TUIAgentUIMessage
+): TodoItem[] | null {
+  let latestTodos: TodoItem[] | null = null;
+  for (const part of message.parts) {
+    if (
+      isToolUIPart(part) &&
+      isTodoWritePart(part) &&
+      part.state === "output-available" &&
+      part.output
+    ) {
+      latestTodos = part.output.todos;
+    }
+  }
+  return latestTodos;
+}
+
+export function extractTodosFromLastAssistantMessage(
+  messages: TUIAgentUIMessage[]
+): TodoItem[] | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message) continue;
+    if (message.role === "assistant") {
+      const todos = extractTodosFromMessage(message);
+      if (todos !== null) {
+        return todos;
+      }
+    }
+    if (message.role === "user") {
+      break;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Users can now toggle todo visibility with Ctrl+T, and todos are displayed in both the status bar and expanded tool views.

**What changed:**
- Created `TodoViewProvider` context and `useTodoView` hook to manage todo visibility state globally
- Added `extractTodosFromLastAssistantMessage()` utility to extract todo data from the most recent assistant message
- Enhanced `StatusBar` component to display extracted todos with status indicators (☐ pending, ◎ in progress, ☒ completed) and a toggle hint
- Added todo list rendering in the expanded `ToolCall` view for `tool-todo_write` with a collapsible summary showing todo counts by status
- Integrated Ctrl+T keyboard shortcut in `AppContent` to toggle todo visibility
- Passed `isExpanded` prop through `ToolPartWrapper` to enable conditional rendering of todo details in tool views

**Why:**
- Provides visibility into task progress and status within the TUI chat interface
- Allows users to focus/minimize todo details as needed
- Creates a consistent todo display pattern across the status bar and expanded views

**How:**
- Used React Context for global state management of todo visibility
- Leveraged existing `tool-todo_write` tool output structure to extract and display todos
- Added visual indicators (icons and colors) to distinguish todo statuses at a glance
- Maintained backward compatibility by making todo display optional and defaulting to hidden state
