### PR TITLE
Refactor tools to use factory functions with dynamic approval

### DIFF
--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -19,7 +19,7 @@ import { buildSystemPrompt } from "./system-prompt";
 import { formatTodosForContext, formatScratchpadForContext } from "./state";
 import type { TodoItem, ScratchpadEntry } from "./types";
 import { todoItemSchema } from "./types";
-import { addCacheControl, compactContext } from "./utils";
+import { addCacheControl, compactContext, sharedContext } from "./utils";
 import { gateway } from "../models";
 import { createLocalSandbox, type Sandbox } from "./sandbox";
 
@@ -56,11 +56,11 @@ export const deepAgent = new ToolLoopAgent({
   tools: addCacheControl({
     tools: {
       todo_write: todoWriteTool,
-      read: readFileTool,
+      read: readFileTool(),
       write: writeFileTool({ needsApproval: true }),
       edit: editFileTool({ needsApproval: true }),
-      grep: grepTool,
-      glob: globTool,
+      grep: grepTool(),
+      glob: globTool(),
       bash: bashTool({ needsApproval: true }),
       task: taskTool,
       // memory_save: memorySaveTool,
@@ -78,6 +78,8 @@ export const deepAgent = new ToolLoopAgent({
   }),
   prepareCall: ({ options, model, ...settings }) => {
     const workingDirectory = options?.workingDirectory ?? process.cwd();
+    // Update shared context for tool approval functions
+    sharedContext.workingDirectory = workingDirectory;
     const customInstructions = options?.customInstructions;
     const todos = options?.todos ?? [];
     const scratchpad =

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import { isPathWithinDirectory, getSandbox } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
 
 const TIMEOUT_MS = 120_000;
 
@@ -18,6 +18,46 @@ type ApprovalFn = (args: BashInput) => boolean | Promise<boolean>;
 
 interface ToolOptions {
   needsApproval?: boolean | ApprovalFn;
+}
+
+/**
+ * Check if the cwd parameter is outside the working directory.
+ * If cwd is not provided, it defaults to working directory (no approval needed for path).
+ */
+function cwdIsOutsideWorkingDirectory(cwd: string | undefined): boolean {
+  if (!cwd) {
+    return false;
+  }
+  const absoluteCwd = path.isAbsolute(cwd)
+    ? cwd
+    : path.resolve(sharedContext.workingDirectory, cwd);
+  return !isPathWithinDirectory(absoluteCwd, sharedContext.workingDirectory);
+}
+
+/**
+ * Create a combined approval function for bash operations.
+ * Always requires approval if cwd is outside working directory,
+ * then checks command safety and user-provided option.
+ */
+function createBashApprovalFn(options?: ToolOptions): ApprovalFn {
+  return async (args) => {
+    // Always need approval if cwd is outside working directory
+    if (cwdIsOutsideWorkingDirectory(args.cwd)) {
+      return true;
+    }
+
+    // Check command safety
+    if (commandNeedsApproval(args.command)) {
+      // If command is dangerous, check user's approval setting
+      if (typeof options?.needsApproval === "function") {
+        return options.needsApproval(args);
+      }
+      return options?.needsApproval ?? true;
+    }
+
+    // Command is safe - no approval needed
+    return false;
+  };
 }
 
 // Read-only commands that are safe to run without approval
@@ -92,7 +132,7 @@ export function commandNeedsApproval(command: string): boolean {
 }
 
 export const bashTool = (options?: ToolOptions) => tool({
-  needsApproval: options?.needsApproval ?? true,
+  needsApproval: createBashApprovalFn(options),
   description: `Execute a bash command in the user's shell (non-interactive).
 
 WHEN TO USE:
@@ -123,7 +163,7 @@ IMPORTANT:
 - Never use interactive commands (vim, nano, top, bash, ssh, etc.)
 - Never start background processes with '&'
 - Always quote file paths that may contain spaces
-- The working directory (cwd) must be within the main working directory; paths outside are rejected
+- Setting cwd to a path outside the working directory requires approval
 
 EXAMPLES:
 - Run the test suite: command: "npm test", cwd: "/Users/username/project"
@@ -138,16 +178,6 @@ EXAMPLES:
     const workingDir = cwd
       ? (path.isAbsolute(cwd) ? cwd : path.resolve(workingDirectory, cwd))
       : workingDirectory;
-
-    // Security check: ensure cwd is within working directory
-    if (!isPathWithinDirectory(workingDir, workingDirectory)) {
-      return {
-        success: false,
-        exitCode: null,
-        stdout: "",
-        stderr: `Access denied: cwd "${workingDir}" is outside the working directory "${workingDirectory}"`,
-      };
-    }
 
     const result = await sandbox.exec(command, workingDir, TIMEOUT_MS);
 

--- a/src/agent/tools/file-system/glob.ts
+++ b/src/agent/tools/file-system/glob.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import type { Sandbox } from "../../sandbox";
-import { isPathWithinDirectory, getSandbox } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
 
 interface FileInfo {
   path: string;
@@ -90,7 +90,37 @@ async function findFiles(
   return results;
 }
 
-export const globTool = tool({
+const globInputSchema = z.object({
+  pattern: z.string().describe("Glob pattern to match (e.g., '**/*.ts')"),
+  path: z
+    .string()
+    .optional()
+    .describe("Base directory to search from (absolute path)"),
+  limit: z
+    .number()
+    .optional()
+    .describe("Maximum number of results. Default: 100"),
+});
+
+type GlobInput = z.infer<typeof globInputSchema>;
+
+/**
+ * Check if a glob operation needs approval based on the search path.
+ * Returns true if the path is outside the working directory.
+ */
+function pathNeedsApproval(args: GlobInput): boolean {
+  // If no path is provided, it defaults to working directory (no approval needed)
+  if (!args.path) {
+    return false;
+  }
+  const absolutePath = path.isAbsolute(args.path)
+    ? args.path
+    : path.resolve(sharedContext.workingDirectory, args.path);
+  return !isPathWithinDirectory(absolutePath, sharedContext.workingDirectory);
+}
+
+export const globTool = () => tool({
+  needsApproval: pathNeedsApproval,
   description: `Find files matching a glob pattern.
 
 WHEN TO USE:
@@ -111,7 +141,7 @@ USAGE:
 - Results are limited by the limit parameter (default: 100)
 
 IMPORTANT:
-- Access is restricted to paths under the working directory; base paths outside will be rejected
+- Paths outside the working directory require approval
 - Patterns are matched primarily on the final path segment (file name), with basic "*" and "**" support
 - Use this to narrow down candidate files before calling readFileTool or grepTool
 
@@ -119,17 +149,7 @@ EXAMPLES:
 - All TypeScript files in the project: pattern: "**/*.ts"
 - All Jest tests under src: pattern: "src/**/*.test.ts"
 - Recent JSON config files: pattern: "*.json", path: "/Users/username/project/config", limit: 20`,
-  inputSchema: z.object({
-    pattern: z.string().describe("Glob pattern to match (e.g., '**/*.ts')"),
-    path: z
-      .string()
-      .optional()
-      .describe("Base directory to search from (absolute path)"),
-    limit: z
-      .number()
-      .optional()
-      .describe("Maximum number of results. Default: 100"),
-  }),
+  inputSchema: globInputSchema,
   execute: async ({ pattern, path: basePath, limit = 100 }, { experimental_context }) => {
     const sandbox = getSandbox(experimental_context);
     const workingDirectory = sandbox.workingDirectory;
@@ -143,14 +163,6 @@ EXAMPLES:
           : path.resolve(workingDirectory, basePath);
       } else {
         searchDir = workingDirectory;
-      }
-
-      // Security check: ensure search directory is within working directory
-      if (!isPathWithinDirectory(searchDir, workingDirectory)) {
-        return {
-          success: false,
-          error: `Access denied: path "${searchDir}" is outside the working directory "${workingDirectory}"`,
-        };
       }
 
       const files = await findFiles(searchDir, pattern, limit, sandbox);

--- a/src/agent/tools/file-system/grep.ts
+++ b/src/agent/tools/file-system/grep.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import type { Sandbox } from "../../sandbox";
-import { isPathWithinDirectory, getSandbox } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
 
 interface GrepMatch {
   file: string;
@@ -79,7 +79,36 @@ async function walkDirectory(
   return files;
 }
 
-export const grepTool = tool({
+const grepInputSchema = z.object({
+  pattern: z.string().describe("Regex pattern to search for"),
+  path: z
+    .string()
+    .describe("File or directory to search in (absolute path)"),
+  glob: z
+    .string()
+    .optional()
+    .describe("Glob pattern to filter files (e.g., '*.ts')"),
+  caseSensitive: z
+    .boolean()
+    .optional()
+    .describe("Case-sensitive search. Default: true"),
+});
+
+type GrepInput = z.infer<typeof grepInputSchema>;
+
+/**
+ * Check if a grep operation needs approval based on the search path.
+ * Returns true if the path is outside the working directory.
+ */
+function pathNeedsApproval(args: GrepInput): boolean {
+  const absolutePath = path.isAbsolute(args.path)
+    ? args.path
+    : path.resolve(sharedContext.workingDirectory, args.path);
+  return !isPathWithinDirectory(absolutePath, sharedContext.workingDirectory);
+}
+
+export const grepTool = () => tool({
+  needsApproval: pathNeedsApproval,
   description: `Search for patterns in files using JavaScript regular expressions.
 
 WHEN TO USE:
@@ -103,25 +132,12 @@ IMPORTANT:
 - ALWAYS use this tool for code/content searches instead of running grep/rg via bashTool
 - Use caseSensitive: false for case-insensitive searches
 - Hidden files and node_modules are skipped when searching directories
-- Access is restricted to files under the current working directory; paths outside will be rejected
+- Paths outside the working directory require approval
 
 EXAMPLES:
 - Find all TODO comments in TypeScript files: pattern: "TODO", path: "/Users/username/project", glob: "*.ts"
 - Find all references to a function (case-insensitive): pattern: "handleRequest", path: "/Users/username/project/src", caseSensitive: false`,
-  inputSchema: z.object({
-    pattern: z.string().describe("Regex pattern to search for"),
-    path: z
-      .string()
-      .describe("File or directory to search in (absolute path)"),
-    glob: z
-      .string()
-      .optional()
-      .describe("Glob pattern to filter files (e.g., '*.ts')"),
-    caseSensitive: z
-      .boolean()
-      .optional()
-      .describe("Case-sensitive search. Default: true"),
-  }),
+  inputSchema: grepInputSchema,
   execute: async ({
     pattern,
     path: searchPath,
@@ -138,14 +154,6 @@ EXAMPLES:
       const absolutePath = path.isAbsolute(searchPath)
         ? searchPath
         : path.resolve(workingDirectory, searchPath);
-
-      // Security check: ensure path is within working directory
-      if (!isPathWithinDirectory(absolutePath, workingDirectory)) {
-        return {
-          success: false,
-          error: `Access denied: path "${absolutePath}" is outside the working directory "${workingDirectory}"`,
-        };
-      }
 
       const stats = await sandbox.stat(absolutePath);
       let files: string[];

--- a/src/agent/tools/file-system/read.ts
+++ b/src/agent/tools/file-system/read.ts
@@ -1,9 +1,39 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import { isPathWithinDirectory, getSandbox } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
 
-export const readFileTool = tool({
+const readInputSchema = z.object({
+  filePath: z
+    .string()
+    .describe(
+      "Full absolute path to the file (e.g., /Users/username/project/file.ts)",
+    ),
+  offset: z
+    .number()
+    .optional()
+    .describe("Line number to start reading from (1-indexed)"),
+  limit: z
+    .number()
+    .optional()
+    .describe("Maximum number of lines to read. Default: 2000"),
+});
+
+type ReadInput = z.infer<typeof readInputSchema>;
+
+/**
+ * Check if a read operation needs approval based on the file path.
+ * Returns true if the path is outside the working directory.
+ */
+function pathNeedsApproval(args: ReadInput): boolean {
+  const absolutePath = path.isAbsolute(args.filePath)
+    ? args.filePath
+    : path.resolve(sharedContext.workingDirectory, args.filePath);
+  return !isPathWithinDirectory(absolutePath, sharedContext.workingDirectory);
+}
+
+export const readFileTool = () => tool({
+  needsApproval: pathNeedsApproval,
   description: `Read a file from the filesystem.
 
 USAGE:
@@ -17,27 +47,13 @@ USAGE:
 IMPORTANT:
 - Always read a file at least once before editing it with the edit/write tools
 - This tool can only read files, not directories - attempting to read a directory returns an error
-- Access is restricted to files inside the current working directory; paths outside will be rejected
+- Paths outside the working directory require approval
 - You can call multiple reads in parallel to speculatively load several files
 
 EXAMPLES:
 - Read an entire file: filePath: "/Users/username/project/src/index.ts"
 - Read a slice of a long file: filePath: "/Users/username/project/logs/app.log", offset: 500, limit: 200`,
-  inputSchema: z.object({
-    filePath: z
-      .string()
-      .describe(
-        "Full absolute path to the file (e.g., /Users/username/project/file.ts)",
-      ),
-    offset: z
-      .number()
-      .optional()
-      .describe("Line number to start reading from (1-indexed)"),
-    limit: z
-      .number()
-      .optional()
-      .describe("Maximum number of lines to read. Default: 2000"),
-  }),
+  inputSchema: readInputSchema,
   execute: async ({ filePath, offset = 1, limit = 2000 }, { experimental_context }) => {
     const sandbox = getSandbox(experimental_context);
     const workingDirectory = sandbox.workingDirectory;
@@ -78,14 +94,6 @@ EXAMPLES:
             // Neither path exists - let it fall through to the original error handling
           }
         }
-      }
-
-      // Security check: ensure path is within working directory
-      if (!isPathWithinDirectory(absolutePath, workingDirectory)) {
-        return {
-          success: false,
-          error: `Access denied: path "${absolutePath}" is outside the working directory "${workingDirectory}"`,
-        };
       }
 
       const stats = await sandbox.stat(absolutePath);

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import { isPathWithinDirectory, getSandbox } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
 
 const writeInputSchema = z.object({
   filePath: z.string().describe("Absolute path to the file to write"),
@@ -34,8 +34,54 @@ interface EditToolOptions {
   needsApproval?: boolean | EditApprovalFn;
 }
 
+/**
+ * Check if a path is outside the working directory.
+ */
+function isOutsideWorkingDirectory(filePath: string): boolean {
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(sharedContext.workingDirectory, filePath);
+  return !isPathWithinDirectory(absolutePath, sharedContext.workingDirectory);
+}
+
+/**
+ * Create a combined approval function for write operations.
+ * Always requires approval if path is outside CWD, otherwise uses the provided option.
+ */
+function createWriteApprovalFn(options?: WriteToolOptions): WriteApprovalFn {
+  return async (args) => {
+    // Always need approval if outside working directory
+    if (isOutsideWorkingDirectory(args.filePath)) {
+      return true;
+    }
+    // Otherwise use the configured approval setting
+    if (typeof options?.needsApproval === "function") {
+      return options.needsApproval(args);
+    }
+    return options?.needsApproval ?? true;
+  };
+}
+
+/**
+ * Create a combined approval function for edit operations.
+ * Always requires approval if path is outside CWD, otherwise uses the provided option.
+ */
+function createEditApprovalFn(options?: EditToolOptions): EditApprovalFn {
+  return async (args) => {
+    // Always need approval if outside working directory
+    if (isOutsideWorkingDirectory(args.filePath)) {
+      return true;
+    }
+    // Otherwise use the configured approval setting
+    if (typeof options?.needsApproval === "function") {
+      return options.needsApproval(args);
+    }
+    return options?.needsApproval ?? true;
+  };
+}
+
 export const writeFileTool = (options?: WriteToolOptions) => tool({
-  needsApproval: options?.needsApproval ?? true,
+  needsApproval: createWriteApprovalFn(options),
   description: `Write content to a file on the filesystem.
 
 WHEN TO USE:
@@ -58,7 +104,7 @@ IMPORTANT:
 - Prefer editing existing files over creating new ones unless a new file is explicitly needed
 - NEVER proactively create documentation files (e.g., *.md) unless the user explicitly requests them
 - Do not write files that contain secrets or credentials (API keys, passwords, .env, etc.)
-- Access is restricted to paths inside the working directory; paths outside will be rejected
+- Paths outside the working directory require approval
 
 EXAMPLES:
 - Create a new test file: filePath: "/Users/username/project/src/user.test.ts", content: "<full file contents>"
@@ -72,14 +118,6 @@ EXAMPLES:
       const absolutePath = path.isAbsolute(filePath)
         ? filePath
         : path.resolve(workingDirectory, filePath);
-
-      // Security check: ensure path is within working directory
-      if (!isPathWithinDirectory(absolutePath, workingDirectory)) {
-        return {
-          success: false,
-          error: `Access denied: path "${absolutePath}" is outside the working directory "${workingDirectory}"`,
-        };
-      }
 
       const dir = path.dirname(absolutePath);
       await sandbox.mkdir(dir, { recursive: true });
@@ -103,7 +141,7 @@ EXAMPLES:
 });
 
 export const editFileTool = (options?: EditToolOptions) => tool({
-  needsApproval: options?.needsApproval ?? true,
+  needsApproval: createEditApprovalFn(options),
   description: `Perform exact string replacement in a file.
 
 WHEN TO USE:
@@ -126,7 +164,7 @@ IMPORTANT:
 - Preserve exact indentation and spacing from the file's content as returned by readFileTool
 - Never include line numbers or the "N: " line prefixes from the read output in oldString or newString
 - If oldString appears multiple times and replaceAll is false, the tool will FAIL with an error and occurrence count
-- Access is restricted to paths inside the working directory; paths outside will be rejected
+- Paths outside the working directory require approval
 
 EXAMPLES:
 - Replace a single function call: filePath: "/Users/username/project/src/auth.ts", oldString: "login(user, password)", newString: "loginWithAudit(user, password)"
@@ -147,14 +185,6 @@ EXAMPLES:
       const absolutePath = path.isAbsolute(filePath)
         ? filePath
         : path.resolve(workingDirectory, filePath);
-
-      // Security check: ensure path is within working directory
-      if (!isPathWithinDirectory(absolutePath, workingDirectory)) {
-        return {
-          success: false,
-          error: `Access denied: path "${absolutePath}" is outside the working directory "${workingDirectory}"`,
-        };
-      }
 
       const content = await sandbox.readFile(absolutePath, "utf-8");
 

--- a/src/agent/tools/task-delegation/subagents/executor.ts
+++ b/src/agent/tools/task-delegation/subagents/executor.ts
@@ -55,11 +55,11 @@ export const executorSubagent = new ToolLoopAgent({
   model: "anthropic/claude-sonnet-4-20250514",
   instructions: EXECUTOR_SYSTEM_PROMPT,
   tools: {
-    read: readFileTool,
+    read: readFileTool(),
     write: writeFileTool({ needsApproval: false }),
     edit: editFileTool({ needsApproval: false }),
-    grep: grepTool,
-    glob: globTool,
+    grep: grepTool(),
+    glob: globTool(),
     // Use smart approval: safe read-only commands run without approval,
     // dangerous commands (rm, git push, etc.) still require approval
     bash: bashTool({

--- a/src/agent/tools/task-delegation/subagents/explorer.ts
+++ b/src/agent/tools/task-delegation/subagents/explorer.ts
@@ -66,9 +66,9 @@ export const explorerSubagent = new ToolLoopAgent({
   model: "anthropic/claude-sonnet-4-20250514",
   instructions: EXPLORER_SYSTEM_PROMPT,
   tools: {
-    read: readFileTool,
-    grep: grepTool,
-    glob: globTool,
+    read: readFileTool(),
+    grep: grepTool(),
+    glob: globTool(),
     // Use smart approval: safe read-only commands run without approval,
     // dangerous commands are blocked (explorer is read-only anyway)
     bash: bashTool({

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -1,3 +1,4 @@
 export { addCacheControl } from "./cache-control/add-cache-control";
 export { compactContext } from "./compact-context";
 export { isPathWithinDirectory, getSandbox } from "./path";
+export { sharedContext } from "./shared-context";


### PR DESCRIPTION
## Summary
This change refactors filesystem and command tools to be factory functions that accept options and dynamically determine approval requirements based on the working directory context. It moves security checks from runtime execution to the approval layer, enabling the AI framework to make informed decisions about which operations need user approval.

## What Changed

**Tool Factory Pattern**
- Converted `readFileTool`, `grepTool`, `globTool`, and `bashTool` from tool objects to factory functions that return tool objects
- Updated all tool instantiations across the codebase to call these functions: `readFileTool()` instead of `readFileTool`
- Extracted input schemas for `read`, `grep`, and `glob` tools into separate constants for reuse and clarity

**Shared Context Management**
- Added `sharedContext` export to `src/agent/utils/index.ts` to provide runtime context (working directory) to approval functions
- Updated `deep-agent.ts` to populate `sharedContext.workingDirectory` during the `prepareCall` phase, ensuring approval functions have access to the current working directory

**Intelligent Approval Functions**
- Created `pathNeedsApproval()` functions for read-only tools (`read`, `grep`, `glob`) that check if the target path is outside the working directory
- Implemented `createBashApprovalFn()` for bash operations that:
  - Always requires approval for commands executed outside the working directory
  - Uses the `commandNeedsApproval()` utility to check if a command is inherently dangerous
  - Falls back to the configured approval setting for non-dangerous commands
- Created `createWriteApprovalFn()` and `createEditApprovalFn()` for write operations with similar layered approval logic

**Security Refactoring**
- Removed inline security checks (path validation) from tool `execute()` functions
- Moved path boundary validation to the approval layer where it informs user decisions rather than silently failing
- Updated tool documentation to reflect the new approval-based security model (e.g., "Paths outside the working directory require approval" instead of "paths outside will be rejected")
- Removed runtime access denial errors that users could not override

## Why
This refactoring improves the separation of concerns between security policy decisions (approval layer) and operation execution. It allows the AI framework to:
- Make informed decisions about which operations need user approval based on context
- Provide clear visibility into why approval is needed (e.g., "requires approval because path is outside working directory")
- Enable future policy variations where some tools might allow out-of-bounds operations with explicit user consent

## How
- Tools now accept an `options` parameter containing approval settings
- Factory functions create approval functions that close over both the tool options and the shared context
- Approval functions are stateless and pure (except for reading shared context), making them predictable and testable
- The working directory context is injected at agent initialization time through the `prepareCall` hook