### PR TITLE
Display input token count in streaming status bar

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -434,6 +434,9 @@ const StreamingStatusBar = memo(function StreamingStatusBar({
   const messageId = lastMessage?.id ?? "";
   const thinkingState = getThinkingState(messageId);
 
+  // Extract input tokens from the last message's metadata
+  const inputTokens = lastMessage?.metadata?.usage?.inputTokens ?? null;
+
   // Extract todos from the most recent assistant message in the current exchange
   const todos = useMemo(
     () => extractTodosFromLastAssistantMessage(messages),
@@ -458,6 +461,7 @@ const StreamingStatusBar = memo(function StreamingStatusBar({
       thinkingState={thinkingState}
       todos={todos}
       isTodoVisible={isTodoVisible}
+      inputTokens={inputTokens}
     />
   );
 });

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -78,6 +78,7 @@ type StatusBarProps = {
   thinkingState: ThinkingState;
   todos?: TodoItem[] | null;
   isTodoVisible?: boolean;
+  inputTokens?: number | null;
 };
 
 function getThinkingMeta(thinkingState: ThinkingState): string {
@@ -90,13 +91,22 @@ function getThinkingMeta(thinkingState: ThinkingState): string {
   return "";
 }
 
+function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  return tokens.toString();
+}
+
 // Status indicator - not memoized to allow animation
 function StatusIndicator({
   isStreaming,
   thinkingState,
+  inputTokens,
 }: {
   isStreaming: boolean;
   thinkingState: ThinkingState;
+  inputTokens?: number | null;
 }) {
   const { word, pulsePosition } = useSillyWord();
 
@@ -106,8 +116,10 @@ function StatusIndicator({
 
   // Build the meta text
   const thinkingMeta = getThinkingMeta(thinkingState);
-  const metaText = thinkingMeta
-    ? `(esc to interrupt · ${thinkingMeta})`
+  const tokensMeta = inputTokens ? `${formatTokens(inputTokens)} tokens` : "";
+  const metaParts = [thinkingMeta, tokensMeta].filter(Boolean).join(" · ");
+  const metaText = metaParts
+    ? `(esc to interrupt · ${metaParts})`
     : "(esc to interrupt)";
 
   if (isStreaming) {
@@ -198,6 +210,7 @@ export function StatusBar({
   thinkingState,
   todos,
   isTodoVisible = true,
+  inputTokens,
 }: StatusBarProps) {
   const hasTodos = todos && todos.length > 0;
   const hasIncompleteTodos = hasTodos && todos.some((t) => t.status !== "completed");
@@ -217,6 +230,7 @@ export function StatusBar({
         <StatusIndicator
           isStreaming={isStreaming}
           thinkingState={thinkingState}
+          inputTokens={inputTokens}
         />
         {hasTodos && <Text color="gray">{todoHint}</Text>}
       </Box>

--- a/src/tui/transport.ts
+++ b/src/tui/transport.ts
@@ -41,13 +41,24 @@ export function createAgentTransport({
 
       // Capture usage after stream completes (non-blocking)
       // Use per-call usage (last step) for accurate context % display
-      Promise.resolve(result.usage).then((usage) => {
-        onUsageUpdate?.(usage);
-      }).catch(() => {
-        // Ignore errors from aborted requests
-      });
+      Promise.resolve(result.usage)
+        .then((usage) => {
+          onUsageUpdate?.(usage);
+        })
+        .catch(() => {
+          // Ignore errors from aborted requests
+        });
 
-      return result.toUIMessageStream();
+      return result.toUIMessageStream<TUIAgentUIMessage>({
+        messageMetadata: ({ part }) => {
+          if (part.type === "finish") {
+            return { usage: part.totalUsage };
+          }
+          if (part.type === "finish-step") {
+            return { usage: part.usage };
+          }
+        },
+      });
     },
 
     reconnectToStream: async () => {

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -2,6 +2,7 @@ import type {
   DynamicToolUIPart,
   InferAgentUIMessage,
   InferUITools,
+  LanguageModelUsage,
   ToolUIPart,
 } from "ai";
 import type { tuiAgent } from "./config";
@@ -11,8 +12,12 @@ export type TUIAgentCallOptions = Parameters<
   TUIAgent["generate"]
 >["0"]["options"];
 
+export type TUIAgentMessageMetadata = {
+  usage: LanguageModelUsage;
+}
+
 // all derived
-export type TUIAgentUIMessage = InferAgentUIMessage<TUIAgent>;
+export type TUIAgentUIMessage = InferAgentUIMessage<TUIAgent, TUIAgentMessageMetadata>;
 export type TUIAgentUIMessagePart = TUIAgentUIMessage["parts"][number];
 export type TUIAgentTools = TUIAgent["tools"];
 export type TUIAgentUITools = InferUITools<TUIAgentTools>;


### PR DESCRIPTION
Display input token count in the streaming status bar alongside thinking state.

- Extract and pass `inputTokens` from message metadata through the status bar component hierarchy
- Add `formatTokens()` utility to display tokens with k-suffix for values ≥1000
- Update `transport.ts` to capture usage data in message metadata via `messageMetadata` callback
- Define `TUIAgentMessageMetadata` type to support usage tracking in agent messages