### PR TITLE
Add approval rules to skip manual tool approval

### DIFF
--- a/docs/session-based-tool-approval-plan.md
+++ b/docs/session-based-tool-approval-plan.md
@@ -1,372 +1,179 @@
-# Session-Based Tool Approval
+# Saved Tool Approval Preferences
 
-This document outlines a feature to allow users to control tool approval behavior through auto-accept modes and session-based pattern approval.
+This plan uses the call options pattern (like `autoApprove`) to pass approval
+rules from the client to the agent's `needsApproval` functions via
+`sharedContext`.
 
 ## Current State
 
-The codebase has:
-
-1. **Factory function tools** with `needsApproval` support (boolean or function)
-2. **`AutoAcceptMode`** state in ChatContext (`"off"` | `"edits"` | `"all"`)
-3. **Approval UI** with Yes/No/Reason options via `ApprovalButtons`
-4. **Context injection** via `experimental_context` in `prepareCall`
-
-### Key Files
-
-| File                                   | Purpose                                              |
-| -------------------------------------- | ---------------------------------------------------- |
-| `src/tui/chat-context.tsx`             | Manages `autoAcceptMode` state (lines 101, 145-151)  |
-| `src/tui/types.ts`                     | Defines `AutoAcceptMode` type (line 24)              |
-| `src/agent/deep-agent.ts`              | Agent with tools and `prepareCall` context injection |
-| `src/agent/tools/file-system/bash.ts`  | Bash tool with `commandNeedsApproval()`              |
-| `src/agent/tools/file-system/write.ts` | Write/Edit tools with `needsApproval` option         |
-| `src/tui/components/tool-call.tsx`     | `ApprovalButtons` component                          |
-| `src/tui/transport.ts`                 | Passes `agentOptions` to agent                       |
-
-### Current Problem
-
-The `autoAcceptMode` state exists but **isn't wired up**. It's purely UI state - changing it doesn't affect tool approval behavior. Tools are configured at agent creation time with static `needsApproval: true`.
+- `autoApprove` is already passed via call options and stored in `sharedContext`
+- Transport calls `getAutoApprove()` at request time to get current mode
+- Each tool's `needsApproval` function reads `sharedContext.autoApprove`
+- "Yes, and don't ask again" in `ApprovalPanel` is a placeholder
 
 ## Goals
 
-1. **Wire up `autoAcceptMode`** to control tool approval behavior:
-   - `"off"`: All tools require manual approval
-   - `"edits"`: Auto-approve write/edit tools, manual approval for bash
-   - `"all"`: Auto-approve all tools
+1. Persist approval patterns within a session so "don't ask again" suppresses
+   repeat prompts for similar requests.
+2. Auto-approve when a session rule matches a tool request.
+3. Keep a clear UI path to save and clear preferences.
+4. Preserve safety defaults for paths outside the working directory.
 
-2. **Session-based pattern approval** (future enhancement):
-   - Approve `bun test` once, then auto-approve `bun test:unit`, `bun test src/`
-   - Approve writes to `src/components/`, then auto-approve other writes in that directory
+## Approach
 
----
+Follow the existing `autoApprove` pattern:
+
+1. Define approval rules schema and add `approvalRules` to call options
+2. Store rules in `sharedContext` via `prepareCall`
+3. Update each tool's `needsApproval` function to check rules
+4. On the client, keep rules in state/ref and pass via transport
+
+## Data Model
+
+```typescript
+// Rule types for different tools
+type ApprovalRule =
+  | { type: "command-prefix"; tool: "bash"; prefix: string }
+  | { type: "path-glob"; tool: "write" | "edit" | "read" | "grep" | "glob"; glob: string }
+  | { type: "subagent-type"; tool: "task"; subagentType: "executor" | "explorer" };
+
+type ApprovalRules = ApprovalRule[];
+```
+
+Example rules:
+
+```json
+[
+  { "type": "command-prefix", "tool": "bash", "prefix": "bun test" },
+  { "type": "path-glob", "tool": "write", "glob": "src/**" },
+  { "type": "subagent-type", "tool": "task", "subagentType": "executor" }
+]
+```
 
 ## Implementation Plan
 
-### Phase 1: Wire Up `autoAcceptMode`
+### Phase 1: Add Approval Rules to Call Options
 
-#### Step 1: Add `autoAcceptMode` to Agent Options
+Files: `src/agent/deep-agent.ts`, `src/agent/utils/shared-context.ts`, `src/agent/types.ts`
 
-Update the call options schema to include `autoAcceptMode`:
+1. Add `ApprovalRule` type to `src/agent/types.ts`
+2. Add `approvalRulesSchema` to `callOptionsSchema` in deep-agent.ts
+3. Add `approvalRules: ApprovalRule[]` to `sharedContext`
+4. Update `prepareCall` to set `sharedContext.approvalRules`
+
+### Phase 2: Update needsApproval Functions
+
+Files: `src/agent/tools/file-system/bash.ts`, `src/agent/tools/file-system/write.ts`,
+`src/agent/tools/file-system/read.ts`, `src/agent/tools/file-system/grep.ts`,
+`src/agent/tools/file-system/glob.ts`, `src/agent/tools/task-delegation/task.ts`
+
+Add rule matching to each tool's approval function:
 
 ```typescript
-// src/agent/deep-agent.ts
-const callOptionsSchema = z.object({
-  workingDirectory: z.string(),
-  customInstructions: z.string().optional(),
-  todos: z.array(todoItemSchema).optional(),
-  scratchpad: z.map(...).optional(),
-  autoAcceptMode: z.enum(["off", "edits", "all"]).optional(), // NEW
+// bash.ts - check command-prefix rules
+function createBashApprovalFn(options?: ToolOptions): ApprovalFn {
+  return async (args) => {
+    // ... existing checks ...
+    
+    // Check approval rules
+    for (const rule of sharedContext.approvalRules) {
+      if (rule.type === "command-prefix" && rule.tool === "bash") {
+        if (args.command.trim().startsWith(rule.prefix)) {
+          return false; // auto-approve
+        }
+      }
+    }
+    
+    // ... rest of existing logic ...
+  };
+}
+```
+
+Similar patterns for:
+- `write.ts` / `edit.ts`: match `path-glob` rules against file path
+- `read.ts` / `grep.ts` / `glob.ts`: match `path-glob` rules
+- `task.ts`: match `subagent-type` rules
+
+### Phase 3: Client-Side State Management
+
+Files: `src/tui/chat-context.tsx`, `src/tui/transport.ts`, `src/tui/types.ts`
+
+1. Add `ApprovalRule[]` state and ref in `ChatProvider`
+2. Add `addApprovalRule` and `clearApprovalRules` functions to context
+3. Pass `getApprovalRules` callback to transport (like `getAutoApprove`)
+4. Update transport to include `approvalRules` in call options
+
+```typescript
+// chat-context.tsx
+const [approvalRules, setApprovalRules] = useState<ApprovalRule[]>([]);
+const approvalRulesRef = useRef(approvalRules);
+approvalRulesRef.current = approvalRules;
+
+const addApprovalRule = (rule: ApprovalRule) => {
+  setApprovalRules((prev) => [...prev, rule]);
+};
+
+// transport.ts
+const approvalRules = getApprovalRules?.() ?? [];
+const result = await agent.stream({
+  messages: prunedMessages,
+  options: { ...agentOptions, autoApprove, approvalRules },
+  // ...
 });
 ```
 
-#### Step 2: Pass `autoAcceptMode` to Context
+### Phase 4: Rule Inference + "Don't Ask Again"
 
-Inject `autoAcceptMode` into `experimental_context`:
+Files: `src/tui/components/approval-panel.tsx`, `src/tui/components/tool-call.tsx`
 
-```typescript
-// src/agent/deep-agent.ts - prepareCall
-prepareCall: ({ options, model, ...settings }) => {
-  const workingDirectory = options?.workingDirectory ?? process.cwd();
-  const autoAcceptMode = options?.autoAcceptMode ?? "off"; // NEW
-  // ...
-  return {
-    ...settings,
-    model,
-    instructions: buildSystemPrompt({ ... }),
-    experimental_context: {
-      workingDirectory,
-      autoAcceptMode, // NEW
-    },
-  };
-},
-```
+1. Add `inferApprovalRule(toolName, args)` helper that creates a rule from tool args:
+   - bash: extract first 1-2 tokens as `command-prefix`
+   - write/edit: extract directory as `path-glob` (e.g., `src/components/**`)
+   - task: create `subagent-type` rule for executor
 
-Update `AgentContext` type:
-
-```typescript
-// src/agent/types.ts
-export interface AgentContext {
-  workingDirectory: string;
-  autoAcceptMode?: "off" | "edits" | "all"; // NEW
-}
-```
-
-#### Step 3: Update ChatProvider to Pass `autoAcceptMode`
-
-```typescript
-// src/tui/chat-context.tsx
-const agentOptionsWithAutoAccept = useMemo(
-  () => ({
-    ...agentOptions,
-    autoAcceptMode,
-  }),
-  [agentOptions, autoAcceptMode],
-);
-
-const transport = useMemo(
-  () =>
-    createAgentTransport({
-      agent: tuiAgent,
-      agentOptions: agentOptionsWithAutoAccept, // Use merged options
-      onUsageUpdate: handleUsageUpdate,
-    }),
-  [agentOptionsWithAutoAccept, handleUsageUpdate],
-);
-```
-
-#### Step 4: Make `needsApproval` Dynamic in Tools
-
-The key insight: `needsApproval` can be a function that receives `args` and can access context. However, the AI SDK's `needsApproval` function signature is `(args) => boolean`, not `(args, context) => boolean`.
-
-**Solution**: Create tool factories that accept `autoAcceptMode` through closure, then recreate tools when mode changes.
-
-**Alternative (simpler)**: Since `needsApproval` is evaluated per-call, we can use a factory pattern at the agent level.
-
-For simplicity, the recommended approach is to **recreate the transport** when `autoAcceptMode` changes (which already happens due to the useMemo dependency).
-
-Update tool definitions to use function-based approval:
-
-```typescript
-// src/agent/tools/file-system/write.ts
-export const writeFileTool = (options?: WriteToolOptions) =>
-  tool({
-    needsApproval: (args) => {
-      // If a custom function is provided, use it
-      if (typeof options?.needsApproval === "function") {
-        return options.needsApproval(args);
-      }
-      // Otherwise use the boolean (default true)
-      return options?.needsApproval ?? true;
-    },
-    // ...
-  });
-```
-
-**For the agent**, create a helper that generates tools based on mode:
-
-```typescript
-// src/agent/tools/index.ts (new export)
-export function createToolsWithApprovalMode(mode: AutoAcceptMode) {
-  const editApproval = mode === "off"; // edits auto-approved in "edits" and "all"
-  const bashApproval = mode !== "all" ? commandNeedsApproval : false;
-
-  return {
-    todo_write: todoWriteTool,
-    read: readFileTool,
-    write: writeFileTool({ needsApproval: editApproval }),
-    edit: editFileTool({ needsApproval: editApproval }),
-    grep: grepTool,
-    glob: globTool,
-    bash: bashTool({ needsApproval: bashApproval }),
-    task: taskTool,
-  };
-}
-```
-
-#### Architecture Decision: Static vs Dynamic Tools
-
-**Option A: Static Tools + Context Check** (Current direction)
-
-- Tools defined once at agent creation
-- `needsApproval` functions check `experimental_context.autoAcceptMode`
-- Requires AI SDK to support passing context to `needsApproval`
-
-**Option B: Dynamic Agent Recreation** (Alternative)
-
-- Create new agent instance when `autoAcceptMode` changes
-- Simpler implementation but more overhead
-
-**Option C: UI-Level Auto-Approval** (Recommended for MVP)
-
-- Keep tools as-is with static `needsApproval`
-- Handle auto-approval in the TUI layer before sending approval response
-- When approval requested and mode matches, auto-send approval
-
-#### Recommended: Option C - UI-Level Auto-Approval
-
-This approach doesn't require agent/tool changes:
-
-```typescript
-// src/tui/app.tsx or a new hook
-useEffect(() => {
-  if (!hasPendingApproval || !activeApprovalId) return;
-
-  const lastMessage = messages[messages.length - 1];
-  const pendingPart = lastMessage?.parts.find(
-    (p) => isToolUIPart(p) && p.state === "approval-requested",
-  );
-
-  if (!pendingPart) return;
-
-  const toolName = getToolName(pendingPart);
-  const shouldAutoApprove =
-    autoAcceptMode === "all" ||
-    (autoAcceptMode === "edits" &&
-      (toolName === "write" || toolName === "edit"));
-
-  if (shouldAutoApprove) {
-    addToolApprovalResponse({ id: activeApprovalId, approved: true });
-  }
-}, [hasPendingApproval, activeApprovalId, autoAcceptMode, messages]);
-```
-
----
-
-### Phase 2: Session-Based Pattern Approval (Future)
-
-Once Phase 1 is complete, add pattern-based approval:
-
-#### Step 1: Add Approved Patterns State
-
-```typescript
-// src/tui/chat-context.tsx
-type ApprovedPattern = {
-  toolName: string;
-  pattern: string; // e.g., "bun test:*", "src/components/**"
-  createdAt: number;
-};
-
-const [approvedPatterns, setApprovedPatterns] = useState<ApprovedPattern[]>([]);
-```
-
-#### Step 2: Add "Approve Similar" Button
-
-Update `ApprovalButtons` to offer pattern-based approval:
-
-```typescript
-// src/tui/components/tool-call.tsx
-function ApprovalButtons({ approvalId, toolName, args }: ApprovalButtonsProps) {
-  const suggestedPattern = inferPattern(toolName, args);
-
-  // Options: Yes, Yes + approve similar, No, Reason
-  // ...
-}
-
-function inferPattern(toolName: string, args: unknown): string | null {
-  if (
-    toolName === "bash" &&
-    typeof args === "object" &&
-    args &&
-    "command" in args
-  ) {
-    const command = (args as { command: string }).command;
-    // Extract prefix: "bun test src/" -> "bun test"
-    const parts = command.split(" ");
-    if (parts.length >= 2) {
-      return `${parts[0]} ${parts[1]}:*`;
-    }
-  }
-  if (
-    (toolName === "write" || toolName === "edit") &&
-    typeof args === "object" &&
-    args &&
-    "filePath" in args
-  ) {
-    const filePath = (args as { filePath: string }).filePath;
-    // Extract directory pattern: "/Users/x/project/src/components/Button.tsx" -> "src/components/**"
-    const relativePath = path.relative(workingDirectory, filePath);
-    const dir = path.dirname(relativePath);
-    return `${dir}/**`;
-  }
-  return null;
-}
-```
-
-#### Step 3: Pattern Matching Logic
-
-```typescript
-// src/tui/utils/pattern-matching.ts
-export function matchesBashPattern(command: string, pattern: string): boolean {
-  // Pattern: "bun test:*" matches "bun test", "bun test:unit", "bun test src/"
-  if (pattern.endsWith(":*")) {
-    const prefix = pattern.slice(0, -2);
-    return command.startsWith(prefix);
-  }
-  // Pattern: "bun *" matches any bun command
-  if (pattern.endsWith(" *")) {
-    const prefix = pattern.slice(0, -1);
-    return command.startsWith(prefix);
-  }
-  return command === pattern;
-}
-
-export function matchesFilePattern(filePath: string, pattern: string): boolean {
-  // Use minimatch for glob matching
-  return minimatch(filePath, pattern);
-}
-```
-
-#### Step 4: Check Patterns in Auto-Approval Logic
-
-```typescript
-// Extend the useEffect from Phase 1
-const shouldAutoApprove =
-  autoAcceptMode === "all" ||
-  (autoAcceptMode === "edits" &&
-    (toolName === "write" || toolName === "edit")) ||
-  matchesApprovedPattern(toolName, args, approvedPatterns);
-```
-
----
+2. Update `ApprovalPanel` to:
+   - Infer a rule candidate when displaying
+   - On "Yes, and don't ask again": call `addApprovalRule(inferredRule)` then approve
+   - Show the inferred pattern in the button label
 
 ## Files to Modify
 
-### Phase 1 (Wire up autoAcceptMode)
+**Agent (server-side):**
+- `src/agent/types.ts` - add `ApprovalRule` type
+- `src/agent/utils/shared-context.ts` - add `approvalRules` to context
+- `src/agent/deep-agent.ts` - add to call options schema and prepareCall
+- `src/agent/tools/file-system/bash.ts` - check rules in approval fn
+- `src/agent/tools/file-system/write.ts` - check rules for write/edit
+- `src/agent/tools/file-system/read.ts` - check rules
+- `src/agent/tools/file-system/grep.ts` - check rules
+- `src/agent/tools/file-system/glob.ts` - check rules
+- `src/agent/tools/task-delegation/task.ts` - check rules
 
-| File                       | Changes                                                 |
-| -------------------------- | ------------------------------------------------------- |
-| `src/tui/app.tsx`          | Add auto-approval effect based on mode                  |
-| `src/tui/chat-context.tsx` | Export `autoAcceptMode` in context value (already done) |
-
-### Phase 2 (Pattern Approval)
-
-| File                                | Changes                                      |
-| ----------------------------------- | -------------------------------------------- |
-| `src/tui/chat-context.tsx`          | Add `approvedPatterns` state and setter      |
-| `src/tui/components/tool-call.tsx`  | Add "approve similar" button, pass tool args |
-| `src/tui/utils/pattern-matching.ts` | New file for pattern matching utilities      |
-
----
+**TUI (client-side):**
+- `src/tui/types.ts` - re-export `ApprovalRule` type
+- `src/tui/chat-context.tsx` - state, ref, and context functions
+- `src/tui/transport.ts` - pass rules in call options
+- `src/tui/components/approval-panel.tsx` - infer rules, handle "don't ask again"
 
 ## User Experience
 
-### Phase 1 Flow
-
-1. User cycles `autoAcceptMode` with keyboard shortcut (already works)
-2. Status bar shows current mode with visual indicator
-3. When tool requests approval:
-   - `"off"`: Show approval buttons
-   - `"edits"`: Auto-approve write/edit, show buttons for bash
-   - `"all"`: Auto-approve everything (show brief notification)
-
-### Phase 2 Flow
-
-1. Tool requests approval (e.g., `bash: bun test src/utils`)
-2. User sees options:
-   - **1. Yes** - Approve this one execution
-   - **2. Yes, approve "bun test:\*"** - Approve and add pattern
-   - **3. No** - Deny execution
-   - **4. Reason** - Deny with explanation
-3. If pattern approved, future matching commands auto-approve
-4. Status bar shows: `Auto-approved: bun test:*, src/components/**`
-
----
+1. Tool requests approval, ApprovalPanel shows pattern (e.g., "bun test")
+2. User selects "Yes, and don't ask again for `bun test`"
+3. Rule is added to state, request is approved
+4. Next request with same pattern: rule sent via call options, `needsApproval`
+   returns false, no approval UI shown
 
 ## Security Considerations
 
-- Patterns reset on session end (no persistence)
-- Patterns should be specific to avoid unintended approvals
-- "all" mode shows warning indicator in status bar
-- Allow users to clear patterns mid-session (`/clear-approvals` command)
-- Show notification when auto-approving: `Auto-approved: bun test src/`
+- Rules only skip approval for paths within working directory
+- Outside-cwd paths always require manual approval (rules ignored)
+- Bash safety patterns still apply (rules only affect the approval check, not
+  the underlying safety list)
+- Rules are session-only, not persisted to disk
 
----
+## Validation
 
-## Implementation Order
-
-1. **Phase 1A**: Add auto-approval effect in `app.tsx` for `autoAcceptMode`
-2. **Phase 1B**: Add visual feedback when auto-approving
-3. **Phase 2A**: Add `approvedPatterns` state
-4. **Phase 2B**: Implement pattern inference and "approve similar" button
-5. **Phase 2C**: Add pattern matching and integrate with auto-approval
-6. **Phase 2D**: Add UI for viewing/clearing approved patterns
+- Unit test rule matching logic in each tool's approval function
+- Manual: approve `bun test` once, confirm next `bun test` auto-approves
+- Manual: confirm write/edit auto-approval only works within cwd
+- Manual: confirm outside-cwd paths still require approval

--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -16,7 +16,8 @@ import {
   taskTool,
 } from "./tools";
 import { buildSystemPrompt } from "./system-prompt";
-import type { TodoItem, AgentMode } from "./types";
+import type { TodoItem, AgentMode, ApprovalRule } from "./types";
+import { approvalRuleSchema } from "./types";
 import { addCacheControl, compactContext, getSandbox, sharedContext } from "./utils";
 import { gateway } from "../models";
 import { createLocalSandbox, type Sandbox } from "./sandbox";
@@ -30,6 +31,7 @@ const callOptionsSchema = z.object({
   customInstructions: z.string().optional(),
   sandbox: z.custom<Sandbox>().optional(),
   autoApprove: autoApproveSchema.optional(),
+  approvalRules: z.array(approvalRuleSchema).optional(),
 });
 
 export type DeepAgentCallOptions = z.infer<typeof callOptionsSchema>;
@@ -68,11 +70,13 @@ export const deepAgent = new ToolLoopAgent({
     const workingDirectory = options?.workingDirectory ?? process.cwd();
     const mode: AgentMode = options?.mode ?? "interactive";
     const autoApprove = options?.autoApprove ?? "off";
+    const approvalRules: ApprovalRule[] = options?.approvalRules ?? [];
 
     // Update shared context for tool approval functions
     sharedContext.workingDirectory = workingDirectory;
     sharedContext.mode = mode;
     sharedContext.autoApprove = autoApprove;
+    sharedContext.approvalRules = approvalRules;
 
     const customInstructions = options?.customInstructions;
 

--- a/src/agent/tools/file-system/bash.ts
+++ b/src/agent/tools/file-system/bash.ts
@@ -35,6 +35,21 @@ function cwdIsOutsideWorkingDirectory(cwd: string | undefined): boolean {
 }
 
 /**
+ * Check if a command matches any command-prefix approval rules.
+ */
+function commandMatchesApprovalRule(command: string): boolean {
+  const trimmedCommand = command.trim();
+  for (const rule of sharedContext.approvalRules) {
+    if (rule.type === "command-prefix" && rule.tool === "bash") {
+      if (trimmedCommand.startsWith(rule.prefix)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Create a combined approval function for bash operations.
  * Always requires approval if cwd is outside working directory,
  * then checks command safety and user-provided option.
@@ -55,6 +70,11 @@ function createBashApprovalFn(options?: ToolOptions): ApprovalFn {
 
     // Auto-approve all bash commands when autoApprove is "all"
     if (sharedContext.autoApprove === "all") {
+      return false;
+    }
+
+    // Check if command matches any saved approval rules
+    if (commandMatchesApprovalRule(args.command)) {
       return false;
     }
 

--- a/src/agent/tools/file-system/glob.ts
+++ b/src/agent/tools/file-system/glob.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import type { Sandbox } from "../../sandbox";
-import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext, pathMatchesGlob } from "../../utils";
 
 interface FileInfo {
   path: string;
@@ -105,18 +105,48 @@ const globInputSchema = z.object({
 type GlobInput = z.infer<typeof globInputSchema>;
 
 /**
+ * Check if a path matches any path-glob approval rules for glob operations.
+ */
+function pathMatchesApprovalRule(searchPath: string): boolean {
+  const absolutePath = path.isAbsolute(searchPath)
+    ? searchPath
+    : path.resolve(sharedContext.workingDirectory, searchPath);
+
+  for (const rule of sharedContext.approvalRules) {
+    if (rule.type === "path-glob" && rule.tool === "glob") {
+      if (pathMatchesGlob(absolutePath, rule.glob, sharedContext.workingDirectory)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Check if a glob operation needs approval based on the search path.
- * Returns true if the path is outside the working directory.
+ * Returns true if the path is outside the working directory and no approval rule matches.
  */
 function pathNeedsApproval(args: GlobInput): boolean {
   // If no path is provided, it defaults to working directory (no approval needed)
   if (!args.path) {
     return false;
   }
+
   const absolutePath = path.isAbsolute(args.path)
     ? args.path
     : path.resolve(sharedContext.workingDirectory, args.path);
-  return !isPathWithinDirectory(absolutePath, sharedContext.workingDirectory);
+
+  // Check if within working directory - no approval needed
+  if (isPathWithinDirectory(absolutePath, sharedContext.workingDirectory)) {
+    return false;
+  }
+
+  // Outside working directory - check if a rule matches
+  if (pathMatchesApprovalRule(args.path)) {
+    return false;
+  }
+
+  return true;
 }
 
 export const globTool = () => tool({

--- a/src/agent/tools/file-system/grep.ts
+++ b/src/agent/tools/file-system/grep.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import type { Sandbox } from "../../sandbox";
-import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext, pathMatchesGlob } from "../../utils";
 
 interface GrepMatch {
   file: string;
@@ -97,14 +97,43 @@ const grepInputSchema = z.object({
 type GrepInput = z.infer<typeof grepInputSchema>;
 
 /**
+ * Check if a path matches any path-glob approval rules for grep operations.
+ */
+function pathMatchesApprovalRule(searchPath: string): boolean {
+  const absolutePath = path.isAbsolute(searchPath)
+    ? searchPath
+    : path.resolve(sharedContext.workingDirectory, searchPath);
+
+  for (const rule of sharedContext.approvalRules) {
+    if (rule.type === "path-glob" && rule.tool === "grep") {
+      if (pathMatchesGlob(absolutePath, rule.glob, sharedContext.workingDirectory)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Check if a grep operation needs approval based on the search path.
- * Returns true if the path is outside the working directory.
+ * Returns true if the path is outside the working directory and no approval rule matches.
  */
 function pathNeedsApproval(args: GrepInput): boolean {
   const absolutePath = path.isAbsolute(args.path)
     ? args.path
     : path.resolve(sharedContext.workingDirectory, args.path);
-  return !isPathWithinDirectory(absolutePath, sharedContext.workingDirectory);
+
+  // Check if within working directory - no approval needed
+  if (isPathWithinDirectory(absolutePath, sharedContext.workingDirectory)) {
+    return false;
+  }
+
+  // Outside working directory - check if a rule matches
+  if (pathMatchesApprovalRule(args.path)) {
+    return false;
+  }
+
+  return true;
 }
 
 export const grepTool = () => tool({

--- a/src/agent/tools/file-system/read.ts
+++ b/src/agent/tools/file-system/read.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext, pathMatchesGlob } from "../../utils";
 
 const readInputSchema = z.object({
   filePath: z
@@ -22,14 +22,45 @@ const readInputSchema = z.object({
 type ReadInput = z.infer<typeof readInputSchema>;
 
 /**
+ * Check if a file path matches any path-glob approval rules for read operations.
+ */
+function pathMatchesApprovalRule(filePath: string): boolean {
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(sharedContext.workingDirectory, filePath);
+
+  for (const rule of sharedContext.approvalRules) {
+    if (rule.type === "path-glob" && rule.tool === "read") {
+      if (pathMatchesGlob(absolutePath, rule.glob, sharedContext.workingDirectory)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Check if a read operation needs approval based on the file path.
- * Returns true if the path is outside the working directory.
+ * Returns true if the path is outside the working directory and no approval rule matches.
  */
 function pathNeedsApproval(args: ReadInput): boolean {
   const absolutePath = path.isAbsolute(args.filePath)
     ? args.filePath
     : path.resolve(sharedContext.workingDirectory, args.filePath);
-  return !isPathWithinDirectory(absolutePath, sharedContext.workingDirectory);
+
+  // Check if within working directory - no approval needed
+  if (isPathWithinDirectory(absolutePath, sharedContext.workingDirectory)) {
+    return false;
+  }
+
+  // Outside working directory - check if a rule matches
+  // Note: Rules only apply within working directory per security considerations,
+  // so this will always return true for outside-cwd paths
+  if (pathMatchesApprovalRule(args.filePath)) {
+    return false;
+  }
+
+  return true;
 }
 
 export const readFileTool = () => tool({

--- a/src/agent/tools/file-system/read.ts
+++ b/src/agent/tools/file-system/read.ts
@@ -1,7 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import { isPathWithinDirectory, getSandbox, sharedContext, pathMatchesGlob } from "../../utils";
+import * as fs from "fs";
+import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
 
 const readInputSchema = z.object({
   filePath: z
@@ -22,44 +23,50 @@ const readInputSchema = z.object({
 type ReadInput = z.infer<typeof readInputSchema>;
 
 /**
- * Check if a file path matches any path-glob approval rules for read operations.
+ * Resolve file path with fallback for root-like paths.
+ * If a path like "/README.md" doesn't exist, try resolving it relative to workingDirectory.
  */
-function pathMatchesApprovalRule(filePath: string): boolean {
-  const absolutePath = path.isAbsolute(filePath)
+function resolveFilePath(filePath: string, workingDirectory: string): string {
+  let absolutePath = path.isAbsolute(filePath)
     ? filePath
-    : path.resolve(sharedContext.workingDirectory, filePath);
+    : path.resolve(workingDirectory, filePath);
 
-  for (const rule of sharedContext.approvalRules) {
-    if (rule.type === "path-glob" && rule.tool === "read") {
-      if (pathMatchesGlob(absolutePath, rule.glob, sharedContext.workingDirectory)) {
-        return true;
+  // If path doesn't exist and looks like a root-relative path (e.g., /README.md),
+  // try resolving it relative to the working directory
+  try {
+    fs.accessSync(absolutePath);
+  } catch {
+    if (
+      filePath.startsWith("/") &&
+      !filePath.startsWith("/Users/") &&
+      !filePath.startsWith("/home/")
+    ) {
+      const workspaceRelativePath = path.join(workingDirectory, filePath);
+      try {
+        fs.accessSync(workspaceRelativePath);
+        absolutePath = workspaceRelativePath;
+      } catch {
+        // Neither path exists - return original
       }
     }
   }
-  return false;
+
+  return absolutePath;
 }
 
 /**
  * Check if a read operation needs approval based on the file path.
- * Returns true if the path is outside the working directory and no approval rule matches.
+ * Returns true if the path is outside the working directory.
  */
 function pathNeedsApproval(args: ReadInput): boolean {
-  const absolutePath = path.isAbsolute(args.filePath)
-    ? args.filePath
-    : path.resolve(sharedContext.workingDirectory, args.filePath);
+  const absolutePath = resolveFilePath(args.filePath, sharedContext.workingDirectory);
 
   // Check if within working directory - no approval needed
   if (isPathWithinDirectory(absolutePath, sharedContext.workingDirectory)) {
     return false;
   }
 
-  // Outside working directory - check if a rule matches
-  // Note: Rules only apply within working directory per security considerations,
-  // so this will always return true for outside-cwd paths
-  if (pathMatchesApprovalRule(args.filePath)) {
-    return false;
-  }
-
+  // Outside working directory - always requires approval
   return true;
 }
 
@@ -89,34 +96,8 @@ EXAMPLES:
     const workingDirectory = sandbox.workingDirectory;
 
     try {
-      // Resolve the path relative to working directory
-      let absolutePath: string;
-      if (path.isAbsolute(filePath)) {
-        absolutePath = filePath;
-      } else {
-        absolutePath = path.resolve(workingDirectory, filePath);
-      }
-
-      // If the path doesn't exist and looks like a root-relative path (e.g., /README.md),
-      // try resolving it relative to the working directory
-      try {
-        await sandbox.access(absolutePath);
-      } catch {
-        // Path doesn't exist - check if it's a root-relative path that should be workspace-relative
-        if (
-          filePath.startsWith("/") &&
-          !filePath.startsWith("/Users/") &&
-          !filePath.startsWith("/home/")
-        ) {
-          const workspaceRelativePath = path.join(workingDirectory, filePath);
-          try {
-            await sandbox.access(workspaceRelativePath);
-            absolutePath = workspaceRelativePath;
-          } catch {
-            // Neither path exists - let it fall through to the original error handling
-          }
-        }
-      }
+      // Use the same path resolution logic as needsApproval
+      const absolutePath = resolveFilePath(filePath, workingDirectory);
 
       const stats = await sandbox.stat(absolutePath);
       if (stats.isDirectory()) {

--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import { isPathWithinDirectory, getSandbox, sharedContext } from "../../utils";
+import { isPathWithinDirectory, getSandbox, sharedContext, pathMatchesGlob } from "../../utils";
 
 const writeInputSchema = z.object({
   filePath: z.string().describe("Absolute path to the file to write"),
@@ -45,6 +45,24 @@ function isOutsideWorkingDirectory(filePath: string): boolean {
 }
 
 /**
+ * Check if a file path matches any path-glob approval rules for a specific tool.
+ */
+function pathMatchesApprovalRule(filePath: string, toolName: "write" | "edit"): boolean {
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(sharedContext.workingDirectory, filePath);
+
+  for (const rule of sharedContext.approvalRules) {
+    if (rule.type === "path-glob" && rule.tool === toolName) {
+      if (pathMatchesGlob(absolutePath, rule.glob, sharedContext.workingDirectory)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Create a combined approval function for write operations.
  * Always requires approval if path is outside CWD, otherwise uses the provided option.
  * In background mode, auto-approve all operations (except outside working directory).
@@ -62,6 +80,10 @@ function createWriteApprovalFn(options?: WriteToolOptions): WriteApprovalFn {
     }
     // Auto-approve edits when autoApprove is "edits" or "all"
     if (sharedContext.autoApprove === "edits" || sharedContext.autoApprove === "all") {
+      return false;
+    }
+    // Check if path matches any saved approval rules
+    if (pathMatchesApprovalRule(args.filePath, "write")) {
       return false;
     }
     // Otherwise use the configured approval setting
@@ -90,6 +112,10 @@ function createEditApprovalFn(options?: EditToolOptions): EditApprovalFn {
     }
     // Auto-approve edits when autoApprove is "edits" or "all"
     if (sharedContext.autoApprove === "edits" || sharedContext.autoApprove === "all") {
+      return false;
+    }
+    // Check if path matches any saved approval rules
+    if (pathMatchesApprovalRule(args.filePath, "edit")) {
       return false;
     }
     // Otherwise use the configured approval setting

--- a/src/agent/tools/task-delegation/task.ts
+++ b/src/agent/tools/task-delegation/task.ts
@@ -2,7 +2,7 @@ import { tool, readUIMessageStream } from "ai";
 import { z } from "zod";
 import { explorerSubagent } from "./subagents/explorer";
 import { executorSubagent } from "./subagents/executor";
-import { getSandbox } from "../../utils";
+import { getSandbox, sharedContext } from "../../utils";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
 
@@ -22,10 +22,42 @@ const taskInputSchema = z.object({
   ),
 });
 
+/**
+ * Check if a subagent type matches any approval rules.
+ */
+function subagentMatchesApprovalRule(subagentType: string): boolean {
+  for (const rule of sharedContext.approvalRules) {
+    if (rule.type === "subagent-type" && rule.tool === "task") {
+      if (rule.subagentType === subagentType) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export const taskTool = tool({
   // Executor subagent has full write access, so require approval
   // Explorer is read-only, so no approval needed
-  needsApproval: ({ subagentType }) => subagentType === "executor",
+  needsApproval: ({ subagentType }) => {
+    // Explorer never needs approval
+    if (subagentType !== "executor") {
+      return false;
+    }
+
+    // In background mode, auto-approve
+    if (sharedContext.mode === "background") {
+      return false;
+    }
+
+    // Check if a rule matches this subagent type
+    if (subagentMatchesApprovalRule(subagentType)) {
+      return false;
+    }
+
+    // Default: executor needs approval
+    return true;
+  },
   description: `Launch a specialized subagent to handle complex tasks autonomously.
 
 SUBAGENT TYPES:

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -35,4 +35,28 @@ export interface AgentContext {
   mode: AgentMode;
 }
 
+/**
+ * Approval rules for auto-approving tool operations within a session.
+ * Rules are matched against tool arguments to skip manual approval.
+ */
+export const approvalRuleSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("command-prefix"),
+    tool: z.literal("bash"),
+    prefix: z.string(),
+  }),
+  z.object({
+    type: z.literal("path-glob"),
+    tool: z.enum(["write", "edit", "read", "grep", "glob"]),
+    glob: z.string(),
+  }),
+  z.object({
+    type: z.literal("subagent-type"),
+    tool: z.literal("task"),
+    subagentType: z.string(),
+  }),
+]);
+
+export type ApprovalRule = z.infer<typeof approvalRuleSchema>;
+
 export const EVICTION_THRESHOLD_BYTES = 80 * 1024;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -38,22 +38,25 @@ export interface AgentContext {
 /**
  * Approval rules for auto-approving tool operations within a session.
  * Rules are matched against tool arguments to skip manual approval.
+ *
+ * Note: Rules only apply to paths within the working directory.
+ * Outside-cwd operations always require explicit approval regardless of rules.
  */
 export const approvalRuleSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("command-prefix"),
     tool: z.literal("bash"),
-    prefix: z.string(),
+    prefix: z.string().min(1, "Prefix cannot be empty"),
   }),
   z.object({
     type: z.literal("path-glob"),
-    tool: z.enum(["write", "edit", "read", "grep", "glob"]),
+    tool: z.enum(["write", "edit", "grep", "glob"]),
     glob: z.string(),
   }),
   z.object({
     type: z.literal("subagent-type"),
     tool: z.literal("task"),
-    subagentType: z.string(),
+    subagentType: z.enum(["explorer", "executor"]),
   }),
 ]);
 

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -1,4 +1,4 @@
 export { addCacheControl } from "./cache-control/add-cache-control";
 export { compactContext } from "./compact-context";
-export { isPathWithinDirectory, getSandbox, getMode, isBackgroundMode } from "./path";
+export { isPathWithinDirectory, getSandbox, getMode, isBackgroundMode, pathMatchesGlob } from "./path";
 export { sharedContext } from "./shared-context";

--- a/src/agent/utils/path.ts
+++ b/src/agent/utils/path.ts
@@ -62,3 +62,40 @@ export function getMode(experimental_context: unknown): AgentMode {
 export function isBackgroundMode(experimental_context: unknown): boolean {
   return getMode(experimental_context) === "background";
 }
+
+/**
+ * Simple glob pattern matching for approval rules.
+ * Supports patterns like "src/**", "**\/*.ts", "src/components/**".
+ *
+ * @param filePath - The absolute file path to check
+ * @param glob - The glob pattern to match against
+ * @param baseDir - The base directory for relative glob patterns
+ * @returns true if the file path matches the glob pattern
+ */
+export function pathMatchesGlob(
+  filePath: string,
+  glob: string,
+  baseDir: string
+): boolean {
+  const resolvedPath = path.resolve(filePath);
+  const resolvedBase = path.resolve(baseDir);
+
+  // Ensure the path is within the base directory
+  if (!isPathWithinDirectory(resolvedPath, resolvedBase)) {
+    return false;
+  }
+
+  // Get the relative path from the base directory
+  const relativePath = path.relative(resolvedBase, resolvedPath);
+
+  // Convert glob pattern to regex
+  // Handle ** (match any directory depth), * (match any chars except /)
+  const globRegex = glob
+    .replace(/\*\*/g, "<<<GLOBSTAR>>>") // Temporary placeholder
+    .replace(/\*/g, "[^/]*") // * matches anything except /
+    .replace(/<<<GLOBSTAR>>>/g, ".*") // ** matches anything including /
+    .replace(/\//g, "\\/"); // Escape path separators
+
+  const regex = new RegExp(`^${globRegex}`);
+  return regex.test(relativePath);
+}

--- a/src/agent/utils/path.ts
+++ b/src/agent/utils/path.ts
@@ -86,16 +86,24 @@ export function pathMatchesGlob(
   }
 
   // Get the relative path from the base directory
-  const relativePath = path.relative(resolvedBase, resolvedPath);
+  // Normalize to POSIX separators for consistent matching
+  const relativePath = path.relative(resolvedBase, resolvedPath).replace(/\\/g, "/");
 
   // Convert glob pattern to regex
-  // Handle ** (match any directory depth), * (match any chars except /)
-  const globRegex = glob
-    .replace(/\*\*/g, "<<<GLOBSTAR>>>") // Temporary placeholder
-    .replace(/\*/g, "[^/]*") // * matches anything except /
-    .replace(/<<<GLOBSTAR>>>/g, ".*") // ** matches anything including /
-    .replace(/\//g, "\\/"); // Escape path separators
+  // First escape regex metacharacters (except * which we handle specially)
+  // Then handle ** (match any directory depth), * (match any chars except /)
+  try {
+    const globRegex = glob
+      .replace(/[.+?^${}()|[\]\\]/g, "\\$&") // Escape regex metacharacters
+      .replace(/\*\*/g, "<<<GLOBSTAR>>>") // Temporary placeholder
+      .replace(/\*/g, "[^/]*") // * matches anything except /
+      .replace(/<<<GLOBSTAR>>>/g, ".*") // ** matches anything including /
+      .replace(/\//g, "\\/"); // Escape path separators
 
-  const regex = new RegExp(`^${globRegex}`);
-  return regex.test(relativePath);
+    const regex = new RegExp(`^${globRegex}`);
+    return regex.test(relativePath);
+  } catch {
+    // If regex construction fails (malformed pattern), treat as no match
+    return false;
+  }
 }

--- a/src/agent/utils/shared-context.ts
+++ b/src/agent/utils/shared-context.ts
@@ -1,4 +1,4 @@
-import type { AgentMode, AutoApprove } from "../types";
+import type { AgentMode, AutoApprove, ApprovalRule } from "../types";
 
 /**
  * Mutable global state shared between prepareCall and tool approval functions.
@@ -16,8 +16,10 @@ export const sharedContext: {
   workingDirectory: string;
   mode: AgentMode;
   autoApprove: AutoApprove;
+  approvalRules: ApprovalRule[];
 } = {
   workingDirectory: process.cwd(),
   mode: "interactive",
   autoApprove: "off",
+  approvalRules: [],
 };

--- a/src/agent/utils/shared-context.ts
+++ b/src/agent/utils/shared-context.ts
@@ -9,6 +9,12 @@ import type { AgentMode, AutoApprove, ApprovalRule } from "../types";
  * background mode, check if paths are within working directory), we use this
  * global as a workaround.
  *
+ * WARNING: This global state means the agent is NOT safe for concurrent use
+ * across multiple sessions in the same process. If two `agent.stream` calls
+ * run concurrently, their approval rules, mode, and workingDirectory will
+ * interfere with each other. For now, ensure only one active session per
+ * process, or create separate agent instances per session.
+ *
  * TODO: Remove this once the AI SDK passes context to `needsApproval` functions.
  * At that point, approval functions can read from `experimental_context` directly.
  */

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -587,13 +587,14 @@ function AppContent({ options }: AppProps) {
       <ErrorDisplay error={error} />
 
       {/* Show approval panel when there's a pending approval (replaces status bar and input) */}
-      {hasPendingApproval && activeApprovalId && approvalInfo ? (
+      {hasPendingApproval && activeApprovalId && approvalInfo && pendingToolPart ? (
         <ApprovalPanel
           approvalId={activeApprovalId}
           toolType={approvalInfo.toolType}
           toolCommand={approvalInfo.toolCommand}
           toolDescription={approvalInfo.toolDescription}
           dontAskAgainPattern={approvalInfo.dontAskAgainPattern}
+          toolPart={pendingToolPart}
         />
       ) : (
         <>

--- a/src/tui/chat-context.tsx
+++ b/src/tui/chat-context.tsx
@@ -18,6 +18,7 @@ import type {
   TUIAgentCallOptions,
   TUIAgentUIMessage,
   AutoAcceptMode,
+  ApprovalRule,
 } from "./types.js";
 import { getContextLimit } from "../agent/utils/model-context-limits.js";
 
@@ -28,6 +29,7 @@ type ChatState = {
   usage: LanguageModelUsage;
   sessionUsage: LanguageModelUsage;
   contextLimit: number;
+  approvalRules: ApprovalRule[];
 };
 
 type ChatContextValue = {
@@ -35,6 +37,8 @@ type ChatContextValue = {
   state: ChatState;
   setAutoAcceptMode: (mode: AutoAcceptMode) => void;
   cycleAutoAcceptMode: () => void;
+  addApprovalRule: (rule: ApprovalRule) => void;
+  clearApprovalRules: () => void;
 };
 
 const ChatContext = createContext<ChatContextValue | undefined>(undefined);
@@ -103,10 +107,13 @@ export function ChatProvider({
   const [usage, setUsage] = useState<LanguageModelUsage>(DEFAULT_USAGE);
   const [sessionUsage, setSessionUsage] =
     useState<LanguageModelUsage>(DEFAULT_USAGE);
+  const [approvalRules, setApprovalRules] = useState<ApprovalRule[]>([]);
 
-  // Use ref to pass current autoAcceptMode to transport without recreating it
+  // Use refs to pass current values to transport without recreating it
   const autoAcceptModeRef = useRef(autoAcceptMode);
   autoAcceptModeRef.current = autoAcceptMode;
+  const approvalRulesRef = useRef(approvalRules);
+  approvalRulesRef.current = approvalRules;
 
   const contextLimit = useMemo(() => getContextLimit(model ?? ""), [model]);
 
@@ -115,12 +122,28 @@ export function ChatProvider({
     setSessionUsage((prev) => accumulateUsage(prev, newUsage));
   }, []);
 
+  const addApprovalRule = useCallback((rule: ApprovalRule) => {
+    setApprovalRules((prev) => {
+      // Avoid duplicates - check if an identical rule already exists
+      const exists = prev.some(
+        (r) => JSON.stringify(r) === JSON.stringify(rule),
+      );
+      if (exists) return prev;
+      return [...prev, rule];
+    });
+  }, []);
+
+  const clearApprovalRules = useCallback(() => {
+    setApprovalRules([]);
+  }, []);
+
   const transport = useMemo(
     () =>
       createAgentTransport({
         agent: tuiAgent,
         agentOptions,
         getAutoApprove: () => autoAcceptModeRef.current,
+        getApprovalRules: () => approvalRulesRef.current,
         onUsageUpdate: handleUsageUpdate,
       }),
     [agentOptions, handleUsageUpdate],
@@ -144,8 +167,9 @@ export function ChatProvider({
       usage,
       sessionUsage,
       contextLimit,
+      approvalRules,
     }),
-    [model, autoAcceptMode, workingDirectory, usage, sessionUsage, contextLimit],
+    [model, autoAcceptMode, workingDirectory, usage, sessionUsage, contextLimit, approvalRules],
   );
 
   const cycleAutoAcceptMode = () => {
@@ -163,6 +187,8 @@ export function ChatProvider({
         state,
         setAutoAcceptMode,
         cycleAutoAcceptMode,
+        addApprovalRule,
+        clearApprovalRules,
       }}
     >
       {children}

--- a/src/tui/components/approval-panel.tsx
+++ b/src/tui/components/approval-panel.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Box, Text, useInput } from "ink";
 import { useChat } from "@ai-sdk/react";
 import { useChatContext } from "../chat-context.js";
+import type { TUIAgentUIToolPart, ApprovalRule } from "../types.js";
+import { inferApprovalRule } from "./tool-call.js";
 
 export type ApprovalPanelProps = {
   approvalId: string;
@@ -9,6 +11,7 @@ export type ApprovalPanelProps = {
   toolCommand: string;
   toolDescription?: string;
   dontAskAgainPattern?: string;
+  toolPart?: TUIAgentUIToolPart;
 };
 
 export function ApprovalPanel({
@@ -17,9 +20,16 @@ export function ApprovalPanel({
   toolCommand,
   toolDescription,
   dontAskAgainPattern,
+  toolPart,
 }: ApprovalPanelProps) {
-  const { chat } = useChatContext();
+  const { chat, state, addApprovalRule } = useChatContext();
   const { addToolApprovalResponse } = useChat({ chat });
+
+  // Infer the approval rule from the tool part
+  const inferredRule = useMemo((): ApprovalRule | null => {
+    if (!toolPart) return null;
+    return inferApprovalRule(toolPart, state.workingDirectory);
+  }, [toolPart, state.workingDirectory]);
   const [selected, setSelected] = useState(0);
   const [reason, setReason] = useState("");
 
@@ -69,7 +79,10 @@ export function ApprovalPanel({
         // Yes
         addToolApprovalResponse({ id: approvalId, approved: true });
       } else if (selected === 1) {
-        // Yes, and don't ask again (placeholder - behaves as Yes for now)
+        // Yes, and don't ask again - add the rule then approve
+        if (inferredRule) {
+          addApprovalRule(inferredRule);
+        }
         addToolApprovalResponse({ id: approvalId, approved: true });
       }
     }

--- a/src/tui/components/approval-panel.tsx
+++ b/src/tui/components/approval-panel.tsx
@@ -30,6 +30,10 @@ export function ApprovalPanel({
     if (!toolPart) return null;
     return inferApprovalRule(toolPart, state.workingDirectory);
   }, [toolPart, state.workingDirectory]);
+  // Determine available options based on whether a rule can be inferred
+  const canSaveRule = inferredRule !== null;
+  const maxOption = canSaveRule ? 2 : 1; // 0=Yes, 1=Don't ask again (if available), last=reason
+
   const [selected, setSelected] = useState(0);
   const [reason, setReason] = useState("");
 
@@ -39,6 +43,11 @@ export function ApprovalPanel({
     setReason("");
   }, [approvalId]);
 
+  // Determine which "logical" option is selected based on available options
+  // When canSaveRule: 0=Yes, 1=Don't ask again, 2=Reason
+  // When !canSaveRule: 0=Yes, 1=Reason (skip "don't ask again")
+  const reasonOptionIndex = canSaveRule ? 2 : 1;
+
   useInput((input, key) => {
     // Handle escape to cancel (deny without reason)
     if (key.escape) {
@@ -46,8 +55,8 @@ export function ApprovalPanel({
       return;
     }
 
-    // When on the text input option (selected === 2)
-    if (selected === 2) {
+    // When on the text input option (reason)
+    if (selected === reasonOptionIndex) {
       if (key.return) {
         addToolApprovalResponse({
           id: approvalId,
@@ -57,7 +66,7 @@ export function ApprovalPanel({
       } else if (key.backspace || key.delete) {
         setReason((prev) => prev.slice(0, -1));
       } else if (key.upArrow || (key.ctrl && input === "p")) {
-        setSelected(1);
+        setSelected(reasonOptionIndex - 1);
       } else if (input && !key.ctrl && !key.meta && !key.return) {
         setReason((prev) => prev + input);
       }
@@ -69,20 +78,18 @@ export function ApprovalPanel({
       key.downArrow || input === "j" || (key.ctrl && input === "n");
 
     if (goUp) {
-      setSelected((prev) => (prev === 0 ? 2 : prev - 1));
+      setSelected((prev) => (prev === 0 ? reasonOptionIndex : prev - 1));
     }
     if (goDown) {
-      setSelected((prev) => (prev === 2 ? 0 : prev + 1));
+      setSelected((prev) => (prev === reasonOptionIndex ? 0 : prev + 1));
     }
     if (key.return) {
       if (selected === 0) {
         // Yes
         addToolApprovalResponse({ id: approvalId, approved: true });
-      } else if (selected === 1) {
+      } else if (canSaveRule && selected === 1) {
         // Yes, and don't ask again - add the rule then approve
-        if (inferredRule) {
-          addApprovalRule(inferredRule);
-        }
+        addApprovalRule(inferredRule!);
         addToolApprovalResponse({ id: approvalId, approved: true });
       }
     }
@@ -121,21 +128,23 @@ export function ApprovalPanel({
             <Text>1. Yes</Text>
           </Text>
 
-          {/* Option 2: Yes, and don't ask again */}
-          <Text>
-            <Text color="yellow">{selected === 1 ? "› " : "  "}</Text>
-            <Text>2. Yes, and don't ask again for </Text>
-            <Text bold>{dontAskAgainPattern}</Text>
-          </Text>
+          {/* Option 2: Yes, and don't ask again (only if rule can be inferred) */}
+          {canSaveRule && (
+            <Text>
+              <Text color="yellow">{selected === 1 ? "› " : "  "}</Text>
+              <Text>2. Yes, and don't ask again for </Text>
+              <Text bold>{dontAskAgainPattern}</Text>
+            </Text>
+          )}
 
-          {/* Option 3: Inline text input */}
+          {/* Option 3 (or 2 if no rule): Inline text input */}
           <Box>
-            <Text color="yellow">{selected === 2 ? "› " : "  "}</Text>
-            <Text>3. </Text>
-            {reason || selected === 2 ? (
+            <Text color="yellow">{selected === reasonOptionIndex ? "› " : "  "}</Text>
+            <Text>{canSaveRule ? "3" : "2"}. </Text>
+            {reason || selected === reasonOptionIndex ? (
               <>
                 <Text>{reason}</Text>
-                {selected === 2 && <Text color="gray">█</Text>}
+                {selected === reasonOptionIndex && <Text color="gray">█</Text>}
               </>
             ) : (
               <Text color="gray">Type here to tell Claude what to do differently</Text>
@@ -147,7 +156,7 @@ export function ApprovalPanel({
       {/* Footer hint */}
       <Box marginTop={1}>
         <Text color="gray">
-          {selected === 2 ? "Enter to submit, Esc to cancel" : "Esc to cancel"}
+          {selected === reasonOptionIndex ? "Enter to submit, Esc to cancel" : "Esc to cancel"}
         </Text>
       </Box>
     </Box>

--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -3,7 +3,8 @@ import { Box, Text, useInput } from "ink";
 import { useChat } from "@ai-sdk/react";
 import { getToolName, isTextUIPart, isToolUIPart } from "ai";
 import { useChatContext } from "../chat-context.js";
-import type { TUIAgentUIToolPart } from "../types.js";
+import type { TUIAgentUIToolPart, ApprovalRule } from "../types.js";
+import * as path from "path";
 
 export type ToolApprovalInfo = {
   toolType: string;
@@ -11,6 +12,16 @@ export type ToolApprovalInfo = {
   toolDescription?: string;
   dontAskAgainPattern?: string;
 };
+
+/**
+ * Extract command prefix for approval rules.
+ * Uses 3 tokens if second token is "run" (e.g., "bun run dev"), otherwise 2.
+ */
+function getCommandPrefix(command: string): string {
+  const tokens = command.trim().split(/\s+/);
+  const tokenCount = tokens[1] === "run" ? 3 : 2;
+  return tokens.slice(0, Math.min(tokenCount, tokens.length)).join(" ") || "this command";
+}
 
 export function getToolApprovalInfo(
   part: TUIAgentUIToolPart,
@@ -21,36 +32,47 @@ export function getToolApprovalInfo(
   switch (part.type) {
     case "tool-bash": {
       const command = String(part.input?.command ?? "");
-      // Description may be provided by Claude as additional context
       const description = (part.input as { description?: string } | undefined)
         ?.description;
-      // Extract first word of command for the pattern
-      const firstWord = command.split(" ")[0] ?? "this command";
       return {
         toolType: "Bash command",
         toolCommand: command,
         toolDescription: description,
-        dontAskAgainPattern: `${firstWord} commands in ${cwd}`,
+        dontAskAgainPattern: `${getCommandPrefix(command)} commands`,
       };
     }
 
     case "tool-write": {
       const filePath = String(part.input?.filePath ?? "");
+      // Get the directory glob pattern (matches inferApprovalRule)
+      const absolutePath = path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(cwd, filePath);
+      const relativePath = path.relative(cwd, absolutePath);
+      const dirPath = path.dirname(relativePath);
+      const glob = dirPath === "." ? "**" : `${dirPath}/**`;
       return {
         toolType: "Write file",
         toolCommand: filePath,
         toolDescription: "Create new file",
-        dontAskAgainPattern: `writes in ${cwd}`,
+        dontAskAgainPattern: `writes in ${glob}`,
       };
     }
 
     case "tool-edit": {
       const filePath = String(part.input?.filePath ?? "");
+      // Get the directory glob pattern (matches inferApprovalRule)
+      const absolutePath = path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(cwd, filePath);
+      const relativePath = path.relative(cwd, absolutePath);
+      const dirPath = path.dirname(relativePath);
+      const glob = dirPath === "." ? "**" : `${dirPath}/**`;
       return {
         toolType: "Edit file",
         toolCommand: filePath,
         toolDescription: "Modify existing file",
-        dontAskAgainPattern: `edits in ${cwd}`,
+        dontAskAgainPattern: `edits in ${glob}`,
       };
     }
 
@@ -82,6 +104,84 @@ export function getToolApprovalInfo(
         dontAskAgainPattern: `${toolName} operations`,
       };
     }
+  }
+}
+
+/**
+ * Infer an ApprovalRule from a tool part.
+ * Returns null if no suitable rule can be inferred.
+ */
+export function inferApprovalRule(
+  part: TUIAgentUIToolPart,
+  workingDirectory?: string,
+): ApprovalRule | null {
+  const cwd = workingDirectory ?? process.cwd();
+
+  switch (part.type) {
+    case "tool-bash": {
+      const command = String(part.input?.command ?? "").trim();
+      if (!command) return null;
+
+      return {
+        type: "command-prefix",
+        tool: "bash",
+        prefix: getCommandPrefix(command),
+      };
+    }
+
+    case "tool-write": {
+      const filePath = String(part.input?.filePath ?? "");
+      if (!filePath) return null;
+
+      // Extract directory glob pattern (e.g., "src/components/**")
+      const absolutePath = path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(cwd, filePath);
+      const relativePath = path.relative(cwd, absolutePath);
+      const dirPath = path.dirname(relativePath);
+
+      // Create a glob pattern for the directory
+      const glob = dirPath === "." ? "**" : `${dirPath}/**`;
+
+      return {
+        type: "path-glob",
+        tool: "write",
+        glob,
+      };
+    }
+
+    case "tool-edit": {
+      const filePath = String(part.input?.filePath ?? "");
+      if (!filePath) return null;
+
+      const absolutePath = path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(cwd, filePath);
+      const relativePath = path.relative(cwd, absolutePath);
+      const dirPath = path.dirname(relativePath);
+
+      const glob = dirPath === "." ? "**" : `${dirPath}/**`;
+
+      return {
+        type: "path-glob",
+        tool: "edit",
+        glob,
+      };
+    }
+
+    case "tool-task": {
+      const subagentType = (part.input as { subagentType?: string })?.subagentType;
+      if (!subagentType) return null;
+
+      return {
+        type: "subagent-type",
+        tool: "task",
+        subagentType,
+      };
+    }
+
+    default:
+      return null;
   }
 }
 

--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -20,7 +20,10 @@ export type ToolApprovalInfo = {
 function getCommandPrefix(command: string): string {
   const tokens = command.trim().split(/\s+/);
   const tokenCount = tokens[1] === "run" ? 3 : 2;
-  return tokens.slice(0, Math.min(tokenCount, tokens.length)).join(" ") || "this command";
+  return (
+    tokens.slice(0, Math.min(tokenCount, tokens.length)).join(" ") ||
+    "this command"
+  );
 }
 
 export function getToolApprovalInfo(
@@ -78,8 +81,7 @@ export function getToolApprovalInfo(
 
     case "tool-task": {
       const desc = String(part.input?.task ?? "Spawning subagent");
-      const subagentType = (part.input as { subagentType?: string })
-        ?.subagentType;
+      const subagentType = part.input?.subagentType;
       return {
         toolType:
           subagentType === "executor"
@@ -170,8 +172,10 @@ export function inferApprovalRule(
     }
 
     case "tool-task": {
-      const subagentType = (part.input as { subagentType?: string })?.subagentType;
-      if (!subagentType) return null;
+      const input = part.input;
+      const subagentType = input?.subagentType;
+      if (subagentType !== "explorer" && subagentType !== "executor")
+        return null;
 
       return {
         type: "subagent-type",
@@ -606,7 +610,8 @@ export function SubagentToolCall({
   part: Parameters<typeof getToolName>[0];
 }) {
   const toolName = getToolName(part);
-  const isRunning = part.state === "input-streaming" || part.state === "input-available";
+  const isRunning =
+    part.state === "input-streaming" || part.state === "input-available";
   const hasError = part.state === "output-error";
 
   // Extract a summary based on common tool input patterns
@@ -657,7 +662,9 @@ export function ToolCall({
 }) {
   const running =
     part.state === "input-streaming" || part.state === "input-available";
-  const approval = (part as { approval?: { id?: string; approved?: boolean; reason?: string } }).approval;
+  const approval = (
+    part as { approval?: { id?: string; approved?: boolean; reason?: string } }
+  ).approval;
   // Check for denial both via state and via approval object (for intermediate states)
   const denied = part.state === "output-denied" || approval?.approved === false;
   const denialReason = denied ? approval?.reason : undefined;
@@ -665,7 +672,8 @@ export function ToolCall({
   const error = part.state === "output-error" ? part.errorText : undefined;
   const approvalId = approvalRequested ? approval?.id : undefined;
   // Only show interactive approval buttons for the first pending approval
-  const isActiveApproval = approvalId != null && approvalId === activeApprovalId;
+  const isActiveApproval =
+    approvalId != null && approvalId === activeApprovalId;
 
   switch (part.type) {
     case "tool-read": {
@@ -807,27 +815,37 @@ export function ToolCall({
     }
 
     case "tool-todo_write": {
-      const todos = part.input?.todos as Array<{ id: string; content: string; status: string }> | undefined;
+      const todos = part.input?.todos as
+        | Array<{ id: string; content: string; status: string }>
+        | undefined;
       const todoCount = todos?.length ?? 0;
-      const completedCount = todos?.filter(t => t.status === "completed").length ?? 0;
-      const inProgressCount = todos?.filter(t => t.status === "in_progress").length ?? 0;
-      
+      const completedCount =
+        todos?.filter((t) => t.status === "completed").length ?? 0;
+      const inProgressCount =
+        todos?.filter((t) => t.status === "in_progress").length ?? 0;
+
       const getTodoIcon = (status: string) => {
         switch (status) {
-          case "completed": return "☒";
-          case "in_progress": return "◎";
-          default: return "☐";
+          case "completed":
+            return "☒";
+          case "in_progress":
+            return "◎";
+          default:
+            return "☐";
         }
       };
-      
+
       const getTodoColor = (status: string) => {
         switch (status) {
-          case "completed": return "gray";
-          case "in_progress": return "yellow";
-          default: return "white";
+          case "completed":
+            return "gray";
+          case "in_progress":
+            return "yellow";
+          default:
+            return "white";
         }
       };
-      
+
       return (
         <Box flexDirection="column">
           <ToolLayout
@@ -863,12 +881,13 @@ export function ToolCall({
 
     case "tool-task": {
       const desc = part.input?.task ?? "Spawning subagent";
-      const subagentType = (part.input as { subagentType?: string })?.subagentType;
+      const subagentType = part.input?.subagentType;
       const taskApprovalRequested = part.state === "approval-requested";
       const taskApprovalId = taskApprovalRequested
         ? (part as { approval?: { id: string } }).approval?.id
         : undefined;
-      const isTaskActiveApproval = taskApprovalId != null && taskApprovalId === activeApprovalId;
+      const isTaskActiveApproval =
+        taskApprovalId != null && taskApprovalId === activeApprovalId;
       const taskDenied = part.state === "output-denied";
       const taskDenialReason = taskDenied
         ? (part as { approval?: { reason?: string } }).approval?.reason
@@ -883,7 +902,7 @@ export function ToolCall({
       // Get all parts in order, filter to text and tool parts
       const messageParts = message?.parts ?? [];
       const relevantParts = messageParts.filter(
-        (p) => isToolUIPart(p) || isTextUIPart(p)
+        (p) => isToolUIPart(p) || isTextUIPart(p),
       );
       const toolParts = messageParts.filter(isToolUIPart);
 
@@ -895,29 +914,43 @@ export function ToolCall({
       const isComplete = hasOutput && !isPreliminary;
       const isStreaming = hasOutput && isPreliminary;
 
-      const dotColor = taskDenied 
-        ? "red" 
-        : taskApprovalRequested 
+      const dotColor = taskDenied
+        ? "red"
+        : taskApprovalRequested
           ? "yellow"
-          : isStreaming 
-            ? "yellow" 
-            : isComplete 
-              ? "green" 
+          : isStreaming
+            ? "yellow"
+            : isComplete
+              ? "green"
               : "yellow";
-      
+
       // Format subagent type for display
-      const subagentLabel = subagentType === "explorer" 
-        ? "Explorer" 
-        : subagentType === "executor" 
-          ? "Executor" 
-          : "Task";
+      const subagentLabel =
+        subagentType === "explorer"
+          ? "Explorer"
+          : subagentType === "executor"
+            ? "Executor"
+            : "Task";
 
       return (
         <Box flexDirection="column" marginTop={1} marginBottom={1}>
           {/* Header */}
           <Box>
-            {running || isStreaming ? <ToolSpinner /> : <Text color={dotColor}>● </Text>}
-            <Text bold color={taskDenied ? "red" : running || isStreaming || taskApprovalRequested ? "yellow" : "white"}>
+            {running || isStreaming ? (
+              <ToolSpinner />
+            ) : (
+              <Text color={dotColor}>● </Text>
+            )}
+            <Text
+              bold
+              color={
+                taskDenied
+                  ? "red"
+                  : running || isStreaming || taskApprovalRequested
+                    ? "yellow"
+                    : "white"
+              }
+            >
               {subagentLabel}
             </Text>
             <Text color="gray">(</Text>
@@ -929,7 +962,8 @@ export function ToolCall({
           {taskApprovalRequested && subagentType === "executor" && (
             <Box paddingLeft={2} marginTop={1}>
               <Text color="yellow">
-                This executor has full write access and can create, modify, and delete files.
+                This executor has full write access and can create, modify, and
+                delete files.
               </Text>
             </Box>
           )}
@@ -949,9 +983,7 @@ export function ToolCall({
             <Box flexDirection="column" paddingLeft={2} marginTop={1}>
               {hiddenCount > 0 && (
                 <Box marginBottom={1}>
-                  <Text color="gray">
-                    ... {hiddenCount} more above
-                  </Text>
+                  <Text color="gray">... {hiddenCount} more above</Text>
                 </Box>
               )}
               {visibleParts.map((p, i) => {
@@ -962,11 +994,14 @@ export function ToolCall({
                   // Show truncated text, dimmed
                   const text = p.text.trim();
                   if (!text) return null;
-                  const truncated = text.length > 80 ? text.slice(0, 80) + "..." : text;
+                  const truncated =
+                    text.length > 80 ? text.slice(0, 80) + "..." : text;
                   return (
                     <Box key={`text-${i}`} paddingLeft={1}>
                       <Text color="gray">│ </Text>
-                      <Text color="gray" dimColor>{truncated}</Text>
+                      <Text color="gray" dimColor>
+                        {truncated}
+                      </Text>
                     </Box>
                   );
                 }
@@ -979,7 +1014,9 @@ export function ToolCall({
           {isComplete && (
             <Box paddingLeft={2}>
               <Text color="gray">└ </Text>
-              <Text color="white">Complete ({toolParts.length} tool calls)</Text>
+              <Text color="white">
+                Complete ({toolParts.length} tool calls)
+              </Text>
             </Box>
           )}
 

--- a/src/tui/transport.ts
+++ b/src/tui/transport.ts
@@ -5,12 +5,13 @@ import {
   smoothStream,
   pruneMessages,
 } from "ai";
-import type { TUIAgent, TUIAgentCallOptions, TUIAgentUIMessage, AutoAcceptMode } from "./types";
+import type { TUIAgent, TUIAgentCallOptions, TUIAgentUIMessage, AutoAcceptMode, ApprovalRule } from "./types";
 
 export type AgentTransportOptions = {
   agent: TUIAgent;
   agentOptions: TUIAgentCallOptions;
   getAutoApprove?: () => AutoAcceptMode;
+  getApprovalRules?: () => ApprovalRule[];
   onUsageUpdate?: (usage: LanguageModelUsage) => void;
 };
 
@@ -18,6 +19,7 @@ export function createAgentTransport({
   agent,
   agentOptions,
   getAutoApprove,
+  getApprovalRules,
   onUsageUpdate,
 }: AgentTransportOptions): ChatTransport<TUIAgentUIMessage> {
   return {
@@ -34,12 +36,13 @@ export function createAgentTransport({
         emptyMessages: "remove",
       });
 
-      // Get current autoApprove setting at request time
+      // Get current settings at request time
       const autoApprove = getAutoApprove?.() ?? "off";
+      const approvalRules = getApprovalRules?.() ?? [];
 
       const result = await agent.stream({
         messages: prunedMessages,
-        options: { ...agentOptions, autoApprove },
+        options: { ...agentOptions, autoApprove, approvalRules },
         abortSignal: abortSignal ?? undefined,
         experimental_transform: smoothStream(),
       });

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -28,6 +28,9 @@ export type TUIAgentUIToolPart =
 /* --- */
 export type AutoAcceptMode = "off" | "edits" | "all";
 
+// Re-export ApprovalRule for client-side use
+export type { ApprovalRule } from "../agent/types";
+
 export type TUIOptions = {
   /** Initial prompt to run (for one-shot mode) */
   initialPrompt?: string;

--- a/todos.txt
+++ b/todos.txt
@@ -24,6 +24,7 @@
 - [x] when going through suggestions, you should be able to use ctrl+n to go through to hidden files
 - [ ] command+enter should only delete until the end of the line
 - [x] sandbox adapter (sandbox.readFile) -> could be mapped to native fs or sandbox command (can live on the experimental_context too)
+- [ ] create action bullet has no space... 
 
 ---
 


### PR DESCRIPTION
Implement session-based approval rules that allow users to save patterns (e.g., "bun test", "src/components/**") and auto-approve matching tool requests without manual confirmation.

- Add `ApprovalRule` schema (command-prefix, path-glob, subagent-type) to call options and `sharedContext`
- Update each tool's `needsApproval` function to check rules before requiring approval
- Add client-side state and pass rules via transport like `autoApprove`
- Infer rules from tool args and implement "don't ask again" functionality in approval panel
- Maintain safety defaults: rules only apply within working directory, bash safety checks remain