### PR TITLE
Add dedicated approval panel for tool confirmation

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -11,7 +11,8 @@ import { useChatContext } from "./chat-context.js";
 import { useReasoningContext } from "./reasoning-context.js";
 import { useExpandedView } from "./expanded-view-context.js";
 import { useTodoView } from "./todo-view-context.js";
-import { ToolCall } from "./components/tool-call.js";
+import { ToolCall, getToolApprovalInfo } from "./components/tool-call.js";
+import { ApprovalPanel } from "./components/approval-panel.js";
 import { TaskGroupView } from "./components/task-group-view.js";
 import { StatusBar } from "./components/status-bar.js";
 import { InputBox } from "./components/input-box.js";
@@ -499,7 +500,7 @@ function AppContent({ options }: AppProps) {
     }
   }, [isStreaming]);
 
-  const { hasPendingApproval, activeApprovalId } = useMemo(() => {
+  const { hasPendingApproval, activeApprovalId, pendingToolPart } = useMemo(() => {
     const lastMessage = messages[messages.length - 1];
     if (lastMessage?.role === "assistant") {
       for (const p of lastMessage.parts) {
@@ -508,12 +509,19 @@ function AppContent({ options }: AppProps) {
           return {
             hasPendingApproval: true,
             activeApprovalId: approval?.id ?? null,
+            pendingToolPart: p,
           };
         }
       }
     }
-    return { hasPendingApproval: false, activeApprovalId: null };
+    return { hasPendingApproval: false, activeApprovalId: null, pendingToolPart: null };
   }, [messages]);
+
+  // Get approval info for the pending tool
+  const approvalInfo = useMemo(() => {
+    if (!pendingToolPart) return null;
+    return getToolApprovalInfo(pendingToolPart, state.workingDirectory);
+  }, [pendingToolPart, state.workingDirectory]);
 
   useInput((input, key) => {
     if (key.escape && isStreaming) {
@@ -547,6 +555,7 @@ function AppContent({ options }: AppProps) {
     [isStreaming, sendMessage],
   );
 
+  // Show message list with either approval panel or input box at bottom
   return (
     <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
       <Header
@@ -567,20 +576,35 @@ function AppContent({ options }: AppProps) {
 
       <ErrorDisplay error={error} />
 
-      {isStreaming && (
-        <StreamingStatusBar messages={messages} />
-      )}
-
-      {!hasPendingApproval && !isExpanded && (
-        <InputBox
-          onSubmit={handleSubmit}
-          autoAcceptMode={state.autoAcceptMode}
-          onToggleAutoAccept={cycleAutoAcceptMode}
-          disabled={isStreaming}
-          inputTokens={state.usage.inputTokens ?? 0}
-          contextLimit={state.contextLimit}
-          pasteCollapseLineThreshold={pasteCollapseLineThreshold}
+      {/* Show approval panel when there's a pending approval (replaces status bar and input) */}
+      {hasPendingApproval && activeApprovalId && approvalInfo ? (
+        <ApprovalPanel
+          approvalId={activeApprovalId}
+          toolType={approvalInfo.toolType}
+          toolCommand={approvalInfo.toolCommand}
+          toolDescription={approvalInfo.toolDescription}
+          dontAskAgainPattern={approvalInfo.dontAskAgainPattern}
         />
+      ) : (
+        <>
+          {/* Show streaming status bar when streaming */}
+          {isStreaming && (
+            <StreamingStatusBar messages={messages} />
+          )}
+
+          {/* Show input box (disabled when streaming) */}
+          {!isExpanded && (
+            <InputBox
+              onSubmit={handleSubmit}
+              autoAcceptMode={state.autoAcceptMode}
+              onToggleAutoAccept={cycleAutoAcceptMode}
+              disabled={isStreaming}
+              inputTokens={state.usage.inputTokens ?? 0}
+              contextLimit={state.contextLimit}
+              pasteCollapseLineThreshold={pasteCollapseLineThreshold}
+            />
+          )}
+        </>
       )}
 
       {isExpanded && <ExpandedViewIndicator />}

--- a/src/tui/components/approval-panel.tsx
+++ b/src/tui/components/approval-panel.tsx
@@ -1,0 +1,142 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+import { useChat } from "@ai-sdk/react";
+import { useChatContext } from "../chat-context.js";
+
+export type ApprovalPanelProps = {
+  approvalId: string;
+  toolType: string;
+  toolCommand: string;
+  toolDescription?: string;
+  dontAskAgainPattern?: string;
+};
+
+export function ApprovalPanel({
+  approvalId,
+  toolType,
+  toolCommand,
+  toolDescription,
+  dontAskAgainPattern,
+}: ApprovalPanelProps) {
+  const { chat } = useChatContext();
+  const { addToolApprovalResponse } = useChat({ chat });
+  const [selected, setSelected] = useState(0);
+  const [reason, setReason] = useState("");
+
+  // Reset state when approval request changes
+  useEffect(() => {
+    setSelected(0);
+    setReason("");
+  }, [approvalId]);
+
+  useInput((input, key) => {
+    // Handle escape to cancel (deny without reason)
+    if (key.escape) {
+      addToolApprovalResponse({ id: approvalId, approved: false });
+      return;
+    }
+
+    // When on the text input option (selected === 2)
+    if (selected === 2) {
+      if (key.return) {
+        addToolApprovalResponse({
+          id: approvalId,
+          approved: false,
+          reason: reason.trim() || undefined,
+        });
+      } else if (key.backspace || key.delete) {
+        setReason((prev) => prev.slice(0, -1));
+      } else if (key.upArrow || (key.ctrl && input === "p")) {
+        setSelected(1);
+      } else if (input && !key.ctrl && !key.meta && !key.return) {
+        setReason((prev) => prev + input);
+      }
+      return;
+    }
+
+    const goUp = key.upArrow || input === "k" || (key.ctrl && input === "p");
+    const goDown =
+      key.downArrow || input === "j" || (key.ctrl && input === "n");
+
+    if (goUp) {
+      setSelected((prev) => (prev === 0 ? 2 : prev - 1));
+    }
+    if (goDown) {
+      setSelected((prev) => (prev === 2 ? 0 : prev + 1));
+    }
+    if (key.return) {
+      if (selected === 0) {
+        // Yes
+        addToolApprovalResponse({ id: approvalId, approved: true });
+      } else if (selected === 1) {
+        // Yes, and don't ask again (placeholder - behaves as Yes for now)
+        addToolApprovalResponse({ id: approvalId, approved: true });
+      }
+    }
+  });
+
+  return (
+    <Box
+      flexDirection="column"
+      marginTop={1}
+      borderStyle="single"
+      borderTop
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      borderColor="gray"
+      paddingTop={1}
+    >
+      {/* Tool type header */}
+      <Text color="blueBright" bold>
+        {toolType}
+      </Text>
+
+      {/* Command and description */}
+      <Box flexDirection="column" marginTop={1} marginLeft={2}>
+        <Text>{toolCommand}</Text>
+        {toolDescription && <Text color="gray">{toolDescription}</Text>}
+      </Box>
+
+      {/* Question and options */}
+      <Box flexDirection="column" marginTop={1}>
+        <Text>Do you want to proceed?</Text>
+        <Box flexDirection="column" marginTop={1}>
+          {/* Option 1: Yes */}
+          <Text>
+            <Text color="yellow">{selected === 0 ? "› " : "  "}</Text>
+            <Text>1. Yes</Text>
+          </Text>
+
+          {/* Option 2: Yes, and don't ask again */}
+          <Text>
+            <Text color="yellow">{selected === 1 ? "› " : "  "}</Text>
+            <Text>2. Yes, and don't ask again for </Text>
+            <Text bold>{dontAskAgainPattern}</Text>
+          </Text>
+
+          {/* Option 3: Inline text input */}
+          <Box>
+            <Text color="yellow">{selected === 2 ? "› " : "  "}</Text>
+            <Text>3. </Text>
+            {reason || selected === 2 ? (
+              <>
+                <Text>{reason}</Text>
+                {selected === 2 && <Text color="gray">█</Text>}
+              </>
+            ) : (
+              <Text color="gray">Type here to tell Claude what to do differently</Text>
+            )}
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Footer hint */}
+      <Box marginTop={1}>
+        <Text color="gray">
+          {selected === 2 ? "Enter to submit, Esc to cancel" : "Esc to cancel"}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -5,6 +5,86 @@ import { getToolName, isTextUIPart, isToolUIPart } from "ai";
 import { useChatContext } from "../chat-context.js";
 import type { TUIAgentUIToolPart } from "../types.js";
 
+export type ToolApprovalInfo = {
+  toolType: string;
+  toolCommand: string;
+  toolDescription?: string;
+  dontAskAgainPattern?: string;
+};
+
+export function getToolApprovalInfo(
+  part: TUIAgentUIToolPart,
+  workingDirectory?: string,
+): ToolApprovalInfo {
+  const cwd = workingDirectory ?? process.cwd();
+
+  switch (part.type) {
+    case "tool-bash": {
+      const command = String(part.input?.command ?? "");
+      // Description may be provided by Claude as additional context
+      const description = (part.input as { description?: string } | undefined)
+        ?.description;
+      // Extract first word of command for the pattern
+      const firstWord = command.split(" ")[0] ?? "this command";
+      return {
+        toolType: "Bash command",
+        toolCommand: command,
+        toolDescription: description,
+        dontAskAgainPattern: `${firstWord} commands in ${cwd}`,
+      };
+    }
+
+    case "tool-write": {
+      const filePath = String(part.input?.filePath ?? "");
+      return {
+        toolType: "Write file",
+        toolCommand: filePath,
+        toolDescription: "Create new file",
+        dontAskAgainPattern: `writes in ${cwd}`,
+      };
+    }
+
+    case "tool-edit": {
+      const filePath = String(part.input?.filePath ?? "");
+      return {
+        toolType: "Edit file",
+        toolCommand: filePath,
+        toolDescription: "Modify existing file",
+        dontAskAgainPattern: `edits in ${cwd}`,
+      };
+    }
+
+    case "tool-task": {
+      const desc = String(part.input?.task ?? "Spawning subagent");
+      const subagentType = (part.input as { subagentType?: string })
+        ?.subagentType;
+      return {
+        toolType:
+          subagentType === "executor"
+            ? "Executor task"
+            : subagentType === "explorer"
+              ? "Explorer task"
+              : "Task",
+        toolCommand: desc,
+        toolDescription:
+          subagentType === "executor"
+            ? "This executor has full write access and can create, modify, and delete files."
+            : undefined,
+        dontAskAgainPattern: `${subagentType ?? "task"} operations`,
+      };
+    }
+
+    default: {
+      const toolName = getToolName(part);
+      return {
+        toolType: toolName.charAt(0).toUpperCase() + toolName.slice(1),
+        toolCommand: JSON.stringify(part.input).slice(0, 60),
+        dontAskAgainPattern: `${toolName} operations`,
+      };
+    }
+  }
+}
+
 type DiffLine = {
   type: "context" | "addition" | "removal" | "separator";
   lineNumber?: number;
@@ -159,11 +239,15 @@ function ToolLayout({
         <Text color="gray">)</Text>
       </Box>
 
-      {isActiveApproval && approvalId && (
-        <ApprovalButtons approvalId={approvalId} />
+      {/* Show Running/Waiting status for approval-requested tools */}
+      {approvalRequested && (
+        <Box paddingLeft={2}>
+          <Text color="gray">└ </Text>
+          <Text color="gray">{isActiveApproval ? "Running…" : "Waiting…"}</Text>
+        </Box>
       )}
 
-      {output && (
+      {output && !approvalRequested && (
         <Box paddingLeft={2}>
           <Text color="gray">└ </Text>
           {output}
@@ -246,8 +330,16 @@ function FileChangeLayout({
         <Text color="gray">)</Text>
       </Box>
 
+      {/* Show Running/Waiting status for approval-requested tools */}
+      {approvalRequested && (
+        <Box paddingLeft={2}>
+          <Text color="gray">└ </Text>
+          <Text color="gray">{isActiveApproval ? "Running…" : "Waiting…"}</Text>
+        </Box>
+      )}
+
       {/* Subheader: └ Updated src/file.ts with X additions and Y removals */}
-      {showDiff && (
+      {showDiff && !approvalRequested && !denied && (
         <Box paddingLeft={2}>
           <Text color="gray">└ </Text>
           <Text>{action === "Create" ? "Created" : "Updated"} </Text>
@@ -264,7 +356,7 @@ function FileChangeLayout({
       )}
 
       {/* Diff lines */}
-      {showDiff && lines.length > 0 && (
+      {showDiff && !approvalRequested && !denied && lines.length > 0 && (
         <Box flexDirection="column" paddingLeft={4}>
           {lines.map((line, i) => (
             <Box key={i}>
@@ -305,11 +397,6 @@ function FileChangeLayout({
             </Box>
           ))}
         </Box>
-      )}
-
-      {/* Approval buttons */}
-      {isActiveApproval && approvalId && (
-        <ApprovalButtons approvalId={approvalId} />
       )}
 
       {denied && (
@@ -475,15 +562,13 @@ export function ToolCall({
 }) {
   const running =
     part.state === "input-streaming" || part.state === "input-available";
-  const approvalRequested = part.state === "approval-requested";
-  const denied = part.state === "output-denied";
-  const denialReason = denied
-    ? (part as { approval?: { reason?: string } }).approval?.reason
-    : undefined;
+  const approval = (part as { approval?: { id?: string; approved?: boolean; reason?: string } }).approval;
+  // Check for denial both via state and via approval object (for intermediate states)
+  const denied = part.state === "output-denied" || approval?.approved === false;
+  const denialReason = denied ? approval?.reason : undefined;
+  const approvalRequested = part.state === "approval-requested" && !denied;
   const error = part.state === "output-error" ? part.errorText : undefined;
-  const approvalId = approvalRequested
-    ? (part as { approval?: { id: string } }).approval?.id
-    : undefined;
+  const approvalId = approvalRequested ? approval?.id : undefined;
   // Only show interactive approval buttons for the first pending approval
   const isActiveApproval = approvalId != null && approvalId === activeApprovalId;
 
@@ -752,11 +837,6 @@ export function ToolCall({
                 This executor has full write access and can create, modify, and delete files.
               </Text>
             </Box>
-          )}
-
-          {/* Approval buttons */}
-          {isTaskActiveApproval && taskApprovalId && (
-            <ApprovalButtons approvalId={taskApprovalId} />
           )}
 
           {/* Denied message */}


### PR DESCRIPTION
Implement a dedicated ApprovalPanel component to handle tool confirmation requests instead of embedding approval buttons throughout the UI. This provides a cleaner, more focused approval experience and centralizes the approval logic.

### Changes
- **New ApprovalPanel component** (`approval-panel.tsx`): Interactive component with keyboard navigation for tool approval decisions
  - Supports three options: "Yes", "Yes, don't ask again", and text input for rejection reasoning
  - Handles navigation with arrow keys, vim keys, and Escape to cancel
  - Displays tool type, command, description, and "don't ask again" pattern

- **Extract tool approval info** (`tool-call.tsx`): Added `getToolApprovalInfo()` function to format tool details from parts
  - Supports bash, file write/edit, task, and generic tool types
  - Generates appropriate patterns and descriptions for each tool type
  - Centralizes tool-specific formatting logic

- **Update AppContent layout** (`app.tsx`): Restructured bottom section to show ApprovalPanel when pending approval exists
  - ApprovalPanel replaces both status bar and input box during approval flow
  - Falls back to streaming status bar and input box when no approval pending
  - Extracts approval info via memo hook to avoid unnecessary recalculations

- **Simplify tool call display**: Remove inline ApprovalButtons from ToolLayout and FileChangeLayout
  - Show "Running…" or "Waiting…" status instead
  - Hide diff output and tool details while approval is pending (declutters UI during decision making)

### Impact
Users now see a clean, focused approval panel at the bottom of the chat when a tool needs confirmation, with clear options and keyboard-friendly navigation. This replaces the previous scattered approval buttons embedded in tool output.