### PR TITLE
Export TaskToolUIPart type and improve type safety

### DIFF
--- a/src/agent/tools/task-delegation/task.ts
+++ b/src/agent/tools/task-delegation/task.ts
@@ -1,4 +1,4 @@
-import { tool, readUIMessageStream } from "ai";
+import { tool, readUIMessageStream, type UIToolInvocation } from "ai";
 import { z } from "zod";
 import { explorerSubagent } from "./subagents/explorer";
 import { executorSubagent } from "./subagents/executor";
@@ -137,3 +137,5 @@ NOTE: The executor subagent requires user approval before running because it has
     return { type: "text", value: lastTextPart.text };
   },
 });
+
+export type TaskToolUIPart = UIToolInvocation<typeof taskTool>;

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo, memo } from "react";
 import { Box, Text, useApp, useInput } from "ink";
-import {
-  isToolUIPart,
-  getToolName,
-  type FileUIPart,
-} from "ai";
+import { isToolUIPart, getToolName, type FileUIPart } from "ai";
 import { useChat } from "@ai-sdk/react";
 import { renderMarkdown } from "./lib/markdown.js";
 import { useChatContext } from "./chat-context.js";
@@ -25,6 +21,7 @@ import type {
   TUIAgentUIMessage,
   TUIAgentUIToolPart,
 } from "./types.js";
+import type { TaskToolUIPart } from "../agent/tools/task-delegation/task.js";
 
 type AppProps = {
   options: TUIOptions;
@@ -60,7 +57,7 @@ const TextPart = memo(function TextPart({
       {isExpanded && timestamp && model && (
         <Box marginLeft={2} flexShrink={0}>
           <Text color="gray">
-            {formatTime(timestamp)}   {model}
+            {formatTime(timestamp)} {model}
           </Text>
         </Box>
       )}
@@ -104,7 +101,13 @@ function ToolPartWrapper({
   activeApprovalId: string | null;
   isExpanded: boolean;
 }) {
-  return <ToolCall part={part} activeApprovalId={activeApprovalId} isExpanded={isExpanded} />;
+  return (
+    <ToolCall
+      part={part}
+      activeApprovalId={activeApprovalId}
+      isExpanded={isExpanded}
+    />
+  );
 }
 
 type RenderPartOptions = {
@@ -146,7 +149,12 @@ function renderPart(
 
   if (isToolUIPart(part)) {
     return (
-      <ToolPartWrapper key={key} part={part} activeApprovalId={activeApprovalId} isExpanded={isExpanded} />
+      <ToolPartWrapper
+        key={key}
+        part={part}
+        activeApprovalId={activeApprovalId}
+        isExpanded={isExpanded}
+      />
     );
   }
 
@@ -187,7 +195,7 @@ const UserMessage = memo(function UserMessage({
     .join("");
 
   const imageCount = message.parts.filter(
-    (p) => p.type === "file" && (p as FileUIPart).mediaType?.startsWith("image/")
+    (p) => p.type === "file" && p.mediaType?.startsWith("image/"),
   ).length;
 
   return (
@@ -198,7 +206,9 @@ const UserMessage = memo(function UserMessage({
             &gt;{" "}
           </Text>
           <Text color="blue">
-            {imageCount === 1 ? "[1 image attached]" : `[${imageCount} images attached]`}
+            {imageCount === 1
+              ? "[1 image attached]"
+              : `[${imageCount} images attached]`}
           </Text>
         </Box>
       )}
@@ -219,7 +229,7 @@ const UserMessage = memo(function UserMessage({
 // Group consecutive task parts together while preserving order
 type RenderGroup =
   | { type: "part"; part: TUIAgentUIMessagePart; index: number }
-  | { type: "task-group"; tasks: TUIAgentUIToolPart[]; startIndex: number };
+  | { type: "task-group"; tasks: TaskToolUIPart[]; startIndex: number };
 
 const AssistantMessage = memo(function AssistantMessage({
   message,
@@ -260,20 +270,19 @@ const AssistantMessage = memo(function AssistantMessage({
 
     return {
       hasReasoning: foundReasoning,
-      isReasoningComplete: foundReasoning && (hasContentAfterReasoning || !isStreaming),
+      isReasoningComplete:
+        foundReasoning && (hasContentAfterReasoning || !isStreaming),
     };
   }, [message.parts, isStreaming]);
 
   // Group consecutive task parts together, keeping them in linear order
   const renderGroups = useMemo(() => {
     const groups: RenderGroup[] = [];
-    let currentTaskGroup: TUIAgentUIToolPart[] = [];
+    let currentTaskGroup: TaskToolUIPart[] = [];
     let taskGroupStartIndex = 0;
 
     message.parts.forEach((part, index) => {
-      const isTask = isToolUIPart(part) && part.type === "tool-task";
-
-      if (isTask) {
+      if (isToolUIPart(part) && part.type === "tool-task") {
         if (currentTaskGroup.length === 0) {
           taskGroupStartIndex = index;
         }
@@ -440,7 +449,7 @@ const StreamingStatusBar = memo(function StreamingStatusBar({
   // Extract todos from the most recent assistant message in the current exchange
   const todos = useMemo(
     () => extractTodosFromLastAssistantMessage(messages),
-    [messages]
+    [messages],
   );
 
   // Force re-render periodically to update thinking duration while thinking
@@ -478,7 +487,15 @@ const InterruptedIndicator = memo(function InterruptedIndicator() {
 
 const ExpandedViewIndicator = memo(function ExpandedViewIndicator() {
   return (
-    <Box marginTop={1} borderStyle="single" borderColor="gray" borderTop borderBottom={false} borderLeft={false} borderRight={false}>
+    <Box
+      marginTop={1}
+      borderStyle="single"
+      borderColor="gray"
+      borderTop
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+    >
       <Text color="gray">Showing detailed transcript · ctrl+o to toggle</Text>
     </Box>
   );
@@ -504,27 +521,32 @@ function AppContent({ options }: AppProps) {
     }
   }, [isStreaming]);
 
-  const { hasPendingApproval, activeApprovalId, pendingToolPart } = useMemo(() => {
-    const lastMessage = messages[messages.length - 1];
-    if (lastMessage?.role === "assistant") {
-      for (const p of lastMessage.parts) {
-        if (isToolUIPart(p) && p.state === "approval-requested") {
-          const approval = (p as { approval?: { id: string } }).approval;
-          return {
-            hasPendingApproval: true,
-            activeApprovalId: approval?.id ?? null,
-            pendingToolPart: p,
-          };
+  const { hasPendingApproval, activeApprovalId, pendingToolPart } =
+    useMemo(() => {
+      const lastMessage = messages[messages.length - 1];
+      if (lastMessage?.role === "assistant") {
+        for (const p of lastMessage.parts) {
+          if (isToolUIPart(p) && p.state === "approval-requested") {
+            const approval = (p as { approval?: { id: string } }).approval;
+            return {
+              hasPendingApproval: true,
+              activeApprovalId: approval?.id ?? null,
+              pendingToolPart: p,
+            };
+          }
         }
       }
-    }
-    return { hasPendingApproval: false, activeApprovalId: null, pendingToolPart: null };
-  }, [messages]);
+      return {
+        hasPendingApproval: false,
+        activeApprovalId: null,
+        pendingToolPart: null,
+      };
+    }, [messages]);
 
   // Extract todos for standalone display when not streaming
   const todos = useMemo(
     () => extractTodosFromLastAssistantMessage(messages),
-    [messages]
+    [messages],
   );
 
   // Get approval info for the pending tool
@@ -587,7 +609,10 @@ function AppContent({ options }: AppProps) {
       <ErrorDisplay error={error} />
 
       {/* Show approval panel when there's a pending approval (replaces status bar and input) */}
-      {hasPendingApproval && activeApprovalId && approvalInfo && pendingToolPart ? (
+      {hasPendingApproval &&
+      activeApprovalId &&
+      approvalInfo &&
+      pendingToolPart ? (
         <ApprovalPanel
           approvalId={activeApprovalId}
           toolType={approvalInfo.toolType}
@@ -599,9 +624,7 @@ function AppContent({ options }: AppProps) {
       ) : (
         <>
           {/* Show streaming status bar when streaming */}
-          {isStreaming && (
-            <StreamingStatusBar messages={messages} />
-          )}
+          {isStreaming && <StreamingStatusBar messages={messages} />}
 
           {/* Show standalone todo list when not streaming and has todos */}
           {!isStreaming && todos && todos.length > 0 && (

--- a/src/tui/components/task-group-view.tsx
+++ b/src/tui/components/task-group-view.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Box, Text } from "ink";
-import { getToolName, isToolUIPart, isTextUIPart } from "ai";
-import type { TUIAgentUIToolPart } from "../types.js";
+import { getToolName, isToolUIPart } from "ai";
+import type { TaskToolUIPart } from "../../agent/tools/task-delegation/task.js";
 import { ApprovalButtons } from "./tool-call.js";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -57,7 +57,7 @@ function useTaskTiming(isRunning: boolean) {
     const interval = setInterval(() => {
       if (startTimeRef.current) {
         setElapsedSeconds(
-          Math.floor((Date.now() - startTimeRef.current) / 1000)
+          Math.floor((Date.now() - startTimeRef.current) / 1000),
         );
       }
     }, 1000);
@@ -76,7 +76,7 @@ type TaskStatus =
   | "approval-requested"
   | "denied";
 
-function getTaskStatus(part: TUIAgentUIToolPart): TaskStatus {
+function getTaskStatus(part: TaskToolUIPart): TaskStatus {
   if (part.state === "approval-requested") return "approval-requested";
   if (part.state === "output-denied") return "denied";
   if (part.state === "output-error") return "error";
@@ -91,22 +91,18 @@ function getTaskStatus(part: TUIAgentUIToolPart): TaskStatus {
   return "pending";
 }
 
-// Type for task output which contains parts from sub-agent
-type TaskOutputPart = Parameters<typeof isToolUIPart>[0];
-type TaskOutput = { parts?: TaskOutputPart[] };
-
-function countTaskTools(part: TUIAgentUIToolPart): number {
-  const message = part.output as TaskOutput | undefined;
-  if (!message?.parts) {
-    return 0;
-  }
+function countTaskTools(part: TaskToolUIPart): number {
+  if (part.state !== "output-available") return 0;
+  const message = part.output;
+  if (!message?.parts) return 0;
   return message.parts.filter(isToolUIPart).length;
 }
 
 function getLastToolInfo(
-  part: TUIAgentUIToolPart
+  part: TaskToolUIPart,
 ): { name: string; summary: string } | null {
-  const message = part.output as TaskOutput | undefined;
+  if (part.state !== "output-available") return null;
+  const message = part.output;
   if (!message?.parts) return null;
 
   const toolParts = message.parts.filter(isToolUIPart);
@@ -156,7 +152,7 @@ function TaskItem({
   isLast,
   activeApprovalId,
 }: {
-  part: TUIAgentUIToolPart;
+  part: TaskToolUIPart;
   isLast: boolean;
   activeApprovalId: string | null;
 }) {
@@ -166,25 +162,19 @@ function TaskItem({
   const toolCount = countTaskTools(part);
   const lastTool = getLastToolInfo(part);
 
-  const desc =
-    (part.input as { description?: string })?.description ??
-    (part.input as { task?: string })?.task ??
-    "Task";
+  const desc = part.input?.task ?? "Task";
 
-  const subagentType = (part.input as { subagentType?: string })?.subagentType;
+  const subagentType = part.input?.subagentType;
 
   // Handle approval state
   const approvalRequested = part.state === "approval-requested";
-  const approvalId = approvalRequested
-    ? (part as { approval?: { id: string } }).approval?.id
-    : undefined;
-  const isActiveApproval = approvalId != null && approvalId === activeApprovalId;
+  const approvalId = approvalRequested ? part.approval?.id : undefined;
+  const isActiveApproval =
+    approvalId != null && approvalId === activeApprovalId;
 
   // Handle denial
   const denied = part.state === "output-denied";
-  const denialReason = denied
-    ? (part as { approval?: { reason?: string } }).approval?.reason
-    : undefined;
+  const denialReason = denied ? part.approval?.reason : undefined;
 
   const treeChar = isLast ? "└─" : "├─";
   const continueChar = isLast ? "   " : "│  ";
@@ -197,7 +187,10 @@ function TaskItem({
     nestedStatus = denialReason ? `Denied: ${denialReason}` : "Denied";
   } else if (approvalRequested) {
     nestedStatus = "Awaiting approval...";
-  } else if (status === "pending" || (status === "running" && toolCount === 0)) {
+  } else if (
+    status === "pending" ||
+    (status === "running" && toolCount === 0)
+  ) {
     nestedStatus = "Initializing...";
   } else if (lastTool) {
     nestedStatus = lastTool.summary
@@ -213,11 +206,7 @@ function TaskItem({
         <TaskStatusIndicator status={status} />
         <Text> </Text>
         <Text
-          color={
-            status === "error" || status === "denied"
-              ? "red"
-              : "white"
-          }
+          color={status === "error" || status === "denied" ? "red" : "white"}
         >
           {desc}
         </Text>
@@ -225,9 +214,7 @@ function TaskItem({
           {" "}
           - {toolCount} tool{toolCount !== 1 ? "s" : ""}
         </Text>
-        {approvalRequested && (
-          <Text color="yellow"> [NEEDS APPROVAL]</Text>
-        )}
+        {approvalRequested && <Text color="yellow"> [NEEDS APPROVAL]</Text>}
         {isRunning && elapsedSeconds > 0 && (
           <Text color="gray"> - {formatTime(elapsedSeconds)}</Text>
         )}
@@ -237,7 +224,8 @@ function TaskItem({
       {approvalRequested && subagentType === "executor" && (
         <Box paddingLeft={4}>
           <Text color="yellow">
-            This executor has full write access and can create, modify, and delete files.
+            This executor has full write access and can create, modify, and
+            delete files.
           </Text>
         </Box>
       )}
@@ -259,23 +247,25 @@ function TaskItem({
 }
 
 type TaskGroupViewProps = {
-  taskParts: TUIAgentUIToolPart[];
+  taskParts: TaskToolUIPart[];
   activeApprovalId: string | null;
 };
 
-export function TaskGroupView({ taskParts, activeApprovalId }: TaskGroupViewProps) {
+export function TaskGroupView({
+  taskParts,
+  activeApprovalId,
+}: TaskGroupViewProps) {
   if (taskParts.length === 0) return null;
 
   // Count different states
   const hasApprovalPending = taskParts.some(
-    (p) => getTaskStatus(p) === "approval-requested"
+    (p) => getTaskStatus(p) === "approval-requested",
   );
   const runningCount = taskParts.filter((p) => {
     const status = getTaskStatus(p);
     return status === "running" || status === "pending";
   }).length;
-  const allComplete =
-    runningCount === 0 && !hasApprovalPending;
+  const allComplete = runningCount === 0 && !hasApprovalPending;
 
   // Determine header text
   let headerText: string;

--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -35,12 +35,9 @@ export function getToolApprovalInfo(
   switch (part.type) {
     case "tool-bash": {
       const command = String(part.input?.command ?? "");
-      const description = (part.input as { description?: string } | undefined)
-        ?.description;
       return {
         toolType: "Bash command",
         toolCommand: command,
-        toolDescription: description,
         dontAskAgainPattern: `${getCommandPrefix(command)} commands`,
       };
     }
@@ -662,9 +659,7 @@ export function ToolCall({
 }) {
   const running =
     part.state === "input-streaming" || part.state === "input-available";
-  const approval = (
-    part as { approval?: { id?: string; approved?: boolean; reason?: string } }
-  ).approval;
+  const approval = part.approval;
   // Check for denial both via state and via approval object (for intermediate states)
   const denied = part.state === "output-denied" || approval?.approved === false;
   const denialReason = denied ? approval?.reason : undefined;
@@ -792,8 +787,10 @@ export function ToolCall({
       const command = String(part.input?.command ?? "");
       const exitCode =
         part.state === "output-available" ? part.output?.exitCode : undefined;
-      const stdout = part.state === "output-available" ? part.output?.stdout : undefined;
-      const stderr = part.state === "output-available" ? part.output?.stderr : undefined;
+      const stdout =
+        part.state === "output-available" ? part.output?.stdout : undefined;
+      const stderr =
+        part.state === "output-available" ? part.output?.stderr : undefined;
       const hasOutput = stdout || stderr;
       const isError = exitCode !== undefined && exitCode !== 0;
 
@@ -806,15 +803,41 @@ export function ToolCall({
       return (
         <Box flexDirection="column" marginTop={1} marginBottom={1}>
           <Box>
-            {running ? <ToolSpinner /> : <Text color={denied ? "red" : approvalRequested ? "yellow" : isError ? "red" : "green"}>● </Text>}
+            {running ? (
+              <ToolSpinner />
+            ) : (
+              <Text
+                color={
+                  denied
+                    ? "red"
+                    : approvalRequested
+                      ? "yellow"
+                      : isError
+                        ? "red"
+                        : "green"
+                }
+              >
+                ●{" "}
+              </Text>
+            )}
             <Text
               bold
-              color={denied ? "red" : running || approvalRequested ? "yellow" : "white"}
+              color={
+                denied
+                  ? "red"
+                  : running || approvalRequested
+                    ? "yellow"
+                    : "white"
+              }
             >
               Bash
             </Text>
             <Text color="gray">(</Text>
-            <Text color="cyan">{command.length > 60 ? command.slice(0, 60) + "…" : command || "..."}</Text>
+            <Text color="cyan">
+              {command.length > 60
+                ? command.slice(0, 60) + "…"
+                : command || "..."}
+            </Text>
             <Text color="gray">)</Text>
           </Box>
 
@@ -822,43 +845,53 @@ export function ToolCall({
           {approvalRequested && (
             <Box paddingLeft={2}>
               <Text color="gray">└ </Text>
-              <Text color="gray">{isActiveApproval ? "Running…" : "Waiting…"}</Text>
+              <Text color="gray">
+                {isActiveApproval ? "Running…" : "Waiting…"}
+              </Text>
             </Box>
           )}
 
           {/* Show output when completed */}
-          {part.state === "output-available" && !approvalRequested && !denied && (
-            <Box flexDirection="column" paddingLeft={2}>
-              {isError && (
-                <Box>
-                  <Text color="gray">└ </Text>
-                  <Text color="red">Error: Exit code {exitCode}</Text>
-                </Box>
-              )}
-              {hasOutput ? (
-                <Box flexDirection="column">
-                  {hasMoreLines && (
-                    <Box paddingLeft={isError ? 2 : 0}>
+          {part.state === "output-available" &&
+            !approvalRequested &&
+            !denied && (
+              <Box flexDirection="column" paddingLeft={2}>
+                {isError && (
+                  <Box>
+                    <Text color="gray">└ </Text>
+                    <Text color="red">Error: Exit code {exitCode}</Text>
+                  </Box>
+                )}
+                {hasOutput ? (
+                  <Box flexDirection="column">
+                    {hasMoreLines && (
+                      <Box paddingLeft={isError ? 2 : 0}>
+                        <Text color="gray">└ </Text>
+                        <Text color="gray">...</Text>
+                      </Box>
+                    )}
+                    {outputLines.map((line, i) => (
+                      <Box key={i} paddingLeft={isError ? 2 : 0}>
+                        {!hasMoreLines && !isError && i === 0 && (
+                          <Text color="gray">└ </Text>
+                        )}
+                        {(hasMoreLines || isError || i > 0) && <Text> </Text>}
+                        <Text color={isError ? "red" : "white"}>
+                          {line.slice(0, 100)}
+                        </Text>
+                      </Box>
+                    ))}
+                  </Box>
+                ) : (
+                  !isError && (
+                    <Box>
                       <Text color="gray">└ </Text>
-                      <Text color="gray">...</Text>
+                      <Text color="gray">(No content)</Text>
                     </Box>
-                  )}
-                  {outputLines.map((line, i) => (
-                    <Box key={i} paddingLeft={isError ? 2 : 0}>
-                      {!hasMoreLines && !isError && i === 0 && <Text color="gray">└ </Text>}
-                      {(hasMoreLines || isError || i > 0) && <Text>  </Text>}
-                      <Text color={isError ? "red" : "white"}>{line.slice(0, 100)}</Text>
-                    </Box>
-                  ))}
-                </Box>
-              ) : !isError && (
-                <Box>
-                  <Text color="gray">└ </Text>
-                  <Text color="gray">(No content)</Text>
-                </Box>
-              )}
-            </Box>
-          )}
+                  )
+                )}
+              </Box>
+            )}
 
           {denied && (
             <Box paddingLeft={2}>
@@ -949,14 +982,12 @@ export function ToolCall({
       const subagentType = part.input?.subagentType;
       const taskApprovalRequested = part.state === "approval-requested";
       const taskApprovalId = taskApprovalRequested
-        ? (part as { approval?: { id: string } }).approval?.id
+        ? part.approval?.id
         : undefined;
       const isTaskActiveApproval =
         taskApprovalId != null && taskApprovalId === activeApprovalId;
       const taskDenied = part.state === "output-denied";
-      const taskDenialReason = taskDenied
-        ? (part as { approval?: { reason?: string } }).approval?.reason
-        : undefined;
+      const taskDenialReason = taskDenied ? part.approval?.reason : undefined;
 
       // The output is a UIMessage with parts (text, tool-invocation, etc.)
       // Preliminary results have preliminary: true, final result has preliminary: false/undefined


### PR DESCRIPTION
Exports a new `TaskToolUIPart` type from the task delegation module and uses it throughout the codebase to improve type safety when handling task-related UI parts.

- Added `TaskToolUIPart` type export in task.ts for proper typing of task tool invocations
- Replaced loose type casting with the new typed export in app.tsx and task-group-view.tsx
- Simplified property access by removing unnecessary type assertions (e.g., `part.approval?.id` instead of casting)
- Applied consistent code formatting and line-breaking improvements throughout