### PR TITLE
Add auto-approve option for tool operations

### DIFF
--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -22,12 +22,14 @@ import { gateway } from "../models";
 import { createLocalSandbox, type Sandbox } from "./sandbox";
 
 const agentModeSchema = z.enum(["interactive", "background"]);
+const autoApproveSchema = z.enum(["off", "edits", "all"]);
 
 const callOptionsSchema = z.object({
   workingDirectory: z.string(),
   mode: agentModeSchema.optional(),
   customInstructions: z.string().optional(),
   sandbox: z.custom<Sandbox>().optional(),
+  autoApprove: autoApproveSchema.optional(),
 });
 
 export type DeepAgentCallOptions = z.infer<typeof callOptionsSchema>;
@@ -65,10 +67,12 @@ export const deepAgent = new ToolLoopAgent({
   prepareCall: ({ options, model, ...settings }) => {
     const workingDirectory = options?.workingDirectory ?? process.cwd();
     const mode: AgentMode = options?.mode ?? "interactive";
+    const autoApprove = options?.autoApprove ?? "off";
 
     // Update shared context for tool approval functions
     sharedContext.workingDirectory = workingDirectory;
     sharedContext.mode = mode;
+    sharedContext.autoApprove = autoApprove;
 
     const customInstructions = options?.customInstructions;
 

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -39,6 +39,7 @@ function cwdIsOutsideWorkingDirectory(cwd: string | undefined): boolean {
  * Always requires approval if cwd is outside working directory,
  * then checks command safety and user-provided option.
  * In background mode, auto-approve all operations (except outside working directory).
+ * When autoApprove is "all", auto-approve bash commands within working directory.
  */
 function createBashApprovalFn(options?: ToolOptions): ApprovalFn {
   return async (args) => {
@@ -49,6 +50,11 @@ function createBashApprovalFn(options?: ToolOptions): ApprovalFn {
 
     // In background mode, auto-approve all operations within working directory
     if (sharedContext.mode === "background") {
+      return false;
+    }
+
+    // Auto-approve all bash commands when autoApprove is "all"
+    if (sharedContext.autoApprove === "all") {
       return false;
     }
 

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -48,6 +48,7 @@ function isOutsideWorkingDirectory(filePath: string): boolean {
  * Create a combined approval function for write operations.
  * Always requires approval if path is outside CWD, otherwise uses the provided option.
  * In background mode, auto-approve all operations (except outside working directory).
+ * When autoApprove is "edits" or "all", auto-approve file operations within working directory.
  */
 function createWriteApprovalFn(options?: WriteToolOptions): WriteApprovalFn {
   return async (args) => {
@@ -57,6 +58,10 @@ function createWriteApprovalFn(options?: WriteToolOptions): WriteApprovalFn {
     }
     // In background mode, auto-approve all operations within working directory
     if (sharedContext.mode === "background") {
+      return false;
+    }
+    // Auto-approve edits when autoApprove is "edits" or "all"
+    if (sharedContext.autoApprove === "edits" || sharedContext.autoApprove === "all") {
       return false;
     }
     // Otherwise use the configured approval setting
@@ -71,6 +76,7 @@ function createWriteApprovalFn(options?: WriteToolOptions): WriteApprovalFn {
  * Create a combined approval function for edit operations.
  * Always requires approval if path is outside CWD, otherwise uses the provided option.
  * In background mode, auto-approve all operations (except outside working directory).
+ * When autoApprove is "edits" or "all", auto-approve file operations within working directory.
  */
 function createEditApprovalFn(options?: EditToolOptions): EditApprovalFn {
   return async (args) => {
@@ -80,6 +86,10 @@ function createEditApprovalFn(options?: EditToolOptions): EditApprovalFn {
     }
     // In background mode, auto-approve all operations within working directory
     if (sharedContext.mode === "background") {
+      return false;
+    }
+    // Auto-approve edits when autoApprove is "edits" or "all"
+    if (sharedContext.autoApprove === "edits" || sharedContext.autoApprove === "all") {
       return false;
     }
     // Otherwise use the configured approval setting

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -21,6 +21,15 @@ export type TodoItem = z.infer<typeof todoItemSchema>;
  */
 export type AgentMode = "interactive" | "background";
 
+/**
+ * Auto-approve settings for tool operations in interactive mode.
+ *
+ * - 'off': All destructive operations require manual approval (default)
+ * - 'edits': Auto-approve file edits and writes within working directory
+ * - 'all': Auto-approve all operations within working directory (edits + bash)
+ */
+export type AutoApprove = "off" | "edits" | "all";
+
 export interface AgentContext {
   sandbox: Sandbox;
   mode: AgentMode;

--- a/src/agent/utils/shared-context.ts
+++ b/src/agent/utils/shared-context.ts
@@ -1,4 +1,4 @@
-import type { AgentMode } from "../types";
+import type { AgentMode, AutoApprove } from "../types";
 
 /**
  * Mutable global state shared between prepareCall and tool approval functions.
@@ -15,7 +15,9 @@ import type { AgentMode } from "../types";
 export const sharedContext: {
   workingDirectory: string;
   mode: AgentMode;
+  autoApprove: AutoApprove;
 } = {
   workingDirectory: process.cwd(),
   mode: "interactive",
+  autoApprove: "off",
 };

--- a/src/tui/chat-context.tsx
+++ b/src/tui/chat-context.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useMemo,
   useCallback,
+  useRef,
   type ReactNode,
 } from "react";
 import {
@@ -98,10 +99,14 @@ export function ChatProvider({
   model,
   workingDirectory,
 }: ChatProviderProps) {
-  const [autoAcceptMode, setAutoAcceptMode] = useState<AutoAcceptMode>("edits");
+  const [autoAcceptMode, setAutoAcceptMode] = useState<AutoAcceptMode>("off");
   const [usage, setUsage] = useState<LanguageModelUsage>(DEFAULT_USAGE);
   const [sessionUsage, setSessionUsage] =
     useState<LanguageModelUsage>(DEFAULT_USAGE);
+
+  // Use ref to pass current autoAcceptMode to transport without recreating it
+  const autoAcceptModeRef = useRef(autoAcceptMode);
+  autoAcceptModeRef.current = autoAcceptMode;
 
   const contextLimit = useMemo(() => getContextLimit(model ?? ""), [model]);
 
@@ -115,6 +120,7 @@ export function ChatProvider({
       createAgentTransport({
         agent: tuiAgent,
         agentOptions,
+        getAutoApprove: () => autoAcceptModeRef.current,
         onUsageUpdate: handleUsageUpdate,
       }),
     [agentOptions, handleUsageUpdate],

--- a/src/tui/transport.ts
+++ b/src/tui/transport.ts
@@ -5,17 +5,19 @@ import {
   smoothStream,
   pruneMessages,
 } from "ai";
-import type { TUIAgent, TUIAgentCallOptions, TUIAgentUIMessage } from "./types";
+import type { TUIAgent, TUIAgentCallOptions, TUIAgentUIMessage, AutoAcceptMode } from "./types";
 
 export type AgentTransportOptions = {
   agent: TUIAgent;
   agentOptions: TUIAgentCallOptions;
+  getAutoApprove?: () => AutoAcceptMode;
   onUsageUpdate?: (usage: LanguageModelUsage) => void;
 };
 
 export function createAgentTransport({
   agent,
   agentOptions,
+  getAutoApprove,
   onUsageUpdate,
 }: AgentTransportOptions): ChatTransport<TUIAgentUIMessage> {
   return {
@@ -32,9 +34,12 @@ export function createAgentTransport({
         emptyMessages: "remove",
       });
 
+      // Get current autoApprove setting at request time
+      const autoApprove = getAutoApprove?.() ?? "off";
+
       const result = await agent.stream({
         messages: prunedMessages,
-        options: agentOptions,
+        options: { ...agentOptions, autoApprove },
         abortSignal: abortSignal ?? undefined,
         experimental_transform: smoothStream(),
       });


### PR DESCRIPTION
## Summary
Adds a configurable `autoApprove` option that allows automatic approval of file edits and bash commands within the working directory in interactive mode.

## Changes
- Add `AutoApprove` type with three modes: "off" (default), "edits" (file ops), and "all" (all ops)
- Implement auto-approval logic in bash, file write, and file edit approval functions
- Wire up UI's `autoAcceptMode` to pass through to agent via ref to avoid transport recreation
- Update `sharedContext` to track and propagate the `autoApprove` setting throughout agent execution