### PR TITLE
Replace session-based approval plan with saved preferences

### DIFF
--- a/docs/session-based-tool-approval-plan.md
+++ b/docs/session-based-tool-approval-plan.md
@@ -1,372 +1,158 @@
-# Session-Based Tool Approval
+# Saved Tool Approval Preferences
 
-This document outlines a feature to allow users to control tool approval behavior through auto-accept modes and session-based pattern approval.
+This plan replaces the older session-based approval plan. It reflects the
+current TUI and tool behavior and adds saved (persisted) preferences.
 
 ## Current State
 
-The codebase has:
-
-1. **Factory function tools** with `needsApproval` support (boolean or function)
-2. **`AutoAcceptMode`** state in ChatContext (`"off"` | `"edits"` | `"all"`)
-3. **Approval UI** with Yes/No/Reason options via `ApprovalButtons`
-4. **Context injection** via `experimental_context` in `prepareCall`
-
-### Key Files
-
-| File                                   | Purpose                                              |
-| -------------------------------------- | ---------------------------------------------------- |
-| `src/tui/chat-context.tsx`             | Manages `autoAcceptMode` state (lines 101, 145-151)  |
-| `src/tui/types.ts`                     | Defines `AutoAcceptMode` type (line 24)              |
-| `src/agent/deep-agent.ts`              | Agent with tools and `prepareCall` context injection |
-| `src/agent/tools/file-system/bash.ts`  | Bash tool with `commandNeedsApproval()`              |
-| `src/agent/tools/file-system/write.ts` | Write/Edit tools with `needsApproval` option         |
-| `src/tui/components/tool-call.tsx`     | `ApprovalButtons` component                          |
-| `src/tui/transport.ts`                 | Passes `agentOptions` to agent                       |
-
-### Current Problem
-
-The `autoAcceptMode` state exists but **isn't wired up**. It's purely UI state - changing it doesn't affect tool approval behavior. Tools are configured at agent creation time with static `needsApproval: true`.
+- The TUI uses `ApprovalPanel` (`src/tui/components/approval-panel.tsx`) for
+  approvals; the "Yes, and don't ask again" option is a placeholder and does
+  not persist anything.
+- `autoAcceptMode` is stored in `ChatContext` and cycled via shift+tab in the
+  input (default: `"edits"`), but it is not wired to approval handling.
+- `deepAgent` tools are static. Approvals are determined per-tool:
+  - `bash` uses safe command prefixes and dangerous patterns.
+  - `write`/`edit` always require approval (and always require approval for
+    paths outside the working directory).
+  - `read`/`grep`/`glob` require approval only for paths outside the working
+    directory.
+  - `task` requires approval for `executor` subagents.
+- `sharedContext.workingDirectory` is used for path checks in `needsApproval`.
 
 ## Goals
 
-1. **Wire up `autoAcceptMode`** to control tool approval behavior:
-   - `"off"`: All tools require manual approval
-   - `"edits"`: Auto-approve write/edit tools, manual approval for bash
-   - `"all"`: Auto-approve all tools
+1. Persist approvals within a single session so "don't ask again" immediately
+   suppresses repeat prompts for similar requests.
+2. Auto-approve when a session rule (or auto-accept mode) matches a tool
+   request.
+3. Keep a clear UI path to save and clear preferences.
+4. Preserve safety defaults, especially for paths outside the working
+   directory.
 
-2. **Session-based pattern approval** (future enhancement):
-   - Approve `bun test` once, then auto-approve `bun test:unit`, `bun test src/`
-   - Approve writes to `src/components/`, then auto-approve other writes in that directory
+## Non-Goals
 
----
+- Changing tool approval logic in the agent (use UI-level auto-approval).
+- Syncing preferences across machines.
+
+## Approach
+
+Handle auto-approval in the TUI: when a tool part is in
+`approval-requested`, check `autoAcceptMode` and *session rules*, then send
+`addToolApprovalResponse`. This keeps tool definitions unchanged and aligns
+with the AI SDK approval flow.
+
+## Data Model
+
+- Maintain an in-memory rule set for the current session (source of truth for
+  auto-approval).
+- Validate with Zod and include a version field for future migrations.
+
+Example structure:
+
+```json
+{
+  "version": 1,
+  "autoAcceptMode": "off",
+  "rules": [
+    {
+      "id": "uuid",
+      "tool": "bash",
+      "rule": { "type": "command-prefix", "value": "bun test" },
+      "scope": { "cwd": "/Users/me/project" },
+      "createdAt": 1710000000000,
+      "lastUsedAt": 1710000100000
+    }
+  ]
+}
+```
+
+Rule types to support:
+- `command-prefix` for bash (matches command startsWith prefix, optionally with
+  simple wildcard like `git diff` + pattern).
+- `path-glob` for write/edit/read/grep/glob (relative to working directory).
+- `subagent-type` for task tool (executor/explorer).
 
 ## Implementation Plan
 
-### Phase 1: Wire Up `autoAcceptMode`
+### Phase 1: Session Rule Store + Context
 
-#### Step 1: Add `autoAcceptMode` to Agent Options
+- Add `src/tui/approval-preferences.ts` (or
+  `src/tui/state/approval-preferences.ts`):
+  - Zod schemas for `ApprovalRule` and `ApprovalPreferences`.
+  - In-memory `rules` and helpers: `matchRule`, `touchRule`, `addRule`,
+    `clearRules`.
+- Add `ApprovalPreferencesProvider` to expose session rules to the UI.
 
-Update the call options schema to include `autoAcceptMode`:
+### Phase 2: Wire Auto-Approval (Session-First)
 
-```typescript
-// src/agent/deep-agent.ts
-const callOptionsSchema = z.object({
-  workingDirectory: z.string(),
-  customInstructions: z.string().optional(),
-  todos: z.array(todoItemSchema).optional(),
-  scratchpad: z.map(...).optional(),
-  autoAcceptMode: z.enum(["off", "edits", "all"]).optional(), // NEW
-});
-```
+- In `src/tui/app.tsx`, add a `useEffect` that:
+  - detects the active `approval-requested` tool part
+  - decides `shouldAutoApprove` based on:
+    - `autoAcceptMode === "all"`
+    - `autoAcceptMode === "edits"` and tool is `write`/`edit` (and path is
+      inside cwd)
+    - `matchesSessionRule(pendingToolPart, rules)`
+  - calls `addToolApprovalResponse` and updates `lastUsedAt`
+  - keeps a local set of handled `approvalId`s to avoid repeated approvals on
+    re-render.
+- Consider setting default `autoAcceptMode` to `"off"` once wired up to avoid
+  silent auto-approvals on first run.
 
-#### Step 2: Pass `autoAcceptMode` to Context
+### Phase 3: Rule Inference + "Don't Ask Again"
 
-Inject `autoAcceptMode` into `experimental_context`:
+- Update `getToolApprovalInfo` to return both a display label and a structured
+  rule candidate (session rule).
+- Update `ApprovalPanel` (and `ApprovalButtons` for task rows) to:
+  - store the rule in the session when "Yes, and don't ask again" is chosen
+  - then approve the request.
+- Rule inference suggestions:
+  - Bash: first 1-2 tokens (e.g., `git diff`, `bun test`) as
+    `command-prefix`, optionally with a file glob if present (e.g.,
+    `git diff *.md`).
+  - Write/Edit: directory-based `path-glob` (`src/components/**`) when inside
+    cwd.
+  - Read/Grep/Glob: only offer when the path is inside cwd; outside-cwd can
+    stay manual unless explicitly allowed.
+  - Task: `subagent-type` rule for `executor`.
 
-```typescript
-// src/agent/deep-agent.ts - prepareCall
-prepareCall: ({ options, model, ...settings }) => {
-  const workingDirectory = options?.workingDirectory ?? process.cwd();
-  const autoAcceptMode = options?.autoAcceptMode ?? "off"; // NEW
-  // ...
-  return {
-    ...settings,
-    model,
-    instructions: buildSystemPrompt({ ... }),
-    experimental_context: {
-      workingDirectory,
-      autoAcceptMode, // NEW
-    },
-  };
-},
-```
+### Phase 4: Manage Session
 
-Update `AgentContext` type:
-
-```typescript
-// src/agent/types.ts
-export interface AgentContext {
-  workingDirectory: string;
-  autoAcceptMode?: "off" | "edits" | "all"; // NEW
-}
-```
-
-#### Step 3: Update ChatProvider to Pass `autoAcceptMode`
-
-```typescript
-// src/tui/chat-context.tsx
-const agentOptionsWithAutoAccept = useMemo(
-  () => ({
-    ...agentOptions,
-    autoAcceptMode,
-  }),
-  [agentOptions, autoAcceptMode],
-);
-
-const transport = useMemo(
-  () =>
-    createAgentTransport({
-      agent: tuiAgent,
-      agentOptions: agentOptionsWithAutoAccept, // Use merged options
-      onUsageUpdate: handleUsageUpdate,
-    }),
-  [agentOptionsWithAutoAccept, handleUsageUpdate],
-);
-```
-
-#### Step 4: Make `needsApproval` Dynamic in Tools
-
-The key insight: `needsApproval` can be a function that receives `args` and can access context. However, the AI SDK's `needsApproval` function signature is `(args) => boolean`, not `(args, context) => boolean`.
-
-**Solution**: Create tool factories that accept `autoAcceptMode` through closure, then recreate tools when mode changes.
-
-**Alternative (simpler)**: Since `needsApproval` is evaluated per-call, we can use a factory pattern at the agent level.
-
-For simplicity, the recommended approach is to **recreate the transport** when `autoAcceptMode` changes (which already happens due to the useMemo dependency).
-
-Update tool definitions to use function-based approval:
-
-```typescript
-// src/agent/tools/file-system/write.ts
-export const writeFileTool = (options?: WriteToolOptions) =>
-  tool({
-    needsApproval: (args) => {
-      // If a custom function is provided, use it
-      if (typeof options?.needsApproval === "function") {
-        return options.needsApproval(args);
-      }
-      // Otherwise use the boolean (default true)
-      return options?.needsApproval ?? true;
-    },
-    // ...
-  });
-```
-
-**For the agent**, create a helper that generates tools based on mode:
-
-```typescript
-// src/agent/tools/index.ts (new export)
-export function createToolsWithApprovalMode(mode: AutoAcceptMode) {
-  const editApproval = mode === "off"; // edits auto-approved in "edits" and "all"
-  const bashApproval = mode !== "all" ? commandNeedsApproval : false;
-
-  return {
-    todo_write: todoWriteTool,
-    read: readFileTool,
-    write: writeFileTool({ needsApproval: editApproval }),
-    edit: editFileTool({ needsApproval: editApproval }),
-    grep: grepTool,
-    glob: globTool,
-    bash: bashTool({ needsApproval: bashApproval }),
-    task: taskTool,
-  };
-}
-```
-
-#### Architecture Decision: Static vs Dynamic Tools
-
-**Option A: Static Tools + Context Check** (Current direction)
-
-- Tools defined once at agent creation
-- `needsApproval` functions check `experimental_context.autoAcceptMode`
-- Requires AI SDK to support passing context to `needsApproval`
-
-**Option B: Dynamic Agent Recreation** (Alternative)
-
-- Create new agent instance when `autoAcceptMode` changes
-- Simpler implementation but more overhead
-
-**Option C: UI-Level Auto-Approval** (Recommended for MVP)
-
-- Keep tools as-is with static `needsApproval`
-- Handle auto-approval in the TUI layer before sending approval response
-- When approval requested and mode matches, auto-send approval
-
-#### Recommended: Option C - UI-Level Auto-Approval
-
-This approach doesn't require agent/tool changes:
-
-```typescript
-// src/tui/app.tsx or a new hook
-useEffect(() => {
-  if (!hasPendingApproval || !activeApprovalId) return;
-
-  const lastMessage = messages[messages.length - 1];
-  const pendingPart = lastMessage?.parts.find(
-    (p) => isToolUIPart(p) && p.state === "approval-requested",
-  );
-
-  if (!pendingPart) return;
-
-  const toolName = getToolName(pendingPart);
-  const shouldAutoApprove =
-    autoAcceptMode === "all" ||
-    (autoAcceptMode === "edits" &&
-      (toolName === "write" || toolName === "edit"));
-
-  if (shouldAutoApprove) {
-    addToolApprovalResponse({ id: activeApprovalId, approved: true });
-  }
-}, [hasPendingApproval, activeApprovalId, autoAcceptMode, messages]);
-```
-
----
-
-### Phase 2: Session-Based Pattern Approval (Future)
-
-Once Phase 1 is complete, add pattern-based approval:
-
-#### Step 1: Add Approved Patterns State
-
-```typescript
-// src/tui/chat-context.tsx
-type ApprovedPattern = {
-  toolName: string;
-  pattern: string; // e.g., "bun test:*", "src/components/**"
-  createdAt: number;
-};
-
-const [approvedPatterns, setApprovedPatterns] = useState<ApprovedPattern[]>([]);
-```
-
-#### Step 2: Add "Approve Similar" Button
-
-Update `ApprovalButtons` to offer pattern-based approval:
-
-```typescript
-// src/tui/components/tool-call.tsx
-function ApprovalButtons({ approvalId, toolName, args }: ApprovalButtonsProps) {
-  const suggestedPattern = inferPattern(toolName, args);
-
-  // Options: Yes, Yes + approve similar, No, Reason
-  // ...
-}
-
-function inferPattern(toolName: string, args: unknown): string | null {
-  if (
-    toolName === "bash" &&
-    typeof args === "object" &&
-    args &&
-    "command" in args
-  ) {
-    const command = (args as { command: string }).command;
-    // Extract prefix: "bun test src/" -> "bun test"
-    const parts = command.split(" ");
-    if (parts.length >= 2) {
-      return `${parts[0]} ${parts[1]}:*`;
-    }
-  }
-  if (
-    (toolName === "write" || toolName === "edit") &&
-    typeof args === "object" &&
-    args &&
-    "filePath" in args
-  ) {
-    const filePath = (args as { filePath: string }).filePath;
-    // Extract directory pattern: "/Users/x/project/src/components/Button.tsx" -> "src/components/**"
-    const relativePath = path.relative(workingDirectory, filePath);
-    const dir = path.dirname(relativePath);
-    return `${dir}/**`;
-  }
-  return null;
-}
-```
-
-#### Step 3: Pattern Matching Logic
-
-```typescript
-// src/tui/utils/pattern-matching.ts
-export function matchesBashPattern(command: string, pattern: string): boolean {
-  // Pattern: "bun test:*" matches "bun test", "bun test:unit", "bun test src/"
-  if (pattern.endsWith(":*")) {
-    const prefix = pattern.slice(0, -2);
-    return command.startsWith(prefix);
-  }
-  // Pattern: "bun *" matches any bun command
-  if (pattern.endsWith(" *")) {
-    const prefix = pattern.slice(0, -1);
-    return command.startsWith(prefix);
-  }
-  return command === pattern;
-}
-
-export function matchesFilePattern(filePath: string, pattern: string): boolean {
-  // Use minimatch for glob matching
-  return minimatch(filePath, pattern);
-}
-```
-
-#### Step 4: Check Patterns in Auto-Approval Logic
-
-```typescript
-// Extend the useEffect from Phase 1
-const shouldAutoApprove =
-  autoAcceptMode === "all" ||
-  (autoAcceptMode === "edits" &&
-    (toolName === "write" || toolName === "edit")) ||
-  matchesApprovedPattern(toolName, args, approvedPatterns);
-```
-
----
+- Add a minimal clearing surface:
+  - Option A: add "Clear approvals for this session" to `ApprovalPanel` footer.
+  - Option B: add a keybinding in `InputBox` (for example ctrl+shift+a) to
+    clear rules.
+- Display a small indicator when auto-approving (optional but helpful).
 
 ## Files to Modify
 
-### Phase 1 (Wire up autoAcceptMode)
+Phase 1-3:
+- `src/tui/app.tsx` (auto-approval effect)
+- `src/tui/components/approval-panel.tsx`
+- `src/tui/components/tool-call.tsx`
+- `src/tui/components/task-group-view.tsx`
+- `src/tui/chat-context.tsx` (autoAcceptMode persistence if desired)
+- `src/tui/index.tsx` (wrap new provider)
 
-| File                       | Changes                                                 |
-| -------------------------- | ------------------------------------------------------- |
-| `src/tui/app.tsx`          | Add auto-approval effect based on mode                  |
-| `src/tui/chat-context.tsx` | Export `autoAcceptMode` in context value (already done) |
-
-### Phase 2 (Pattern Approval)
-
-| File                                | Changes                                      |
-| ----------------------------------- | -------------------------------------------- |
-| `src/tui/chat-context.tsx`          | Add `approvedPatterns` state and setter      |
-| `src/tui/components/tool-call.tsx`  | Add "approve similar" button, pass tool args |
-| `src/tui/utils/pattern-matching.ts` | New file for pattern matching utilities      |
-
----
+New files:
+- `src/tui/approval-preferences.ts` (store + matching)
 
 ## User Experience
 
-### Phase 1 Flow
-
-1. User cycles `autoAcceptMode` with keyboard shortcut (already works)
-2. Status bar shows current mode with visual indicator
-3. When tool requests approval:
-   - `"off"`: Show approval buttons
-   - `"edits"`: Auto-approve write/edit, show buttons for bash
-   - `"all"`: Auto-approve everything (show brief notification)
-
-### Phase 2 Flow
-
-1. Tool requests approval (e.g., `bash: bun test src/utils`)
-2. User sees options:
-   - **1. Yes** - Approve this one execution
-   - **2. Yes, approve "bun test:\*"** - Approve and add pattern
-   - **3. No** - Deny execution
-   - **4. Reason** - Deny with explanation
-3. If pattern approved, future matching commands auto-approve
-4. Status bar shows: `Auto-approved: bun test:*, src/components/**`
-
----
+1. Tool requests approval and ApprovalPanel appears.
+2. User selects "Yes" or "Yes, and don't ask again for <pattern>".
+3. The rule is stored for the session; future matching approvals are
+   auto-approved in the same session.
+4. Auto-accept mode still works via shift+tab, now enforced.
 
 ## Security Considerations
 
-- Patterns reset on session end (no persistence)
-- Patterns should be specific to avoid unintended approvals
-- "all" mode shows warning indicator in status bar
-- Allow users to clear patterns mid-session (`/clear-approvals` command)
-- Show notification when auto-approving: `Auto-approved: bun test src/`
+- Keep rules scoped to the current working directory.
+- Do not auto-approve outside-cwd paths unless a specific session rule exists.
+- Bash safety list still applies; preferences only respond to approval
+  requests, they do not bypass tool safety checks.
 
----
+## Validation
 
-## Implementation Order
-
-1. **Phase 1A**: Add auto-approval effect in `app.tsx` for `autoAcceptMode`
-2. **Phase 1B**: Add visual feedback when auto-approving
-3. **Phase 2A**: Add `approvedPatterns` state
-4. **Phase 2B**: Implement pattern inference and "approve similar" button
-5. **Phase 2C**: Add pattern matching and integrate with auto-approval
-6. **Phase 2D**: Add UI for viewing/clearing approved patterns
+- Unit test rule matching and rule inference.
+- Manual: approve `bun test` once, confirm future `bun test` auto-approves.
+- Manual: confirm write/edit auto-approval only occurs within cwd.

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
+import { matchCommandPrefixRule } from "../../utils/session-rules";
 
 const TIMEOUT_MS = 120_000;
 
@@ -50,6 +51,19 @@ function createBashApprovalFn(options?: ToolOptions): ApprovalFn {
     // In background mode, auto-approve all operations within working directory
     if (sharedContext.mode === "background") {
       return false;
+    }
+
+    // Check session rules for command-prefix match
+    for (const rule of sharedContext.sessionRules) {
+      if (
+        matchCommandPrefixRule(
+          rule,
+          args.command,
+          sharedContext.workingDirectory,
+        )
+      ) {
+        return false; // Auto-approve, tool executes silently
+      }
     }
 
     // Check command safety

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
+import { matchPathGlobRule } from "../../utils/session-rules";
 
 const writeInputSchema = z.object({
   filePath: z.string().describe("Absolute path to the file to write"),
@@ -59,6 +60,19 @@ function createWriteApprovalFn(options?: WriteToolOptions): WriteApprovalFn {
     if (sharedContext.mode === "background") {
       return false;
     }
+    // Check session rules for path-glob match
+    for (const rule of sharedContext.sessionRules) {
+      if (
+        matchPathGlobRule(
+          rule,
+          args.filePath,
+          "write",
+          sharedContext.workingDirectory,
+        )
+      ) {
+        return false; // Auto-approve
+      }
+    }
     // Otherwise use the configured approval setting
     if (typeof options?.needsApproval === "function") {
       return options.needsApproval(args);
@@ -81,6 +95,19 @@ function createEditApprovalFn(options?: EditToolOptions): EditApprovalFn {
     // In background mode, auto-approve all operations within working directory
     if (sharedContext.mode === "background") {
       return false;
+    }
+    // Check session rules for path-glob match
+    for (const rule of sharedContext.sessionRules) {
+      if (
+        matchPathGlobRule(
+          rule,
+          args.filePath,
+          "edit",
+          sharedContext.workingDirectory,
+        )
+      ) {
+        return false; // Auto-approve
+      }
     }
     // Otherwise use the configured approval setting
     if (typeof options?.needsApproval === "function") {

--- a/src/agent/tools/task-delegation/task.ts
+++ b/src/agent/tools/task-delegation/task.ts
@@ -2,7 +2,8 @@ import { tool, readUIMessageStream } from "ai";
 import { z } from "zod";
 import { explorerSubagent } from "./subagents/explorer";
 import { executorSubagent } from "./subagents/executor";
-import { getSandbox } from "../../utils";
+import { getSandbox, sharedContext } from "../../utils";
+import { matchSubagentTypeRule } from "../../utils/session-rules";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
 
@@ -25,7 +26,20 @@ const taskInputSchema = z.object({
 export const taskTool = tool({
   // Executor subagent has full write access, so require approval
   // Explorer is read-only, so no approval needed
-  needsApproval: ({ subagentType }) => subagentType === "executor",
+  needsApproval: ({ subagentType }) => {
+    if (subagentType !== "executor") return false;
+
+    // Check session rules for subagent-type match
+    for (const rule of sharedContext.sessionRules) {
+      if (
+        matchSubagentTypeRule(rule, subagentType, sharedContext.workingDirectory)
+      ) {
+        return false; // Auto-approve
+      }
+    }
+
+    return true;
+  },
   description: `Launch a specialized subagent to handle complex tasks autonomously.
 
 SUBAGENT TYPES:

--- a/src/agent/utils/session-rules.ts
+++ b/src/agent/utils/session-rules.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import * as path from "path";
+import { isPathWithinDirectory } from "./path";
+
+// Rule types
+const CommandPrefixRuleSchema = z.object({
+  type: z.literal("command-prefix"),
+  prefix: z.string(), // e.g., "bun test", "git diff"
+});
+
+const PathGlobRuleSchema = z.object({
+  type: z.literal("path-glob"),
+  glob: z.string(), // e.g., "src/**"
+  toolTypes: z.array(z.enum(["write", "edit"])),
+});
+
+const SubagentTypeRuleSchema = z.object({
+  type: z.literal("subagent-type"),
+  subagentType: z.enum(["executor"]),
+});
+
+export const ApprovalRuleSchema = z.discriminatedUnion("type", [
+  CommandPrefixRuleSchema,
+  PathGlobRuleSchema,
+  SubagentTypeRuleSchema,
+]);
+
+export const SessionRuleSchema = z.object({
+  id: z.string(),
+  rule: ApprovalRuleSchema,
+  scope: z.object({ cwd: z.string() }),
+  createdAt: z.number(),
+});
+
+export type ApprovalRule = z.infer<typeof ApprovalRuleSchema>;
+export type SessionRule = z.infer<typeof SessionRuleSchema>;
+
+/**
+ * Check if a command-prefix rule matches the given command.
+ * Only matches if the rule's scope cwd matches the current working directory.
+ */
+export function matchCommandPrefixRule(
+  rule: SessionRule,
+  command: string,
+  cwd: string,
+): boolean {
+  if (rule.rule.type !== "command-prefix") return false;
+  if (rule.scope.cwd !== cwd) return false;
+
+  const prefix = rule.rule.prefix.trim();
+  if (!prefix) return false;
+
+  const trimmedCommand = command.trim();
+  if (!trimmedCommand.startsWith(prefix)) return false;
+  if (trimmedCommand.length === prefix.length) return true;
+
+  const nextChar = trimmedCommand.charAt(prefix.length);
+  return /\s/.test(nextChar);
+}
+
+/**
+ * Check if a path-glob rule matches the given file path.
+ * Only matches if:
+ * - The rule's scope cwd matches the current working directory
+ * - The tool type matches the rule's allowed tool types
+ * - The file path matches the glob pattern
+ */
+export function matchPathGlobRule(
+  rule: SessionRule,
+  filePath: string,
+  toolType: "write" | "edit",
+  cwd: string,
+): boolean {
+  if (rule.rule.type !== "path-glob") return false;
+  if (rule.scope.cwd !== cwd) return false;
+  if (!rule.rule.toolTypes.includes(toolType)) return false;
+
+  // Get relative path from cwd
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(cwd, filePath);
+
+  // File must be within cwd
+  if (!isPathWithinDirectory(absolutePath, cwd)) return false;
+
+  const relativePath = path.relative(cwd, absolutePath);
+  const normalizedRelative = relativePath.split(path.sep).join("/");
+  const pattern = rule.rule.glob;
+  const normalizedPattern = pattern.split(path.sep).join("/");
+
+  if (normalizedPattern === "**") return true;
+
+  // Simple glob matching for directory-based patterns like "src/**"
+  if (normalizedPattern.endsWith("/**")) {
+    const prefix = normalizedPattern.slice(0, -3);
+    if (!prefix) return true;
+    return (
+      normalizedRelative === prefix ||
+      normalizedRelative.startsWith(`${prefix}/`)
+    );
+  }
+
+  // Fallback: exact prefix match with path boundary
+  return (
+    normalizedRelative === normalizedPattern ||
+    normalizedRelative.startsWith(`${normalizedPattern}/`)
+  );
+}
+
+/**
+ * Check if a subagent-type rule matches the given subagent type.
+ * Only matches if the rule's scope cwd matches the current working directory.
+ */
+export function matchSubagentTypeRule(
+  rule: SessionRule,
+  subagentType: string,
+  cwd: string,
+): boolean {
+  if (rule.rule.type !== "subagent-type") return false;
+  if (rule.scope.cwd !== cwd) return false;
+
+  return rule.rule.subagentType === subagentType;
+}

--- a/src/agent/utils/shared-context.ts
+++ b/src/agent/utils/shared-context.ts
@@ -1,4 +1,5 @@
 import type { AgentMode } from "../types";
+import type { SessionRule, ApprovalRule } from "./session-rules";
 
 /**
  * Mutable global state shared between prepareCall and tool approval functions.
@@ -15,7 +16,29 @@ import type { AgentMode } from "../types";
 export const sharedContext: {
   workingDirectory: string;
   mode: AgentMode;
+  sessionRules: SessionRule[];
 } = {
   workingDirectory: process.cwd(),
   mode: "interactive",
+  sessionRules: [],
 };
+
+/**
+ * Add a session rule for auto-approving matching tool requests.
+ * Rules are scoped to the current working directory.
+ */
+export function addSessionRule(rule: ApprovalRule): void {
+  sharedContext.sessionRules.push({
+    id: crypto.randomUUID(),
+    rule,
+    scope: { cwd: sharedContext.workingDirectory },
+    createdAt: Date.now(),
+  });
+}
+
+/**
+ * Clear all session rules.
+ */
+export function clearSessionRules(): void {
+  sharedContext.sessionRules = [];
+}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -529,7 +529,7 @@ function AppContent({ options }: AppProps) {
 
   // Get approval info for the pending tool
   const approvalInfo = useMemo(() => {
-    if (!pendingToolPart) return null;
+    if (!pendingToolPart || !state.workingDirectory) return null;
     return getToolApprovalInfo(pendingToolPart, state.workingDirectory);
   }, [pendingToolPart, state.workingDirectory]);
 
@@ -594,6 +594,7 @@ function AppContent({ options }: AppProps) {
           toolCommand={approvalInfo.toolCommand}
           toolDescription={approvalInfo.toolDescription}
           dontAskAgainPattern={approvalInfo.dontAskAgainPattern}
+          ruleCandidate={approvalInfo.ruleCandidate}
         />
       ) : (
         <>

--- a/src/tui/chat-context.tsx
+++ b/src/tui/chat-context.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useMemo,
   useCallback,
+  useEffect,
   type ReactNode,
 } from "react";
 import {
@@ -13,6 +14,7 @@ import {
 import { Chat } from "@ai-sdk/react";
 import { createAgentTransport } from "./transport.js";
 import { tuiAgent } from "./config.js";
+import { clearSessionRules } from "../agent/utils/shared-context.js";
 import type {
   TUIAgentCallOptions,
   TUIAgentUIMessage,
@@ -104,6 +106,10 @@ export function ChatProvider({
     useState<LanguageModelUsage>(DEFAULT_USAGE);
 
   const contextLimit = useMemo(() => getContextLimit(model ?? ""), [model]);
+
+  useEffect(() => {
+    clearSessionRules();
+  }, []);
 
   const handleUsageUpdate = useCallback((newUsage: LanguageModelUsage) => {
     setUsage(newUsage);

--- a/src/tui/components/approval-panel.tsx
+++ b/src/tui/components/approval-panel.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { useChat } from "@ai-sdk/react";
 import { useChatContext } from "../chat-context.js";
+import { addSessionRule } from "../../agent/utils/shared-context.js";
+import type { RuleCandidate } from "./tool-call.js";
 
 export type ApprovalPanelProps = {
   approvalId: string;
@@ -9,6 +11,7 @@ export type ApprovalPanelProps = {
   toolCommand: string;
   toolDescription?: string;
   dontAskAgainPattern?: string;
+  ruleCandidate?: RuleCandidate;
 };
 
 export function ApprovalPanel({
@@ -17,11 +20,15 @@ export function ApprovalPanel({
   toolCommand,
   toolDescription,
   dontAskAgainPattern,
+  ruleCandidate,
 }: ApprovalPanelProps) {
   const { chat } = useChatContext();
   const { addToolApprovalResponse } = useChat({ chat });
   const [selected, setSelected] = useState(0);
   const [reason, setReason] = useState("");
+  const hasRuleCandidate = Boolean(ruleCandidate);
+  const maxIndex = hasRuleCandidate ? 2 : 1;
+  const reasonIndex = hasRuleCandidate ? 2 : 1;
 
   // Reset state when approval request changes
   useEffect(() => {
@@ -36,8 +43,8 @@ export function ApprovalPanel({
       return;
     }
 
-    // When on the text input option (selected === 2)
-    if (selected === 2) {
+    // When on the text input option
+    if (selected === reasonIndex) {
       if (key.return) {
         addToolApprovalResponse({
           id: approvalId,
@@ -47,7 +54,7 @@ export function ApprovalPanel({
       } else if (key.backspace || key.delete) {
         setReason((prev) => prev.slice(0, -1));
       } else if (key.upArrow || (key.ctrl && input === "p")) {
-        setSelected(1);
+        setSelected(hasRuleCandidate ? 1 : 0);
       } else if (input && !key.ctrl && !key.meta && !key.return) {
         setReason((prev) => prev + input);
       }
@@ -59,17 +66,18 @@ export function ApprovalPanel({
       key.downArrow || input === "j" || (key.ctrl && input === "n");
 
     if (goUp) {
-      setSelected((prev) => (prev === 0 ? 2 : prev - 1));
+      setSelected((prev) => (prev === 0 ? maxIndex : prev - 1));
     }
     if (goDown) {
-      setSelected((prev) => (prev === 2 ? 0 : prev + 1));
+      setSelected((prev) => (prev === maxIndex ? 0 : prev + 1));
     }
     if (key.return) {
       if (selected === 0) {
         // Yes
         addToolApprovalResponse({ id: approvalId, approved: true });
-      } else if (selected === 1) {
-        // Yes, and don't ask again (placeholder - behaves as Yes for now)
+      } else if (hasRuleCandidate && selected === 1 && ruleCandidate) {
+        // Yes, and don't ask again - store the rule for future auto-approval
+        addSessionRule(ruleCandidate.rule);
         addToolApprovalResponse({ id: approvalId, approved: true });
       }
     }
@@ -109,20 +117,24 @@ export function ApprovalPanel({
           </Text>
 
           {/* Option 2: Yes, and don't ask again */}
-          <Text>
-            <Text color="yellow">{selected === 1 ? "› " : "  "}</Text>
-            <Text>2. Yes, and don't ask again for </Text>
-            <Text bold>{dontAskAgainPattern}</Text>
-          </Text>
+          {hasRuleCandidate && (
+            <Text>
+              <Text color="yellow">{selected === 1 ? "› " : "  "}</Text>
+              <Text>2. Yes, and don't ask again for </Text>
+              <Text bold>{ruleCandidate?.displayLabel ?? dontAskAgainPattern}</Text>
+            </Text>
+          )}
 
           {/* Option 3: Inline text input */}
           <Box>
-            <Text color="yellow">{selected === 2 ? "› " : "  "}</Text>
-            <Text>3. </Text>
-            {reason || selected === 2 ? (
+            <Text color="yellow">
+              {selected === reasonIndex ? "› " : "  "}
+            </Text>
+            <Text>{hasRuleCandidate ? "3. " : "2. "}</Text>
+            {reason || selected === reasonIndex ? (
               <>
                 <Text>{reason}</Text>
-                {selected === 2 && <Text color="gray">█</Text>}
+                {selected === reasonIndex && <Text color="gray">█</Text>}
               </>
             ) : (
               <Text color="gray">Type here to tell Claude what to do differently</Text>
@@ -134,7 +146,7 @@ export function ApprovalPanel({
       {/* Footer hint */}
       <Box marginTop={1}>
         <Text color="gray">
-          {selected === 2 ? "Enter to submit, Esc to cancel" : "Esc to cancel"}
+          {selected === reasonIndex ? "Enter to submit, Esc to deny" : "Esc to deny"}
         </Text>
       </Box>
     </Box>

--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -2,21 +2,59 @@ import React, { useState, useEffect, type ReactNode } from "react";
 import { Box, Text, useInput } from "ink";
 import { useChat } from "@ai-sdk/react";
 import { getToolName, isTextUIPart, isToolUIPart } from "ai";
+import * as path from "path";
 import { useChatContext } from "../chat-context.js";
 import type { TUIAgentUIToolPart } from "../types.js";
+import type { ApprovalRule } from "../../agent/utils/session-rules.js";
+
+export type RuleCandidate = {
+  displayLabel: string;
+  rule: ApprovalRule;
+};
 
 export type ToolApprovalInfo = {
   toolType: string;
   toolCommand: string;
   toolDescription?: string;
   dontAskAgainPattern?: string;
+  ruleCandidate?: RuleCandidate;
 };
 
+/**
+ * Get a directory-based glob pattern from a file path.
+ * Returns the first directory component as a pattern like "src/**".
+ */
+function getDirectoryGlob(filePath: string, cwd: string): string | null {
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(cwd, filePath);
+
+  // Get relative path from cwd
+  const relativePath = path.relative(cwd, absolutePath);
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  const dir = path.dirname(relativePath);
+  if (dir === ".") {
+    return null;
+  }
+  const normalizedDir = dir.split(path.sep).join("/");
+
+  return `${normalizedDir}/**`;
+}
+
+/**
+ * Get approval info and rule candidate for a tool part.
+ *
+ * IMPORTANT: The `workingDirectory` parameter must match `sharedContext.workingDirectory`
+ * used by the agent. If they differ, generated rules won't match at runtime.
+ */
 export function getToolApprovalInfo(
   part: TUIAgentUIToolPart,
-  workingDirectory?: string,
+  workingDirectory: string,
 ): ToolApprovalInfo {
-  const cwd = workingDirectory ?? process.cwd();
+  const cwd = workingDirectory;
 
   switch (part.type) {
     case "tool-bash": {
@@ -24,33 +62,56 @@ export function getToolApprovalInfo(
       // Description may be provided by Claude as additional context
       const description = (part.input as { description?: string } | undefined)
         ?.description;
-      // Extract first word of command for the pattern
-      const firstWord = command.split(" ")[0] ?? "this command";
+      // Extract first two tokens for the prefix (e.g., "bun test", "git diff")
+      const trimmedCommand = command.trim();
+      const tokens = trimmedCommand ? trimmedCommand.split(/\s+/) : [];
+      const prefix = tokens.slice(0, Math.min(2, tokens.length)).join(" ");
+      const firstWord = tokens[0] ?? "this command";
       return {
         toolType: "Bash command",
         toolCommand: command,
         toolDescription: description,
         dontAskAgainPattern: `${firstWord} commands in ${cwd}`,
+        ruleCandidate: prefix
+          ? {
+              displayLabel: `"${prefix}" commands`,
+              rule: { type: "command-prefix", prefix },
+            }
+          : undefined,
       };
     }
 
     case "tool-write": {
       const filePath = String(part.input?.filePath ?? "");
+      const dirGlob = getDirectoryGlob(filePath, cwd);
       return {
         toolType: "Write file",
         toolCommand: filePath,
         toolDescription: "Create new file",
         dontAskAgainPattern: `writes in ${cwd}`,
+        ruleCandidate: dirGlob
+          ? {
+              displayLabel: `writes in ${dirGlob}`,
+              rule: { type: "path-glob", glob: dirGlob, toolTypes: ["write"] },
+            }
+          : undefined,
       };
     }
 
     case "tool-edit": {
       const filePath = String(part.input?.filePath ?? "");
+      const dirGlob = getDirectoryGlob(filePath, cwd);
       return {
         toolType: "Edit file",
         toolCommand: filePath,
         toolDescription: "Modify existing file",
         dontAskAgainPattern: `edits in ${cwd}`,
+        ruleCandidate: dirGlob
+          ? {
+              displayLabel: `edits in ${dirGlob}`,
+              rule: { type: "path-glob", glob: dirGlob, toolTypes: ["edit"] },
+            }
+          : undefined,
       };
     }
 
@@ -71,6 +132,13 @@ export function getToolApprovalInfo(
             ? "This executor has full write access and can create, modify, and delete files."
             : undefined,
         dontAskAgainPattern: `${subagentType ?? "task"} operations`,
+        ruleCandidate:
+          subagentType === "executor"
+            ? {
+                displayLabel: "executor tasks",
+                rule: { type: "subagent-type", subagentType: "executor" },
+              }
+            : undefined,
       };
     }
 


### PR DESCRIPTION
## Summary
Replaces the lengthy session-based tool approval plan with a clearer, more actionable saved preferences plan that aligns with current TUI behavior. Implements session rule store and integrates rule-based auto-approval into tool approval functions.

## What Changed
- **docs**: Condensed 372-line approval plan to 158 lines, refocusing on saved preferences instead of complex pattern approval
- **agent tools**: Added session rule matching to `bash`, `write`, `edit`, and `task` tools via new `session-rules.ts` utilities
- **agent context**: Extended `sharedContext` with `sessionRules` array and functions to manage session rules
- **TUI components**: Updated `ApprovalPanel` to offer "don't ask again" with rule storage; enhanced `tool-call.tsx` to generate structured rule candidates
- **TUI chat context**: Clear session rules on provider mount to start fresh each session

## Why
The original plan was too detailed and forward-looking. This refocus clarifies that rules are session-scoped (in-memory only), simplifies the implementation into distinct phases, and makes the "don't ask again" button functional by immediately storing and checking rules.

## How
Session rules are checked in tool `needsApproval` functions before safety checks; rules must match both the pattern (command prefix, path glob, subagent type) and the working directory scope. Users trigger rule creation via the "Yes, and don't ask again" option in the approval UI, which stores a rule candidate and approves the current request. Future matching requests auto-approve silently.