### PR TITLE
Update Claude model versions to 4.5 series

### DIFF
--- a/src/agent/utils/model-context-limits.ts
+++ b/src/agent/utils/model-context-limits.ts
@@ -3,17 +3,10 @@
  * Used to display context usage percentage.
  */
 export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
-  // Anthropic Claude 4 models
-  "claude-opus-4": 200_000,
-  "claude-sonnet-4": 200_000,
-  "claude-haiku-4": 200_000,
-  // Anthropic Claude 3.5 models
-  "claude-3-5-sonnet": 200_000,
-  "claude-3-5-haiku": 200_000,
-  // Anthropic Claude 3 models
-  "claude-3-opus": 200_000,
-  "claude-3-sonnet": 200_000,
-  "claude-3-haiku": 200_000,
+  // Anthropic Claude 4.5 models
+  "claude-opus-4.5": 200_000,
+  "claude-sonnet-4.5": 200_000,
+  "claude-haiku-4.5": 200_000,
 };
 
 export const DEFAULT_CONTEXT_LIMIT = 200_000;


### PR DESCRIPTION
Replace outdated Claude model versions (Claude 3, 3.5, and 4) with the latest Claude 4.5 series models in context limit configuration

- Updated model identifiers from `claude-*-4`, `claude-3-5-*`, and `claude-3-*` to `claude-*-4.5`
- Consolidated redundant model version entries into a single Claude 4.5 section
- Context limits remain at 200,000 tokens for all models