### PR TITLE
Redesign bash tool output to show last 3 lines inline

### DIFF
--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -792,25 +792,90 @@ export function ToolCall({
       const command = String(part.input?.command ?? "");
       const exitCode =
         part.state === "output-available" ? part.output?.exitCode : undefined;
+      const stdout = part.state === "output-available" ? part.output?.stdout : undefined;
+      const stderr = part.state === "output-available" ? part.output?.stderr : undefined;
+      const hasOutput = stdout || stderr;
+      const isError = exitCode !== undefined && exitCode !== 0;
+
+      // Combine stdout and stderr, show last 3 lines
+      const combinedOutput = [stdout, stderr].filter(Boolean).join("\n").trim();
+      const allLines = combinedOutput.split("\n");
+      const outputLines = allLines.slice(-3); // Last 3 lines
+      const hasMoreLines = allLines.length > 3;
+
       return (
-        <ToolLayout
-          name="Bash"
-          summary={command || "..."}
-          output={
-            exitCode !== undefined && (
-              <Text color="white">
-                {exitCode === 0 ? "Command succeeded" : `Exit code ${exitCode}`}
+        <Box flexDirection="column" marginTop={1} marginBottom={1}>
+          <Box>
+            {running ? <ToolSpinner /> : <Text color={denied ? "red" : approvalRequested ? "yellow" : isError ? "red" : "green"}>● </Text>}
+            <Text
+              bold
+              color={denied ? "red" : running || approvalRequested ? "yellow" : "white"}
+            >
+              Bash
+            </Text>
+            <Text color="gray">(</Text>
+            <Text color="cyan">{command.length > 60 ? command.slice(0, 60) + "…" : command || "..."}</Text>
+            <Text color="gray">)</Text>
+          </Box>
+
+          {/* Show Running/Waiting status for approval-requested tools */}
+          {approvalRequested && (
+            <Box paddingLeft={2}>
+              <Text color="gray">└ </Text>
+              <Text color="gray">{isActiveApproval ? "Running…" : "Waiting…"}</Text>
+            </Box>
+          )}
+
+          {/* Show output when completed */}
+          {part.state === "output-available" && !approvalRequested && !denied && (
+            <Box flexDirection="column" paddingLeft={2}>
+              {isError && (
+                <Box>
+                  <Text color="gray">└ </Text>
+                  <Text color="red">Error: Exit code {exitCode}</Text>
+                </Box>
+              )}
+              {hasOutput ? (
+                <Box flexDirection="column">
+                  {hasMoreLines && (
+                    <Box paddingLeft={isError ? 2 : 0}>
+                      <Text color="gray">└ </Text>
+                      <Text color="gray">...</Text>
+                    </Box>
+                  )}
+                  {outputLines.map((line, i) => (
+                    <Box key={i} paddingLeft={isError ? 2 : 0}>
+                      {!hasMoreLines && !isError && i === 0 && <Text color="gray">└ </Text>}
+                      {(hasMoreLines || isError || i > 0) && <Text>  </Text>}
+                      <Text color={isError ? "red" : "white"}>{line.slice(0, 100)}</Text>
+                    </Box>
+                  ))}
+                </Box>
+              ) : !isError && (
+                <Box>
+                  <Text color="gray">└ </Text>
+                  <Text color="gray">(No content)</Text>
+                </Box>
+              )}
+            </Box>
+          )}
+
+          {denied && (
+            <Box paddingLeft={2}>
+              <Text color="gray">└ </Text>
+              <Text color="red">
+                Denied{denialReason ? `: ${denialReason}` : ""}
               </Text>
-            )
-          }
-          error={error}
-          running={running}
-          denied={denied}
-          denialReason={denialReason}
-          approvalRequested={approvalRequested}
-          approvalId={approvalId}
-          isActiveApproval={isActiveApproval}
-        />
+            </Box>
+          )}
+
+          {error && (
+            <Box paddingLeft={2}>
+              <Text color="gray">└ </Text>
+              <Text color="red">Error: {error.slice(0, 80)}</Text>
+            </Box>
+          )}
+        </Box>
       );
     }
 


### PR DESCRIPTION
Replace ToolLayout wrapper with custom Box layout to display bash command output inline.

- Extract stdout/stderr and display last 3 lines of combined output instead of just exit code
- Show visual status indicators: spinner for running, colored dot for success/error/denied states
- Truncate long commands and output lines to improve readability
- Display helpful messages for approval-requested, denied, and error states with proper indentation