### PR TITLE
Add documentation to shared-context global state

### DIFF
--- a/src/agent/utils/shared-context.ts
+++ b/src/agent/utils/shared-context.ts
@@ -1,5 +1,17 @@
 import type { AgentMode } from "../types";
 
+/**
+ * Mutable global state shared between prepareCall and tool approval functions.
+ *
+ * This exists because the AI SDK's `needsApproval` callback only receives tool
+ * arguments, not `experimental_context`. Since approval functions need access
+ * to `workingDirectory` and `mode` to make decisions (e.g., auto-approve in
+ * background mode, check if paths are within working directory), we use this
+ * global as a workaround.
+ *
+ * TODO: Remove this once the AI SDK passes context to `needsApproval` functions.
+ * At that point, approval functions can read from `experimental_context` directly.
+ */
 export const sharedContext: {
   workingDirectory: string;
   mode: AgentMode;


### PR DESCRIPTION
Documents why `sharedContext` exists as a mutable global and the workaround it represents:

- Explains that the global is needed because `needsApproval` callback lacks access to `experimental_context`
- Notes use cases like auto-approval in background mode and path validation
- Includes TODO to remove this workaround once the AI SDK supports passing context to `needsApproval`