### PR TITLE
Remove yellow status color from tool indicators

### DIFF
--- a/src/tui/components/tool-call.tsx
+++ b/src/tui/components/tool-call.tsx
@@ -330,7 +330,7 @@ function ToolLayout({
         <Text
           bold
           color={
-            denied ? "red" : running || approvalRequested ? "yellow" : "white"
+            denied ? "red" : "white"
           }
         >
           {name}
@@ -825,9 +825,7 @@ export function ToolCall({
               color={
                 denied
                   ? "red"
-                  : running || approvalRequested
-                    ? "yellow"
-                    : "white"
+                  : "white"
               }
             >
               Bash
@@ -1042,9 +1040,7 @@ export function ToolCall({
               color={
                 taskDenied
                   ? "red"
-                  : running || isStreaming || taskApprovalRequested
-                    ? "yellow"
-                    : "white"
+                  : "white"
               }
             >
               {subagentLabel}


### PR DESCRIPTION
**Summary:** Simplify tool status coloring by removing the yellow state for running/approval-requested states, keeping only red for denied and white for all other states.

- Remove yellow color conditionals for `running`, `approvalRequested`, `isStreaming`, and `taskApprovalRequested` states across three tool indicator components
- Consolidate status colors to binary: red (denied) or white (everything else)
- Affects `ToolLayout`, main tool name display, and subagent label components