### PR TITLE
Enable sandbox lifecycle management by consumers

### DIFF
--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -13,7 +13,7 @@ import {
 import { buildSystemPrompt } from "./system-prompt";
 import type { TodoItem, AgentMode, ApprovalRule } from "./types";
 import { approvalRuleSchema } from "./types";
-import { addCacheControl, compactContext, getSandbox } from "./utils";
+import { addCacheControl, compactContext } from "./utils";
 import { gateway } from "../models";
 import { createLocalSandbox, type Sandbox } from "./sandbox";
 
@@ -84,14 +84,9 @@ export const deepAgent = new ToolLoopAgent({
       experimental_context: { sandbox, mode, autoApprove, approvalRules },
     };
   },
-  onFinish: async ({ experimental_context }) => {
-    try {
-      const sandbox = getSandbox(experimental_context);
-      await sandbox.stop();
-    } catch {
-      // Sandbox not available, nothing to clean up
-    }
-  },
+  // Sandbox lifecycle is managed by the consumer, not the agent.
+  // Consumers should call sandbox.stop() when they're done with the sandbox.
+  onFinish: async () => {},
 });
 
 export function extractTodosFromStep(

--- a/src/agent/sandbox/index.ts
+++ b/src/agent/sandbox/index.ts
@@ -2,6 +2,7 @@ export type { Sandbox, SandboxStats, ExecResult } from "./interface";
 export { LocalSandbox, createLocalSandbox } from "./local";
 export {
   VercelSandbox,
-  createVercelSandbox,
+  connectVercelSandbox,
   type VercelSandboxConfig,
+  type VercelSandboxConnectConfig,
 } from "./vercel";

--- a/src/agent/sandbox/vercel.ts
+++ b/src/agent/sandbox/vercel.ts
@@ -54,6 +54,11 @@ export interface VercelSandboxConfig {
  * Runs code in isolated Firecracker MicroVMs.
  */
 export class VercelSandbox implements Sandbox {
+  /**
+   * Unique identifier for this sandbox.
+   * Use this to reconnect to an existing sandbox via `connectVercelSandbox({ sandboxId })`.
+   */
+  readonly id: string;
   readonly workingDirectory: string;
   readonly env?: Record<string, string>;
   /**
@@ -65,11 +70,13 @@ export class VercelSandbox implements Sandbox {
 
   private constructor(
     sdk: VercelSandboxSDK,
+    id: string,
     workingDirectory: string,
     env?: Record<string, string>,
     currentBranch?: string
   ) {
     this.sdk = sdk;
+    this.id = id;
     this.workingDirectory = workingDirectory;
     this.env = env;
     this.currentBranch = currentBranch;
@@ -151,7 +158,29 @@ export class VercelSandbox implements Sandbox {
       currentBranch = source.branch;
     }
 
-    return new VercelSandbox(sdk, workingDirectory, env, currentBranch);
+    return new VercelSandbox(
+      sdk,
+      sdk.sandboxId,
+      workingDirectory,
+      env,
+      currentBranch
+    );
+  }
+
+  /**
+   * Connect to an existing Vercel Sandbox by ID.
+   */
+  static async connect(
+    sandboxId: string,
+    options: { env?: Record<string, string> } = {}
+  ): Promise<VercelSandbox> {
+    const sdk = await VercelSandboxSDK.get({ sandboxId });
+    return new VercelSandbox(
+      sdk,
+      sandboxId,
+      DEFAULT_WORKING_DIRECTORY,
+      options.env
+    );
   }
 
   async readFile(path: string, encoding: "utf-8"): Promise<string> {
@@ -349,17 +378,32 @@ export class VercelSandbox implements Sandbox {
 }
 
 /**
- * Create a new Vercel Sandbox instance.
+ * Configuration for reconnecting to an existing sandbox.
+ */
+export interface VercelSandboxConnectConfig {
+  /** The sandbox ID to reconnect to */
+  sandboxId: string;
+  /** Environment variables to make available to commands */
+  env?: Record<string, string>;
+}
+
+/**
+ * Connect to a Vercel Sandbox - either create a new one or reconnect to an existing one.
  *
- * @param config - Configuration options including optional GitHub source
+ * @param config - Configuration options. Pass `sandboxId` to reconnect, or other options to create new.
  *
  * @example
  * // Start empty sandbox
- * const sandbox = await createVercelSandbox();
+ * const sandbox = await connectVercelSandbox();
+ * console.log(sandbox.id); // Save this ID for reconnection
  *
  * @example
- * // Clone a repo into the sandbox
- * const sandbox = await createVercelSandbox({
+ * // Reconnect to an existing sandbox
+ * const sandbox = await connectVercelSandbox({ sandboxId: "saved-sandbox-id" });
+ *
+ * @example
+ * // Clone a repo into a new sandbox
+ * const sandbox = await connectVercelSandbox({
  *   source: {
  *     url: "https://github.com/owner/repo",
  *     branch: "develop",
@@ -368,7 +412,7 @@ export class VercelSandbox implements Sandbox {
  *
  * @example
  * // Clone with authentication and create a new branch for agent work
- * const sandbox = await createVercelSandbox({
+ * const sandbox = await connectVercelSandbox({
  *   source: {
  *     url: "https://github.com/owner/repo",
  *     branch: "main",
@@ -380,14 +424,15 @@ export class VercelSandbox implements Sandbox {
  *   },
  * });
  *
- * // The sandbox exposes the current branch for the agent to use
+ * // The sandbox exposes the ID and current branch
+ * console.log(sandbox.id); // "sandbox-abc123"
  * console.log(sandbox.currentBranch); // "agent/feature-123"
- *
- * // Agent can push to this branch:
- * // git add . && git commit -m "changes" && git push -u origin agent/feature-123
  */
-export async function createVercelSandbox(
-  config: VercelSandboxConfig = {}
+export async function connectVercelSandbox(
+  config: VercelSandboxConfig | VercelSandboxConnectConfig = {}
 ): Promise<VercelSandbox> {
+  if ("sandboxId" in config) {
+    return VercelSandbox.connect(config.sandboxId, { env: config.env });
+  }
   return VercelSandbox.create(config);
 }


### PR DESCRIPTION
Refactored sandbox management to give consumers explicit control over sandbox lifecycle and persistence.

- Remove automatic sandbox cleanup from agent's `onFinish` handler; consumers now own stopping sandboxes
- Add `id` property to `VercelSandbox` and introduce `VercelSandbox.connect()` to reconnect to existing sandboxes
- Rename `createVercelSandbox()` to `connectVercelSandbox()` to unify creation and reconnection into a single entry point
- Remove unused `getSandbox()` utility function