### PR TITLE
Add standalone todo list display when not streaming

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -13,7 +13,7 @@ import { useExpandedView } from "./expanded-view-context.js";
 import { useTodoView } from "./todo-view-context.js";
 import { ToolCall } from "./components/tool-call.js";
 import { TaskGroupView } from "./components/task-group-view.js";
-import { StatusBar } from "./components/status-bar.js";
+import { StatusBar, StandaloneTodoList } from "./components/status-bar.js";
 import { InputBox } from "./components/input-box.js";
 import { Header } from "./components/header.js";
 import { pasteCollapseLineThreshold, tuiAgentModelId } from "./config.js";
@@ -483,7 +483,7 @@ function AppContent({ options }: AppProps) {
   const { exit } = useApp();
   const { chat, state, cycleAutoAcceptMode } = useChatContext();
   const { isExpanded, toggleExpanded } = useExpandedView();
-  const { toggleTodoView } = useTodoView();
+  const { isTodoVisible, toggleTodoView } = useTodoView();
   const [wasInterrupted, setWasInterrupted] = useState(false);
 
   const { messages, sendMessage, status, stop, error } = useChat({
@@ -514,6 +514,12 @@ function AppContent({ options }: AppProps) {
     }
     return { hasPendingApproval: false, activeApprovalId: null };
   }, [messages]);
+
+  // Extract todos for standalone display when not streaming
+  const todos = useMemo(
+    () => extractTodosFromLastAssistantMessage(messages),
+    [messages]
+  );
 
   useInput((input, key) => {
     if (key.escape && isStreaming) {
@@ -569,6 +575,10 @@ function AppContent({ options }: AppProps) {
 
       {isStreaming && (
         <StreamingStatusBar messages={messages} />
+      )}
+
+      {!isStreaming && todos && todos.length > 0 && (
+        <StandaloneTodoList todos={todos} isTodoVisible={isTodoVisible} />
       )}
 
       {!hasPendingApproval && !isExpanded && (

--- a/src/tui/components/index.ts
+++ b/src/tui/components/index.ts
@@ -1,6 +1,6 @@
 export { ToolCall } from "./tool-call.js";
 export { TextOutput } from "./text-output.js";
-export { StatusBar } from "./status-bar.js";
+export { StatusBar, StandaloneTodoList } from "./status-bar.js";
 export { InputBox } from "./input-box.js";
 export { DiffView, parseEditOutput } from "./diff-view.js";
 export { Header } from "./header.js";

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -20,19 +20,55 @@ const SILLY_WORDS = [
   "Vibing",
   "Channeling",
 ];
-const SILLY_WORD_INTERVAL = 2000;
+const SILLY_WORD_INTERVAL = 4000;
+const PULSE_SPEED = 100;
 
 function useSillyWord() {
   const [index, setIndex] = useState(() => Math.floor(Math.random() * SILLY_WORDS.length));
+  const [pulsePosition, setPulsePosition] = useState(0);
+  const currentWord = SILLY_WORDS[index];
 
+  // Pulse animation - moves highlight from left to right
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setPulsePosition((prev) => (prev + 1) % (currentWord.length + 2));
+    }, PULSE_SPEED);
+    return () => clearInterval(timer);
+  }, [currentWord.length]);
+
+  // Change word at interval
   useEffect(() => {
     const timer = setInterval(() => {
       setIndex((prev) => (prev + 1) % SILLY_WORDS.length);
+      setPulsePosition(0);
     }, SILLY_WORD_INTERVAL);
     return () => clearInterval(timer);
   }, []);
 
-  return SILLY_WORDS[index];
+  return { word: currentWord, pulsePosition };
+}
+
+function PulsedWord({ word, pulsePosition }: { word: string; pulsePosition: number }) {
+  return (
+    <>
+      {word.split("").map((char, i) => {
+        const distance = Math.abs(i - pulsePosition);
+        const isBright = distance === 0;
+        const isMedium = distance === 1;
+
+        return (
+          <Text
+            key={i}
+            color={isBright ? "yellowBright" : "yellow"}
+            bold={isBright}
+            dimColor={!isBright && !isMedium}
+          >
+            {char}
+          </Text>
+        );
+      })}
+    </>
+  );
 }
 
 type StatusBarProps = {
@@ -56,16 +92,12 @@ function getThinkingMeta(thinkingState: ThinkingState): string {
 // Status indicator - not memoized to allow animation
 function StatusIndicator({
   isStreaming,
-  status,
   thinkingState,
 }: {
   isStreaming: boolean;
-  status?: string;
   thinkingState: ThinkingState;
 }) {
-  const sillyWord = useSillyWord();
-  const isDefaultStatus = !status || status === "Thinking...";
-  const displayStatus = isDefaultStatus ? `${sillyWord}...` : status;
+  const { word, pulsePosition } = useSillyWord();
 
   // Determine prefix: + while streaming/thinking not done, * when thinking completed
   const hasThinkingCompleted = thinkingState.thinkingDuration !== null;
@@ -81,12 +113,13 @@ function StatusIndicator({
     return (
       <>
         <Text color="yellow">{prefix} </Text>
-        <Text color="yellow">{displayStatus}</Text>
+        <PulsedWord word={word} pulsePosition={pulsePosition} />
+        <Text color="gray">...</Text>
         <Text color="gray"> {metaText}</Text>
       </>
     );
   }
-  return <Text color="green">✓ {status || "Done"}</Text>;
+  return <Text color="green">✓ Done</Text>;
 }
 
 function getTodoIcon(status: TodoItem["status"]): string {
@@ -114,9 +147,6 @@ function getTodoColor(status: TodoItem["status"]): string {
 }
 
 function TodoList({ todos }: { todos: TodoItem[] }) {
-  const hasIncompleteTodos = todos.some((t) => t.status !== "completed");
-  if (!hasIncompleteTodos) return null;
-
   return (
     <Box flexDirection="column" marginLeft={2}>
       {todos.map((todo) => (
@@ -135,6 +165,31 @@ function TodoList({ todos }: { todos: TodoItem[] }) {
   );
 }
 
+// Standalone todo list for when not streaming
+export function StandaloneTodoList({
+  todos,
+  isTodoVisible,
+}: {
+  todos: TodoItem[];
+  isTodoVisible: boolean;
+}) {
+  const hasIncompleteTodos = todos.some((t) => t.status !== "completed");
+
+  if (!hasIncompleteTodos || !isTodoVisible) {
+    return null;
+  }
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box>
+        <Text color="gray">Todo List</Text>
+        <Text color="gray"> · ctrl+t to hide</Text>
+      </Box>
+      <TodoList todos={todos} />
+    </Box>
+  );
+}
+
 // Not memoized to allow animation
 export function StatusBar({
   isStreaming,
@@ -143,13 +198,13 @@ export function StatusBar({
   todos,
   isTodoVisible = true,
 }: StatusBarProps) {
-  if (!isStreaming && !status) {
-    return null;
-  }
-
   const hasTodos = todos && todos.length > 0;
   const hasIncompleteTodos = hasTodos && todos.some((t) => t.status !== "completed");
   const showTodos = isTodoVisible && hasIncompleteTodos;
+
+  if (!isStreaming && !status && !showTodos) {
+    return null;
+  }
 
   const todoHint = hasTodos && hasIncompleteTodos
     ? ` · ctrl+t to ${isTodoVisible ? "hide" : "show"} todos`
@@ -160,7 +215,6 @@ export function StatusBar({
       <Box>
         <StatusIndicator
           isStreaming={isStreaming}
-          status={status}
           thinkingState={thinkingState}
         />
         {hasTodos && <Text color="gray">{todoHint}</Text>}

--- a/src/tui/components/text-input.tsx
+++ b/src/tui/components/text-input.tsx
@@ -286,7 +286,7 @@ export function TextInput({
       }
 
       // Ignore certain key combinations
-      const ignoredCtrlKeys = ["c", "o"];
+      const ignoredCtrlKeys = ["c", "o", "t"];
       if ((key.ctrl && ignoredCtrlKeys.includes(input)) || (key.shift && key.tab)) {
         return;
       }

--- a/src/tui/todo-view-context.tsx
+++ b/src/tui/todo-view-context.tsx
@@ -16,7 +16,7 @@ const TodoViewContext = createContext<TodoViewContextValue | undefined>(
 );
 
 export function TodoViewProvider({ children }: { children: ReactNode }) {
-  const [isTodoVisible, setIsTodoVisible] = useState(false);
+  const [isTodoVisible, setIsTodoVisible] = useState(true);
 
   const toggleTodoView = useCallback(() => {
     setIsTodoVisible((prev) => !prev);

--- a/src/tui/utils/extract-todos.ts
+++ b/src/tui/utils/extract-todos.ts
@@ -28,7 +28,17 @@ export function extractTodosFromMessage(
 export function extractTodosFromLastAssistantMessage(
   messages: TUIAgentUIMessage[]
 ): TodoItem[] | null {
+  // Find the last user message index to separate current vs previous exchanges
+  let lastUserMessageIndex = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") {
+      lastUserMessageIndex = i;
+      break;
+    }
+  }
+
+  // First, look for todos in the current exchange (after last user message)
+  for (let i = messages.length - 1; i > lastUserMessageIndex; i--) {
     const message = messages[i];
     if (!message) continue;
     if (message.role === "assistant") {
@@ -37,9 +47,29 @@ export function extractTodosFromLastAssistantMessage(
         return todos;
       }
     }
-    if (message.role === "user") {
+  }
+
+  // No todos in current exchange - check the previous exchange for incomplete todos
+  // Find the second-to-last user message to bound the previous exchange
+  let prevUserMessageIndex = -1;
+  for (let i = lastUserMessageIndex - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") {
+      prevUserMessageIndex = i;
       break;
     }
   }
+
+  // Look for todos in the previous exchange only
+  for (let i = lastUserMessageIndex - 1; i > prevUserMessageIndex; i--) {
+    const message = messages[i];
+    if (!message) continue;
+    if (message.role === "assistant") {
+      const todos = extractTodosFromMessage(message);
+      if (todos !== null && todos.some((t) => t.status !== "completed")) {
+        return todos;
+      }
+    }
+  }
+
   return null;
 }


### PR DESCRIPTION
## Summary
Displays todos in a dedicated standalone section when the assistant is not streaming, with improved visual feedback through pulsed word animation and better todo extraction logic.

## Key Changes
- **New StandaloneTodoList component**: Shows incomplete todos when streaming stops, visible by default (ctrl+t to toggle)
- **Enhanced todo extraction**: Intelligently searches current exchange first, then falls back to previous exchange for incomplete todos
- **Improved status animation**: Added pulsed highlight effect to the "thinking" status text, moving left-to-right through the word
- **Refactored StatusIndicator**: Removed hardcoded status text, now only shows "Done" when complete, and unified status display logic
- **Visibility defaults**: Todos visible by default, configurable via ctx+t toggle in both streaming and standalone modes