### PR TITLE
Enable auto-accept mode for sandbox environments

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -142,6 +142,8 @@ async function main() {
           customInstructions: agentsMd.content,
         }),
       },
+      // Auto-accept all tools in sandbox mode since it's an isolated environment
+      ...(isRemoteSandbox && { initialAutoAcceptMode: "all" }),
     });
   } catch (error) {
     // Ignore abort errors from ESC key interrupts

--- a/src/tui/chat-context.tsx
+++ b/src/tui/chat-context.tsx
@@ -50,6 +50,7 @@ type ChatProviderProps = {
   agentOptions: TUIAgentCallOptions;
   model?: string;
   workingDirectory?: string;
+  initialAutoAcceptMode?: AutoAcceptMode;
 };
 
 const DEFAULT_USAGE: LanguageModelUsage = {
@@ -111,8 +112,11 @@ export function ChatProvider({
   agentOptions,
   model,
   workingDirectory,
+  initialAutoAcceptMode = "off",
 }: ChatProviderProps) {
-  const [autoAcceptMode, setAutoAcceptMode] = useState<AutoAcceptMode>("off");
+  const [autoAcceptMode, setAutoAcceptMode] = useState<AutoAcceptMode>(
+    initialAutoAcceptMode,
+  );
   const [usage, setUsage] = useState<LanguageModelUsage>(DEFAULT_USAGE);
   const [sessionUsage, setSessionUsage] =
     useState<LanguageModelUsage>(DEFAULT_USAGE);

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -51,6 +51,7 @@ export async function createTUI(options: TUIOptions): Promise<void> {
       agentOptions={agentOptions}
       model={options.header?.model ?? tuiAgentModelId}
       workingDirectory={options.workingDirectory}
+      initialAutoAcceptMode={options.initialAutoAcceptMode}
     >
       <ReasoningProvider>
         <ExpandedViewProvider>
@@ -79,6 +80,7 @@ export function renderTUI(options: TUIOptions) {
       agentOptions={agentOptions}
       model={options.header?.model ?? tuiAgentModelId}
       workingDirectory={options.workingDirectory}
+      initialAutoAcceptMode={options.initialAutoAcceptMode}
     >
       <ReasoningProvider>
         <ExpandedViewProvider>

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -47,4 +47,6 @@ export type TUIOptions = {
     version?: string;
     model?: string;
   };
+  /** Initial auto-accept mode (defaults to "off") */
+  initialAutoAcceptMode?: AutoAcceptMode;
 };


### PR DESCRIPTION
Enable auto-accept mode for all tools when running in remote sandbox mode since it's an isolated environment.

- Add `initialAutoAcceptMode` option to TUIOptions and ChatProvider
- Auto-enable "all" mode when `isRemoteSandbox` is true
- Defaults to "off" mode in non-sandbox environments