### PR TITLE
Add host property to Sandbox interface and make it dynamic

### DIFF
--- a/packages/sandbox/interface.ts
+++ b/packages/sandbox/interface.ts
@@ -111,6 +111,15 @@ export interface Sandbox {
   readonly environmentDetails?: string;
 
   /**
+   * The base host/domain for this sandbox (for remote sandboxes).
+   * Used to construct URLs for accessing running services.
+   * For local sandboxes, this is typically undefined or "localhost".
+   *
+   * @example "abc123.vercel.run"
+   */
+  readonly host?: string;
+
+  /**
    * Read file contents as UTF-8 string
    */
   readFile(path: string, encoding: "utf-8"): Promise<string>;

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -89,14 +89,6 @@ export class VercelSandbox implements Sandbox {
    */
   readonly currentBranch?: string;
   readonly hooks?: SandboxHooks;
-  readonly environmentDetails =
-    `- Ephemeral sandbox - all work is lost unless committed and pushed to git
-- Default workflow: create a new branch, commit changes, push, and open a PR (since the sandbox is ephemeral, this ensures work is preserved)
-- Git is already configured (user, email, remote auth) - no setup or verification needed
-- GitHub CLI (gh) is NOT available - use curl with the GitHub API to create PRs
-  Use the $GITHUB_TOKEN environment variable directly (do not paste the actual token):
-  curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/OWNER/REPO/pulls -d '{"title":"...","head":"branch","base":"main","body":"..."}'
-- Node.js runtime with npm/pnpm available`;
   private sdk: VercelSandboxSDK;
 
   private constructor(
@@ -113,6 +105,31 @@ export class VercelSandbox implements Sandbox {
     this.env = env;
     this.currentBranch = currentBranch;
     this.hooks = hooks;
+  }
+
+  /**
+   * The base host/domain for this sandbox (e.g., "abc123.vercel.run").
+   * To get the full URL for an exposed port, use the `domain(port)` method
+   * which returns the correct subdomain-based URL for that port.
+   */
+  get host(): string | undefined {
+    try {
+      const domainUrl = this.sdk.domain(80);
+      return new URL(domainUrl).host;
+    } catch {
+      return undefined;
+    }
+  }
+
+  get environmentDetails(): string {
+    return `- Ephemeral sandbox - all work is lost unless committed and pushed to git
+- Default workflow: create a new branch, commit changes, push, and open a PR (since the sandbox is ephemeral, this ensures work is preserved)
+- Git is already configured (user, email, remote auth) - no setup or verification needed
+- GitHub CLI (gh) is NOT available - use curl with the GitHub API to create PRs
+  Use the $GITHUB_TOKEN environment variable directly (do not paste the actual token):
+  curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/OWNER/REPO/pulls -d '{"title":"...","head":"branch","base":"main","body":"..."}'
+- Node.js runtime with npm/pnpm available
+- Sandbox host: ${this.host} (use domain(port) method to get URLs for exposed ports)`;
   }
 
   /**
@@ -239,6 +256,7 @@ export class VercelSandbox implements Sandbox {
     options: { env?: Record<string, string>; hooks?: SandboxHooks } = {},
   ): Promise<VercelSandbox> {
     const sdk = await VercelSandboxSDK.get({ sandboxId });
+
     const sandbox = new VercelSandbox(
       sdk,
       sandboxId,


### PR DESCRIPTION
Makes sandbox host information accessible as a computed property rather than hardcoded.

- Added `host?: string` property to the Sandbox interface to represent the base domain for remote sandboxes
- Converted `environmentDetails` from a static readonly field to a getter that dynamically includes the sandbox host and usage information
- Implemented `host` getter in VercelSandbox that extracts the domain from the SDK's port 80 endpoint, with fallback to undefined on error
- Updated environment details message to reference the host and direct users to the `domain(port)` method for accessing exposed services