### PR TITLE
Fix file operations in Vercel sandbox with safer encoding

### DIFF
--- a/src/agent/sandbox/vercel.ts
+++ b/src/agent/sandbox/vercel.ts
@@ -211,10 +211,11 @@ export class VercelSandbox implements Sandbox {
     }
 
     // Use base64 encoding to safely handle special characters
+    // Use printf '%s' instead of echo to avoid interpreting backslash sequences
     const base64Content = Buffer.from(content, "utf-8").toString("base64");
     const result = await this.sdk.runCommand({
       cmd: "bash",
-      args: ["-c", `echo "${base64Content}" | base64 -d > "${path}"`],
+      args: ["-c", `printf '%s' "${base64Content}" | base64 -d > "${path}"`],
       env: this.env,
     });
 
@@ -225,9 +226,10 @@ export class VercelSandbox implements Sandbox {
 
   async stat(path: string): Promise<SandboxStats> {
     // Use stat command to get file info
+    // Use tab delimiter to avoid issues with file types containing spaces (e.g., "regular file")
     const result = await this.sdk.runCommand({
       cmd: "stat",
-      args: ["-c", "%F %s %Y", path],
+      args: ["-c", "%F\t%s\t%Y", path],
       env: this.env,
     });
 
@@ -236,7 +238,7 @@ export class VercelSandbox implements Sandbox {
     }
 
     const output = (await result.stdout()).trim();
-    const [fileType, sizeStr, mtimeStr] = output.split(" ");
+    const [fileType, sizeStr, mtimeStr] = output.split("\t");
 
     const isDir = fileType === "directory";
     const size = parseInt(sizeStr ?? "0", 10);

--- a/test-with-vercel-sandbox.ts
+++ b/test-with-vercel-sandbox.ts
@@ -1,0 +1,43 @@
+import { createTUI } from "./src/tui";
+import { connectVercelSandbox } from "./src/agent/sandbox";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const initialPrompt = args.length > 0 ? args.join(" ") : undefined;
+
+  console.log("Creating Vercel sandbox...");
+
+  const sandbox = await connectVercelSandbox({
+    // Optional: clone a repo
+    // source: {
+    //   url: "https://github.com/owner/repo",
+    //   branch: "main",
+    // },
+    vcpus: 2,
+    timeout: 300_000,
+  });
+
+  console.log("Sandbox ID:", sandbox.id);
+  console.log("Working directory:", sandbox.workingDirectory);
+  console.log("");
+
+  try {
+    await createTUI({
+      initialPrompt,
+      workingDirectory: sandbox.workingDirectory,
+      header: {
+        name: "Deep Agent (Vercel Sandbox)",
+        version: "0.1.0",
+      },
+      agentOptions: {
+        workingDirectory: sandbox.workingDirectory,
+        sandbox,
+      },
+    });
+  } finally {
+    console.log("\nStopping sandbox...");
+    await sandbox.stop();
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION

Summary: Improve reliability of file write and stat operations in the Vercel sandbox implementation by using safer command-line argument handling.

Changes:
- Replace `echo` with `printf '%s'` in file writing to prevent backslash sequence interpretation
- Switch file stat parsing from space-delimited to tab-delimited output to handle filenames and types with spaces correctly
- Add test helper script (`test-with-vercel-sandbox.ts`) for manual testing of Vercel sandbox functionality
