### PR TITLE
Add diff preview to approval panel for file edits

### DIFF
--- a/src/agent/tools/file-system/write.ts
+++ b/src/agent/tools/file-system/write.ts
@@ -18,6 +18,10 @@ const editInputSchema = z.object({
     .boolean()
     .optional()
     .describe("Replace all occurrences. Default: false"),
+  startLine: z
+    .number()
+    .optional()
+    .describe("Line number where oldString starts (for diff display)"),
 });
 
 type WriteInput = z.infer<typeof writeInputSchema>;
@@ -205,6 +209,7 @@ USAGE:
 - Provide oldString as the EXACT text to replace, including whitespace and indentation
 - By default, oldString must be UNIQUE in the file; otherwise the edit will fail
 - Use replaceAll: true to change ALL occurrences of oldString in the file (e.g., for a rename)
+- ALWAYS provide startLine: the line number where oldString begins (from the read output)
 
 IMPORTANT:
 - Preserve exact indentation and spacing from the file's content as returned by readFileTool
@@ -213,8 +218,8 @@ IMPORTANT:
 - Paths outside the working directory require approval
 
 EXAMPLES:
-- Replace a single function call: filePath: "/Users/username/project/src/auth.ts", oldString: "login(user, password)", newString: "loginWithAudit(user, password)"
-- Rename a variable throughout a file: filePath: "/Users/username/project/src/api.ts", oldString: "oldApiClient", newString: "newApiClient", replaceAll: true`,
+- Replace a single function call: filePath: "/Users/username/project/src/auth.ts", oldString: "login(user, password)", newString: "loginWithAudit(user, password)", startLine: 42
+- Rename a variable throughout a file: filePath: "/Users/username/project/src/api.ts", oldString: "oldApiClient", newString: "newApiClient", replaceAll: true, startLine: 15`,
   inputSchema: editInputSchema,
   execute: async ({ filePath, oldString, newString, replaceAll = false }, { experimental_context }) => {
     const sandbox = getSandbox(experimental_context);
@@ -250,6 +255,10 @@ EXAMPLES:
         };
       }
 
+      // Calculate starting line number for the edit
+      const matchIndex = content.indexOf(oldString);
+      const startLine = content.slice(0, matchIndex).split("\n").length;
+
       const newContent = replaceAll
         ? content.replaceAll(oldString, newString)
         : content.replace(oldString, newString);
@@ -260,6 +269,7 @@ EXAMPLES:
         success: true,
         path: absolutePath,
         replacements: replaceAll ? occurrences : 1,
+        startLine,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/tui/components/approval-panel.tsx
+++ b/src/tui/components/approval-panel.tsx
@@ -5,6 +5,104 @@ import { useChatContext } from "../chat-context.js";
 import type { TUIAgentUIToolPart, ApprovalRule } from "../types.js";
 import { inferApprovalRule } from "./tool-call.js";
 
+// Display constants
+const DIFF_MAX_WRITE_LINES = 10;
+const DIFF_MAX_EDIT_LINES = 15;
+const DIFF_LINE_MAX_WIDTH = 80;
+
+type DiffLine = {
+  type: "addition" | "removal" | "separator";
+  lineNumber?: number;
+  content: string;
+};
+
+function createWriteDiffLines(content: string): DiffLine[] {
+  if (!content) return [];
+
+  const contentLines = content.split("\n");
+  // Handle empty string case where split returns [""]
+  if (contentLines.length === 1 && contentLines[0] === "") return [];
+
+  const result: DiffLine[] = [];
+
+  if (contentLines.length <= DIFF_MAX_WRITE_LINES) {
+    contentLines.forEach((line, i) => {
+      result.push({ type: "addition", lineNumber: i + 1, content: line });
+    });
+  } else {
+    // Show first few and last few lines with separator
+    const showStart = Math.floor(DIFF_MAX_WRITE_LINES / 2);
+    const showEnd = DIFF_MAX_WRITE_LINES - showStart;
+
+    for (let i = 0; i < showStart; i++) {
+      const line = contentLines[i];
+      if (line !== undefined) {
+        result.push({ type: "addition", lineNumber: i + 1, content: line });
+      }
+    }
+
+    result.push({ type: "separator", content: "..." });
+
+    for (let i = contentLines.length - showEnd; i < contentLines.length; i++) {
+      const line = contentLines[i];
+      if (line !== undefined) {
+        result.push({ type: "addition", lineNumber: i + 1, content: line });
+      }
+    }
+  }
+
+  return result;
+}
+
+function createEditDiffLines(
+  oldString: string,
+  newString: string,
+  startLine: number = 1,
+): { lines: DiffLine[]; additions: number; removals: number } {
+  // Handle empty strings
+  const oldLines =
+    oldString && !(oldString.split("\n").length === 1 && oldString === "")
+      ? oldString.split("\n")
+      : [];
+  const newLines =
+    newString && !(newString.split("\n").length === 1 && newString === "")
+      ? newString.split("\n")
+      : [];
+
+  const removals = oldLines.length;
+  const additions = newLines.length;
+
+  const allLines: DiffLine[] = [];
+
+  oldLines.forEach((line, i) => {
+    allLines.push({ type: "removal", lineNumber: startLine + i, content: line });
+  });
+
+  newLines.forEach((line, i) => {
+    allLines.push({ type: "addition", lineNumber: startLine + i, content: line });
+  });
+
+  // Limit total lines
+  if (allLines.length <= DIFF_MAX_EDIT_LINES) {
+    return { lines: allLines, additions, removals };
+  }
+
+  // Show first portion and last portion with separator
+  const result: DiffLine[] = [];
+  const half = Math.floor(DIFF_MAX_EDIT_LINES / 2);
+  for (let i = 0; i < half; i++) {
+    const line = allLines[i];
+    if (line) result.push(line);
+  }
+  result.push({ type: "separator", content: "..." });
+  for (let i = allLines.length - half; i < allLines.length; i++) {
+    const line = allLines[i];
+    if (line) result.push(line);
+  }
+
+  return { lines: result, additions, removals };
+}
+
 export type ApprovalPanelProps = {
   approvalId: string;
   toolType: string;
@@ -47,6 +145,27 @@ export function ApprovalPanel({
   // When canSaveRule: 0=Yes, 1=Don't ask again, 2=Reason
   // When !canSaveRule: 0=Yes, 1=Reason (skip "don't ask again")
   const reasonOptionIndex = canSaveRule ? 2 : 1;
+
+  // Generate diff lines if this is a write or edit operation
+  const diffInfo = useMemo(() => {
+    if (!toolPart) return null;
+
+    if (toolPart.type === "tool-write") {
+      const content = String(toolPart.input?.content ?? "");
+      const lines = createWriteDiffLines(content);
+      const additions = content ? content.split("\n").length : 0;
+      return { lines, additions, removals: 0 };
+    }
+
+    if (toolPart.type === "tool-edit") {
+      const oldString = String(toolPart.input?.oldString ?? "");
+      const newString = String(toolPart.input?.newString ?? "");
+      const startLine = Number(toolPart.input?.startLine) || 1;
+      return createEditDiffLines(oldString, newString, startLine);
+    }
+
+    return null;
+  }, [toolPart]);
 
   useInput((input, key) => {
     // Handle escape to cancel (deny without reason)
@@ -117,6 +236,33 @@ export function ApprovalPanel({
         <Text>{toolCommand}</Text>
         {toolDescription && <Text color="gray">{toolDescription}</Text>}
       </Box>
+
+      {/* Diff preview */}
+      {diffInfo && diffInfo.lines.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          {diffInfo.lines.map((line, i) => (
+            <Box key={i}>
+              {line.type === "separator" ? (
+                <Text color="gray">     {line.content}</Text>
+              ) : line.type === "addition" ? (
+                <Text backgroundColor="#234823">
+                  {line.lineNumber !== undefined
+                    ? String(line.lineNumber).padStart(3, " ")
+                    : "   "}{" "}
+                  +{line.content.slice(0, DIFF_LINE_MAX_WIDTH).padEnd(DIFF_LINE_MAX_WIDTH, " ")}
+                </Text>
+              ) : (
+                <Text backgroundColor="#5c2626">
+                  {line.lineNumber !== undefined
+                    ? String(line.lineNumber).padStart(3, " ")
+                    : "   "}{" "}
+                  -{line.content.slice(0, DIFF_LINE_MAX_WIDTH).padEnd(DIFF_LINE_MAX_WIDTH, " ")}
+                </Text>
+              )}
+            </Box>
+          ))}
+        </Box>
+      )}
 
       {/* Question and options */}
       <Box flexDirection="column" marginTop={1}>


### PR DESCRIPTION
This change adds visual diff previews to the file edit approval interface. 

- **Write tool**: Enhanced to track and return the starting line number of edits, enabling better diff context for approvals
- **Approval panel**: Added diff rendering functions that display old/new content with color-coded additions (green) and removals (red), with smart truncation for large changes
- **Input validation**: `startLine` parameter added to edit schema to support accurate line number tracking in diffs