### PR TITLE
Move sandbox limitations to environment details

### DIFF
--- a/src/agent/deep-agent.ts
+++ b/src/agent/deep-agent.ts
@@ -72,17 +72,13 @@ export const deepAgent = new ToolLoopAgent({
     // Use provided sandbox, or create a local sandbox with the working directory
     const sandbox = options?.sandbox ?? createLocalSandbox(workingDirectory);
 
-    let instructions = buildSystemPrompt({
+    const instructions = buildSystemPrompt({
       cwd: sandbox.workingDirectory,
       mode,
       currentBranch: sandbox.currentBranch,
       customInstructions,
+      environmentDetails: sandbox.environmentDetails,
     });
-
-    if (sandbox.type === "just-bash") {
-      instructions +=
-        "\n\n# Sandbox Limitations\n\nGit commands are not available. Do not attempt git operations.";
-    }
 
     return {
       ...settings,

--- a/src/agent/sandbox/interface.ts
+++ b/src/agent/sandbox/interface.ts
@@ -101,6 +101,16 @@ export interface Sandbox {
   readonly hooks?: SandboxHooks;
 
   /**
+   * Environment-specific details for the agent system prompt.
+   * Describes available commands, capabilities, and limitations.
+   * Added to the system prompt under the Environment section.
+   *
+   * @example
+   * environmentDetails: "- Git available, GitHub CLI (gh) is NOT available"
+   */
+  readonly environmentDetails?: string;
+
+  /**
    * Read file contents as UTF-8 string
    */
   readFile(path: string, encoding: "utf-8"): Promise<string>;

--- a/src/agent/sandbox/just-bash.ts
+++ b/src/agent/sandbox/just-bash.ts
@@ -69,6 +69,11 @@ export class JustBashSandbox implements Sandbox {
   readonly workingDirectory: string;
   readonly env?: Record<string, string>;
   readonly hooks?: SandboxHooks;
+  readonly environmentDetails =
+    `- Simulated shell environment (not a real bash process)
+- Git is NOT available - do not attempt git operations
+- Limited to basic file operations and shell commands
+- No package installation or network access`;
 
   private bash: Bash;
   private mode: "memory" | "overlay";

--- a/src/agent/sandbox/local.ts
+++ b/src/agent/sandbox/local.ts
@@ -16,6 +16,9 @@ export class LocalSandbox implements Sandbox {
   readonly type = "local";
   readonly workingDirectory: string;
   readonly env?: Record<string, string>;
+  readonly environmentDetails = `- Full shell access with all standard CLI tools
+- Git and GitHub CLI (gh) available
+- Can install packages and run any commands`;
 
   constructor(workingDirectory: string, env?: Record<string, string>) {
     this.workingDirectory = workingDirectory;

--- a/src/agent/sandbox/vercel.ts
+++ b/src/agent/sandbox/vercel.ts
@@ -89,6 +89,14 @@ export class VercelSandbox implements Sandbox {
    */
   readonly currentBranch?: string;
   readonly hooks?: SandboxHooks;
+  readonly environmentDetails =
+    `- Ephemeral sandbox - all work is lost unless committed and pushed to git
+- Default workflow: create a new branch, commit changes, push, and open a PR (since the sandbox is ephemeral, this ensures work is preserved)
+- Git is already configured (user, email, remote auth) - no setup or verification needed
+- GitHub CLI (gh) is NOT available - use curl with the GitHub API to create PRs
+  Use the $GITHUB_TOKEN environment variable directly (do not paste the actual token):
+  curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/OWNER/REPO/pulls -d '{"title":"...","head":"branch","base":"main","body":"..."}'
+- Node.js runtime with npm/pnpm available`;
   private sdk: VercelSandboxSDK;
 
   private constructor(

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -173,6 +173,7 @@ export interface BuildSystemPromptOptions {
   mode?: "interactive" | "background";
   currentBranch?: string;
   customInstructions?: string;
+  environmentDetails?: string;
 }
 
 export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
@@ -180,6 +181,9 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 
   if (options.cwd) {
     parts.push(`\n# Environment\n\nWorking directory: ${options.cwd}`);
+    if (options.environmentDetails) {
+      parts.push(`\n${options.environmentDetails}`);
+    }
   }
 
   if (options.mode === "background") {


### PR DESCRIPTION
Refactored sandbox-specific environment constraints from inline conditional logic into a structured `environmentDetails` field.

- **What changed**: Each sandbox type now declares its capabilities and limitations via an `environmentDetails` property, which gets passed to the system prompt builder
- **Why**: Centralizes environment documentation in sandbox implementations, making it easier to maintain and modify constraints per sandbox type
- **How**: Added `environmentDetails` optional field to `Sandbox` interface; implemented in JustBashSandbox, LocalSandbox, and VercelSandbox with specific capability descriptions; removed conditional "just-bash" instructions from deep-agent.ts