### PR TITLE
Add just-bash sandbox implementation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "ink": "^6.6.0",
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
+        "just-bash": "^2.1.0",
         "marked": "^17.0.1",
         "react": "^19.2.3",
         "zod": "^3.24.0",
@@ -62,7 +63,15 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
 
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.7", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw=="],
+
+    "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
+
+    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -83,6 +92,10 @@
     "@oxlint/win32-x64": ["@oxlint/win32-x64@1.38.0", "", { "os": "win32", "cpu": "x64" }, "sha512-7IuZMYiZiOcgg5zHvpJY6jRlEwh8EB/uq7GsoQJO9hANq96TIjyntGByhIjFSsL4asyZmhTEki+MO/u5Fb/WQA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
@@ -138,7 +151,11 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -156,6 +173,10 @@
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
+    "fast-xml-parser": ["fast-xml-parser@5.3.3", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA=="],
+
+    "file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
@@ -166,7 +187,11 @@
 
     "hono": ["hono@4.11.3", "", {}, "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "ink": ["ink@6.6.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.1", "ansi-escapes": "^7.2.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^8.1.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": "^6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-QDt6FgJxgmSxAelcOvOHUvFxbIUjVpCH5bx+Slvc5m7IEcpGt3dYwbz/L+oRnqEGeRvwy1tineKK4ect3nW1vQ=="],
 
@@ -182,9 +207,13 @@
 
     "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
 
+    "just-bash": ["just-bash@2.1.0", "", { "dependencies": { "diff": "^8.0.2", "fast-xml-parser": "^5.3.3", "file-type": "^21.2.0", "ini": "^6.0.0", "minimatch": "^10.1.1", "papaparse": "^5.5.3", "smol-toml": "^1.6.0", "sprintf-js": "^1.1.3", "turndown": "^7.2.2", "yaml": "^2.8.2" }, "bin": { "just-bash": "dist/bin/just-bash.js", "just-bash-shell": "dist/bin/shell/shell.js" } }, "sha512-fFIC5HpOWmgHl8vcsyQr1SCfQ8LanwRAFUp4xs4pwTRClIEusIuL2AXAIrBRffQSqT5kYheLJVLvt+/8SlIB7g=="],
+
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -195,6 +224,8 @@
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "oxlint": ["oxlint@1.38.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.38.0", "@oxlint/darwin-x64": "1.38.0", "@oxlint/linux-arm64-gnu": "1.38.0", "@oxlint/linux-arm64-musl": "1.38.0", "@oxlint/linux-x64-gnu": "1.38.0", "@oxlint/linux-x64-musl": "1.38.0", "@oxlint/win32-arm64": "1.38.0", "@oxlint/win32-x64": "1.38.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.10.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-XT7tBinQS+hVLxtfJOnokJ9qVBiQvZqng40tDgR6qEJMRMnpVq/JwYfbYyGntSq8MO+Y+N9M1NG4bAMFUtCJiw=="],
+
+    "papaparse": ["papaparse@5.5.3", "", {}, "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="],
 
     "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
@@ -218,6 +249,10 @@
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
+    "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
@@ -225,6 +260,10 @@
     "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
+
+    "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -240,9 +279,15 @@
 
     "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "turndown": ["turndown@7.2.2", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ=="],
+
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
@@ -257,6 +302,8 @@
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ink": "^6.6.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
+    "just-bash": "^2.1.0",
     "marked": "^17.0.1",
     "react": "^19.2.3",
     "zod": "^3.24.0"

--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -72,15 +72,22 @@ export const deepAgent = new ToolLoopAgent({
     // Use provided sandbox, or create a local sandbox with the working directory
     const sandbox = options?.sandbox ?? createLocalSandbox(workingDirectory);
 
+    let instructions = buildSystemPrompt({
+      cwd: sandbox.workingDirectory,
+      mode,
+      currentBranch: sandbox.currentBranch,
+      customInstructions,
+    });
+
+    if (sandbox.type === "just-bash") {
+      instructions +=
+        "\n\n# Sandbox Limitations\n\nGit commands are not available. Do not attempt git operations.";
+    }
+
     return {
       ...settings,
       model,
-      instructions: buildSystemPrompt({
-        cwd: sandbox.workingDirectory,
-        mode,
-        currentBranch: sandbox.currentBranch,
-        customInstructions,
-      }),
+      instructions,
       experimental_context: { sandbox, mode, autoApprove, approvalRules },
     };
   },

--- a/src/agent/sandbox/index.ts
+++ b/src/agent/sandbox/index.ts
@@ -12,3 +12,8 @@ export {
   type VercelSandboxConfig,
   type VercelSandboxConnectConfig,
 } from "./vercel";
+export {
+  JustBashSandbox,
+  createJustBashSandbox,
+  type JustBashSandboxConfig,
+} from "./just-bash";

--- a/src/agent/sandbox/interface.ts
+++ b/src/agent/sandbox/interface.ts
@@ -69,6 +69,12 @@ export interface ExecResult {
  */
 export interface Sandbox {
   /**
+   * Identifier for the sandbox implementation type.
+   * Used to conditionally adjust agent behavior (e.g., disable git instructions).
+   */
+  readonly type?: string;
+
+  /**
    * The working directory for this sandbox.
    * All path validations should be relative to this directory.
    */

--- a/src/agent/sandbox/just-bash.ts
+++ b/src/agent/sandbox/just-bash.ts
@@ -1,0 +1,341 @@
+import { Bash, OverlayFs } from "just-bash";
+import type { Dirent } from "fs";
+import type {
+  Sandbox,
+  SandboxStats,
+  ExecResult,
+  SandboxHooks,
+} from "./interface";
+
+const MAX_OUTPUT_LENGTH = 50_000;
+
+export interface JustBashSandboxConfig {
+  /**
+   * The working directory for this sandbox.
+   * In overlay mode, this is the root directory that will be mounted.
+   * In memory mode, this path is used as the logical working directory.
+   */
+  workingDirectory: string;
+
+  /**
+   * Environment variables available to commands.
+   */
+  env?: Record<string, string>;
+
+  /**
+   * Initial files to populate in the virtual filesystem.
+   * Keys are absolute paths, values are file contents.
+   */
+  files?: Record<string, string>;
+
+  /**
+   * Lifecycle hooks for setup and teardown.
+   */
+  hooks?: SandboxHooks;
+
+  /**
+   * Filesystem mode:
+   * - "memory": Pure in-memory filesystem (default). All files must be provided via `files` option.
+   * - "overlay": Copy-on-write over a real directory. Reads come from disk, writes stay in memory.
+   */
+  mode?: "memory" | "overlay";
+
+  /**
+   * Execution limits for protecting against infinite loops and deep recursion.
+   */
+  executionLimits?: {
+    maxCallDepth?: number;
+    maxCommandCount?: number;
+    maxLoopIterations?: number;
+  };
+}
+
+/**
+ * Sandbox implementation using just-bash - a simulated bash environment
+ * with an in-memory virtual filesystem.
+ *
+ * This sandbox provides a secure, isolated bash environment without
+ * spawning real shell processes. All file operations happen in memory
+ * (or copy-on-write with OverlayFs).
+ *
+ * Key features:
+ * - No real shell process spawning
+ * - In-memory or overlay filesystem
+ * - Configurable execution limits
+ * - Full lifecycle hook support
+ */
+export class JustBashSandbox implements Sandbox {
+  readonly type = "just-bash";
+  readonly workingDirectory: string;
+  readonly env?: Record<string, string>;
+  readonly hooks?: SandboxHooks;
+
+  private bash: Bash;
+  private mode: "memory" | "overlay";
+
+  private constructor(
+    workingDirectory: string,
+    bash: Bash,
+    mode: "memory" | "overlay",
+    env?: Record<string, string>,
+    hooks?: SandboxHooks,
+  ) {
+    this.workingDirectory = workingDirectory;
+    this.bash = bash;
+    this.mode = mode;
+    this.env = env;
+    this.hooks = hooks;
+  }
+
+  /**
+   * Create a new JustBashSandbox instance.
+   */
+  static async create(config: JustBashSandboxConfig): Promise<JustBashSandbox> {
+    const {
+      workingDirectory,
+      env,
+      files,
+      hooks,
+      mode = "memory",
+      executionLimits,
+    } = config;
+
+    let bash: Bash;
+    let effectiveWorkingDirectory: string;
+
+    if (mode === "overlay") {
+      const overlayFs = new OverlayFs({ root: workingDirectory });
+      const mountPoint = overlayFs.getMountPoint();
+      bash = new Bash({
+        fs: overlayFs,
+        cwd: mountPoint,
+        env,
+        executionLimits,
+      });
+      // In overlay mode, use the mount point as the working directory
+      // since the real path doesn't exist in the virtual filesystem
+      effectiveWorkingDirectory = mountPoint;
+    } else {
+      // Memory mode - pure in-memory filesystem
+      bash = new Bash({
+        files: files ?? {},
+        cwd: workingDirectory,
+        env,
+        executionLimits,
+      });
+      effectiveWorkingDirectory = workingDirectory;
+    }
+
+    const sandbox = new JustBashSandbox(
+      effectiveWorkingDirectory,
+      bash,
+      mode,
+      env,
+      hooks,
+    );
+
+    // Run afterStart hook if provided
+    if (hooks?.afterStart) {
+      await hooks.afterStart(sandbox);
+    }
+
+    return sandbox;
+  }
+
+  async readFile(path: string, _encoding: "utf-8"): Promise<string> {
+    // Use cat command to read file contents
+    const result = await this.bash.exec(`cat "${path}"`);
+    if (result.exitCode !== 0) {
+      const error = new Error(
+        result.stderr || `ENOENT: no such file or directory, open '${path}'`,
+      );
+      (error as NodeJS.ErrnoException).code = "ENOENT";
+      throw error;
+    }
+    return result.stdout;
+  }
+
+  async writeFile(
+    path: string,
+    content: string,
+    _encoding: "utf-8",
+  ): Promise<void> {
+    // Ensure parent directory exists
+    const parentDir = path.substring(0, path.lastIndexOf("/"));
+    if (parentDir) {
+      await this.bash.exec(`mkdir -p "${parentDir}"`);
+    }
+
+    // Use heredoc to write content (handles special characters)
+    // Escape any single quotes in the content
+    const escapedContent = content.replace(/'/g, "'\\''");
+    const result = await this.bash.exec(
+      `printf '%s' '${escapedContent}' > "${path}"`,
+    );
+
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to write file: ${path}`);
+    }
+  }
+
+  async stat(path: string): Promise<SandboxStats> {
+    // Check if path exists and get its type
+    const result = await this.bash.exec(`stat "${path}" 2>/dev/null`);
+    if (result.exitCode !== 0) {
+      const error = new Error(
+        `ENOENT: no such file or directory, stat '${path}'`,
+      );
+      (error as NodeJS.ErrnoException).code = "ENOENT";
+      throw error;
+    }
+
+    // Check if it's a directory
+    const dirCheck = await this.bash.exec(`test -d "${path}" && echo "dir"`);
+    const isDir = dirCheck.stdout.trim() === "dir";
+
+    // Get file size
+    let size = 0;
+    if (!isDir) {
+      const sizeResult = await this.bash.exec(`wc -c < "${path}"`);
+      size = parseInt(sizeResult.stdout.trim(), 10) || 0;
+    }
+
+    return {
+      isDirectory: () => isDir,
+      isFile: () => !isDir,
+      size,
+      mtimeMs: Date.now(), // just-bash doesn't track mtimes precisely
+    };
+  }
+
+  async access(path: string): Promise<void> {
+    const result = await this.bash.exec(`test -e "${path}"`);
+    if (result.exitCode !== 0) {
+      const error = new Error(
+        `ENOENT: no such file or directory, access '${path}'`,
+      );
+      (error as NodeJS.ErrnoException).code = "ENOENT";
+      throw error;
+    }
+  }
+
+  async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+    const flags = options?.recursive ? "-p" : "";
+    const result = await this.bash.exec(`mkdir ${flags} "${path}"`);
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to create directory: ${path}`);
+    }
+  }
+
+  async readdir(
+    path: string,
+    _options: { withFileTypes: true },
+  ): Promise<Dirent[]> {
+    // List directory contents
+    const result = await this.bash.exec(
+      `ls -1 "${path}" 2>/dev/null || echo ""`,
+    );
+
+    if (result.exitCode !== 0 || !result.stdout.trim()) {
+      // Check if directory exists
+      const existsCheck = await this.bash.exec(`test -d "${path}"`);
+      if (existsCheck.exitCode !== 0) {
+        const error = new Error(
+          `ENOENT: no such file or directory, scandir '${path}'`,
+        );
+        (error as NodeJS.ErrnoException).code = "ENOENT";
+        throw error;
+      }
+      return [];
+    }
+
+    const entries = result.stdout.trim().split("\n").filter(Boolean);
+    const dirents: Dirent[] = [];
+
+    for (const entry of entries) {
+      const entryPath = path.endsWith("/")
+        ? `${path}${entry}`
+        : `${path}/${entry}`;
+      const dirCheck = await this.bash.exec(`test -d "${entryPath}"`);
+      const isDir = dirCheck.exitCode === 0;
+
+      // Create a Dirent-compatible object
+      dirents.push({
+        name: entry,
+        parentPath: path,
+        path: entryPath,
+        isDirectory: () => isDir,
+        isFile: () => !isDir,
+        isBlockDevice: () => false,
+        isCharacterDevice: () => false,
+        isSymbolicLink: () => false,
+        isFIFO: () => false,
+        isSocket: () => false,
+      } as Dirent);
+    }
+
+    return dirents;
+  }
+
+  async exec(
+    command: string,
+    cwd: string,
+    _timeoutMs: number,
+  ): Promise<ExecResult> {
+    // Execute command with the specified cwd
+    const result = await this.bash.exec(command, { cwd });
+
+    let stdout = result.stdout;
+    let stderr = result.stderr;
+    let truncated = false;
+
+    // Truncate output if necessary
+    if (stdout.length > MAX_OUTPUT_LENGTH) {
+      stdout = stdout.slice(0, MAX_OUTPUT_LENGTH);
+      truncated = true;
+    }
+    if (stderr.length > MAX_OUTPUT_LENGTH) {
+      stderr = stderr.slice(0, MAX_OUTPUT_LENGTH);
+      truncated = true;
+    }
+
+    return {
+      success: result.exitCode === 0,
+      exitCode: result.exitCode,
+      stdout,
+      stderr,
+      truncated,
+    };
+  }
+
+  async stop(): Promise<void> {
+    // Run beforeStop hook if provided
+    if (this.hooks?.beforeStop) {
+      await this.hooks.beforeStop(this);
+    }
+    // No resources to clean up for just-bash
+  }
+}
+
+/**
+ * Create a new JustBashSandbox instance.
+ *
+ * @example
+ * // In-memory mode (default)
+ * const sandbox = await createJustBashSandbox({
+ *   workingDirectory: "/app",
+ *   files: { "/app/data.json": '{"key": "value"}' },
+ * });
+ *
+ * @example
+ * // Overlay mode - reads from disk, writes stay in memory
+ * const sandbox = await createJustBashSandbox({
+ *   workingDirectory: "/path/to/project",
+ *   mode: "overlay",
+ * });
+ */
+export async function createJustBashSandbox(
+  config: JustBashSandboxConfig,
+): Promise<Sandbox> {
+  return JustBashSandbox.create(config);
+}

--- a/src/agent/sandbox/local.ts
+++ b/src/agent/sandbox/local.ts
@@ -13,6 +13,7 @@ const MAX_OUTPUT_LENGTH = 50_000;
  * Use VercelSandbox for hooks support.
  */
 export class LocalSandbox implements Sandbox {
+  readonly type = "local";
   readonly workingDirectory: string;
   readonly env?: Record<string, string>;
 

--- a/src/agent/sandbox/vercel.ts
+++ b/src/agent/sandbox/vercel.ts
@@ -75,6 +75,7 @@ export interface VercelSandboxConfig {
  * Runs code in isolated Firecracker MicroVMs.
  */
 export class VercelSandbox implements Sandbox {
+  readonly type = "vercel";
   /**
    * Unique identifier for this sandbox.
    * Use this to reconnect to an existing sandbox via `connectVercelSandbox({ sandboxId })`.

--- a/src/cli/sandbox-factory.ts
+++ b/src/cli/sandbox-factory.ts
@@ -2,9 +2,10 @@ import {
   type Sandbox,
   createLocalSandbox,
   connectVercelSandbox,
+  createJustBashSandbox,
 } from "../agent/sandbox/index.js";
 
-export type SandboxType = "local" | "vercel";
+export type SandboxType = "local" | "vercel" | "just-bash";
 
 export interface SandboxFactoryOptions {
   type: SandboxType;
@@ -61,6 +62,13 @@ export async function createSandbox(
       });
     }
 
+    case "just-bash": {
+      return createJustBashSandbox({
+        workingDirectory,
+        mode: "overlay",
+      });
+    }
+
     default:
       throw new Error(`Unknown sandbox type: ${type}`);
   }
@@ -82,10 +90,14 @@ function expandRepoUrl(repo: string): string {
  */
 export function parseSandboxType(value: string): SandboxType {
   const normalized = value.toLowerCase();
-  if (normalized === "local" || normalized === "vercel") {
+  if (
+    normalized === "local" ||
+    normalized === "vercel" ||
+    normalized === "just-bash"
+  ) {
     return normalized;
   }
   throw new Error(
-    `Invalid sandbox type: ${value}. Valid options: local, vercel`,
+    `Invalid sandbox type: ${value}. Valid options: local, vercel, just-bash`,
   );
 }


### PR DESCRIPTION
Summary: Introduces a new just-bash sandbox type that provides an isolated, in-memory bash environment without spawning real shell processes.

- **Add JustBashSandbox class**: Implements the Sandbox interface with memory and overlay filesystem modes, delegating bash execution to the just-bash library
- **Update sandbox interface**: Add optional `type` property to distinguish sandbox implementations (enables conditional agent behavior like disabling git instructions for just-bash)
- **Add sandbox type field**: Set `type` identifier on LocalSandbox, VercelSandbox, and new JustBashSandbox instances
- **Extend CLI factory**: Support "just-bash" as a new sandbox type option in the CLI sandbox factory and parser