### PR TITLE
Improve paste buffer handling for split inputs

### DIFF
--- a/src/tui/components/text-input.tsx
+++ b/src/tui/components/text-input.tsx
@@ -241,10 +241,7 @@ export function TextInput({
       const currentValue = valueRef.current;
       const currentCursor = cursorRef.current;
 
-      if (pasteBufferRef.current && input.length <= 1) {
-        flushPasteBuffer();
-      }
-
+      // Handle paste buffering
       if (onPaste && input.length > 1) {
         pasteBufferRef.current += input;
         if (pasteTimerRef.current) {
@@ -254,6 +251,20 @@ export function TextInput({
           flushPasteBuffer();
         }, 50);
         return;
+      }
+
+      // If we have a paste buffer and receive a single printable character,
+      // it's likely the tail end of a paste that got split. Add it to the buffer
+      // and flush immediately.
+      if (pasteBufferRef.current && input.length === 1 && !key.backspace && !key.delete && !key.return && !key.escape && !key.tab) {
+        pasteBufferRef.current += input;
+        flushPasteBuffer();
+        return;
+      }
+
+      // Flush any pending paste buffer for non-character keys
+      if (pasteBufferRef.current) {
+        flushPasteBuffer();
       }
 
       // Handle up arrow - let parent intercept if needed


### PR DESCRIPTION
Refactors paste buffer logic to better handle cases where paste input is split across multiple input events, particularly when the last character arrives separately from the rest of the pasted content.

**What changed:**
- Removed the early unconditional `flushPasteBuffer()` call that was discarding paste data prematurely
- Added logic to detect when a single printable character is received while a paste buffer exists—indicating the tail end of a split paste—and append it to the buffer before flushing
- Added guardrails to exclude non-character keys (backspace, delete, return, escape, tab) from being treated as paste continuations
- Moved the final `flushPasteBuffer()` call to execute after single-character input handling, ensuring pending paste data is properly flushed for non-character key events

**Why:**
The previous implementation would flush the paste buffer before processing single-character input, causing pasted content to be lost when paste events were fragmented across multiple input events. This was particularly problematic in environments where paste events don't arrive as a single atomic input.

**How:**
- Checks if we have buffered paste data and receive a single character that is not a special key
- If conditions are met, appends the character to the buffer and flushes immediately
- For other input types, flushes any pending paste buffer to ensure clean state for subsequent input