### PR TITLE
Add diff viewer to show file changes in sandbox

### DIFF
--- a/apps/web/app/api/tasks/[id]/diff/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/route.ts
@@ -73,8 +73,8 @@ function parseNameStatus(
 }
 
 /**
- * Parse git diff --stat output to get per-file stats
- * Format: " path/to/file.ts | 10 ++++------"
+ * Parse git diff --numstat output to get per-file stats
+ * Format: "<additions>\t<deletions>\t<path>"
  */
 function parseStats(
   output: string,
@@ -82,28 +82,14 @@ function parseStats(
   const result = new Map<string, { additions: number; deletions: number }>();
 
   for (const line of output.trim().split("\n")) {
-    // Skip summary line at the end
-    if (
-      line.includes("file changed") ||
-      line.includes("files changed") ||
-      !line.includes("|")
-    ) {
-      continue;
-    }
+    if (!line) continue;
 
-    const pipeIndex = line.indexOf("|");
-    if (pipeIndex === -1) continue;
+    const parts = line.split("\t");
+    if (parts.length < 3) continue;
 
-    const path = line.slice(0, pipeIndex).trim();
-    const statsSection = line.slice(pipeIndex + 1).trim();
-
-    // Count + and - characters
-    let additions = 0;
-    let deletions = 0;
-    for (const char of statsSection) {
-      if (char === "+") additions++;
-      if (char === "-") deletions++;
-    }
+    const additions = parseInt(parts[0], 10) || 0;
+    const deletions = parseInt(parts[1], 10) || 0;
+    const path = parts[2];
 
     if (path) {
       result.set(path, { additions, deletions });
@@ -177,10 +163,10 @@ export async function GET(req: NextRequest, context: RouteContext) {
     const cwd = sandbox.workingDirectory;
 
     // Run git commands in parallel
-    const [nameStatusResult, statResult, diffResult, untrackedResult] =
+    const [nameStatusResult, numstatResult, diffResult, untrackedResult] =
       await Promise.all([
         sandbox.exec("git diff HEAD --name-status", cwd, 30000),
-        sandbox.exec("git diff HEAD --stat", cwd, 30000),
+        sandbox.exec("git diff HEAD --numstat", cwd, 30000),
         sandbox.exec("git diff HEAD", cwd, 60000),
         // Get untracked files (new files not yet staged)
         sandbox.exec("git ls-files --others --exclude-standard", cwd, 30000),
@@ -188,7 +174,7 @@ export async function GET(req: NextRequest, context: RouteContext) {
 
     // Parse outputs
     const fileStatuses = parseNameStatus(nameStatusResult.stdout);
-    const fileStats = parseStats(statResult.stdout);
+    const fileStats = parseStats(numstatResult.stdout);
     const fileDiffs = splitDiffByFile(diffResult.stdout);
 
     // Build response

--- a/apps/web/app/api/tasks/[id]/diff/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/route.ts
@@ -26,8 +26,24 @@ type RouteContext = {
 };
 
 /**
+ * Unescape C-style escape sequences in git quoted paths
+ * Git uses C-style quoting for special chars: \n, \t, \\, \", etc.
+ * Handles both fully quoted paths ("path") and already-unquoted escaped content
+ */
+function unescapeGitPath(path: string): string {
+  // If path is surrounded by quotes, strip them first
+  if (path.startsWith('"') && path.endsWith('"')) {
+    return path.slice(1, -1).replace(/\\(.)/g, "$1");
+  }
+  // For paths captured from inside quotes (e.g., by regex), still unescape
+  // For truly unquoted paths (no special chars), this is a no-op
+  return path.replace(/\\(.)/g, "$1");
+}
+
+/**
  * Parse git diff --name-status output to get file statuses
  * Format: "M\tpath" or "R100\told\tnew" for renames
+ * Paths may be quoted if they contain special characters
  */
 function parseNameStatus(
   output: string,
@@ -49,22 +65,25 @@ function parseNameStatus(
       const oldPath = parts[1];
       const newPath = parts[2];
       if (newPath) {
-        result.set(newPath, { status: "renamed", oldPath });
+        result.set(unescapeGitPath(newPath), {
+          status: "renamed",
+          oldPath: oldPath ? unescapeGitPath(oldPath) : undefined,
+        });
       }
     } else if (statusCode === "A") {
       const path = parts[1];
       if (path) {
-        result.set(path, { status: "added" });
+        result.set(unescapeGitPath(path), { status: "added" });
       }
     } else if (statusCode === "D") {
       const path = parts[1];
       if (path) {
-        result.set(path, { status: "deleted" });
+        result.set(unescapeGitPath(path), { status: "deleted" });
       }
     } else if (statusCode === "M") {
       const path = parts[1];
       if (path) {
-        result.set(path, { status: "modified" });
+        result.set(unescapeGitPath(path), { status: "modified" });
       }
     }
   }
@@ -75,6 +94,7 @@ function parseNameStatus(
 /**
  * Parse git diff --numstat output to get per-file stats
  * Format: "<additions>\t<deletions>\t<path>"
+ * Paths may be quoted if they contain special characters
  */
 function parseStats(
   output: string,
@@ -92,7 +112,7 @@ function parseStats(
     const path = parts[2];
 
     if (path) {
-      result.set(path, { additions, deletions });
+      result.set(unescapeGitPath(path), { additions, deletions });
     }
   }
 
@@ -102,10 +122,15 @@ function parseStats(
 /**
  * Split full diff output by file
  * Each file starts with "diff --git a/... b/..."
+ * Handles both quoted paths (for special chars) and unquoted paths
  */
 function splitDiffByFile(fullDiff: string): Map<string, string> {
   const result = new Map<string, string>();
-  const filePattern = /^diff --git a\/.+ b\/(.+)$/gm;
+  // Match both quoted and unquoted paths:
+  // - "a/..." (quoted) or a/... (unquoted) for source
+  // - "b/..." (quoted, capture group 1) or b/... (unquoted, capture group 2) for destination
+  const filePattern =
+    /^diff --git (?:"a\/.*?"|a\/\S*) (?:"b\/(.*?)"|b\/(\S+))$/gm;
 
   let lastIndex = 0;
   let lastPath: string | null = null;
@@ -115,7 +140,9 @@ function splitDiffByFile(fullDiff: string): Map<string, string> {
     if (lastPath !== null) {
       result.set(lastPath, fullDiff.slice(lastIndex, match.index).trim());
     }
-    lastPath = match[1] ?? null;
+    // Use quoted path (group 1) if present, otherwise unquoted (group 2)
+    const rawPath = match[1] ?? match[2] ?? null;
+    lastPath = rawPath ? unescapeGitPath(rawPath) : null;
     lastIndex = match.index;
   }
 

--- a/apps/web/app/api/tasks/[id]/diff/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/route.ts
@@ -242,7 +242,7 @@ export async function GET(req: NextRequest, context: RouteContext) {
       const lineCount = lines.length;
 
       // Generate a synthetic diff for the new file
-      const diffLines = lines.map((line, i) => `+${line}`).join("\n");
+      const diffLines = lines.map((line) => `+${line}`).join("\n");
       const syntheticDiff = `diff --git a/${path} b/${path}
 new file mode 100644
 --- /dev/null

--- a/apps/web/app/api/tasks/[id]/diff/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/route.ts
@@ -1,0 +1,285 @@
+import { connectVercelSandbox } from "@open-harness/sandbox";
+import { getTaskById } from "@/lib/db/tasks";
+import { getServerSession } from "@/lib/session/get-server-session";
+import type { NextRequest } from "next/server";
+
+export type DiffFile = {
+  path: string;
+  status: "added" | "modified" | "deleted" | "renamed";
+  additions: number;
+  deletions: number;
+  diff: string;
+  oldPath?: string;
+};
+
+export type DiffResponse = {
+  files: DiffFile[];
+  summary: {
+    totalFiles: number;
+    totalAdditions: number;
+    totalDeletions: number;
+  };
+};
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Parse git diff --name-status output to get file statuses
+ * Format: "M\tpath" or "R100\told\tnew" for renames
+ */
+function parseNameStatus(
+  output: string,
+): Map<string, { status: DiffFile["status"]; oldPath?: string }> {
+  const result = new Map<
+    string,
+    { status: DiffFile["status"]; oldPath?: string }
+  >();
+
+  for (const line of output.trim().split("\n")) {
+    if (!line) continue;
+
+    const parts = line.split("\t");
+    const statusCode = parts[0];
+    if (!statusCode) continue;
+
+    if (statusCode.startsWith("R")) {
+      // Rename: R100\told\tnew
+      const oldPath = parts[1];
+      const newPath = parts[2];
+      if (newPath) {
+        result.set(newPath, { status: "renamed", oldPath });
+      }
+    } else if (statusCode === "A") {
+      const path = parts[1];
+      if (path) {
+        result.set(path, { status: "added" });
+      }
+    } else if (statusCode === "D") {
+      const path = parts[1];
+      if (path) {
+        result.set(path, { status: "deleted" });
+      }
+    } else if (statusCode === "M") {
+      const path = parts[1];
+      if (path) {
+        result.set(path, { status: "modified" });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Parse git diff --stat output to get per-file stats
+ * Format: " path/to/file.ts | 10 ++++------"
+ */
+function parseStats(
+  output: string,
+): Map<string, { additions: number; deletions: number }> {
+  const result = new Map<string, { additions: number; deletions: number }>();
+
+  for (const line of output.trim().split("\n")) {
+    // Skip summary line at the end
+    if (
+      line.includes("file changed") ||
+      line.includes("files changed") ||
+      !line.includes("|")
+    ) {
+      continue;
+    }
+
+    const pipeIndex = line.indexOf("|");
+    if (pipeIndex === -1) continue;
+
+    const path = line.slice(0, pipeIndex).trim();
+    const statsSection = line.slice(pipeIndex + 1).trim();
+
+    // Count + and - characters
+    let additions = 0;
+    let deletions = 0;
+    for (const char of statsSection) {
+      if (char === "+") additions++;
+      if (char === "-") deletions++;
+    }
+
+    if (path) {
+      result.set(path, { additions, deletions });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Split full diff output by file
+ * Each file starts with "diff --git a/... b/..."
+ */
+function splitDiffByFile(fullDiff: string): Map<string, string> {
+  const result = new Map<string, string>();
+  const filePattern = /^diff --git a\/.+ b\/(.+)$/gm;
+
+  let lastIndex = 0;
+  let lastPath: string | null = null;
+  let match: RegExpExecArray | null;
+
+  while ((match = filePattern.exec(fullDiff)) !== null) {
+    if (lastPath !== null) {
+      result.set(lastPath, fullDiff.slice(lastIndex, match.index).trim());
+    }
+    lastPath = match[1] ?? null;
+    lastIndex = match.index;
+  }
+
+  // Don't forget the last file
+  if (lastPath !== null) {
+    result.set(lastPath, fullDiff.slice(lastIndex).trim());
+  }
+
+  return result;
+}
+
+export async function GET(req: NextRequest, context: RouteContext) {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { id: taskId } = await context.params;
+  const sandboxId = req.nextUrl.searchParams.get("sandboxId");
+
+  if (!sandboxId) {
+    return Response.json(
+      { error: "sandboxId query parameter is required" },
+      { status: 400 },
+    );
+  }
+
+  // Verify task ownership
+  const task = await getTaskById(taskId);
+  if (!task) {
+    return Response.json({ error: "Task not found" }, { status: 404 });
+  }
+  if (task.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (task.sandboxId !== sandboxId) {
+    return Response.json(
+      { error: "Sandbox does not belong to this task" },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const sandbox = await connectVercelSandbox({ sandboxId });
+    const cwd = sandbox.workingDirectory;
+
+    // Run git commands in parallel
+    const [nameStatusResult, statResult, diffResult, untrackedResult] =
+      await Promise.all([
+        sandbox.exec("git diff HEAD --name-status", cwd, 30000),
+        sandbox.exec("git diff HEAD --stat", cwd, 30000),
+        sandbox.exec("git diff HEAD", cwd, 60000),
+        // Get untracked files (new files not yet staged)
+        sandbox.exec("git ls-files --others --exclude-standard", cwd, 30000),
+      ]);
+
+    // Parse outputs
+    const fileStatuses = parseNameStatus(nameStatusResult.stdout);
+    const fileStats = parseStats(statResult.stdout);
+    const fileDiffs = splitDiffByFile(diffResult.stdout);
+
+    // Build response
+    const files: DiffFile[] = [];
+    let totalAdditions = 0;
+    let totalDeletions = 0;
+
+    // Add tracked file changes
+    for (const [path, statusInfo] of fileStatuses) {
+      const stats = fileStats.get(path) ?? { additions: 0, deletions: 0 };
+      const diff = fileDiffs.get(path) ?? "";
+
+      totalAdditions += stats.additions;
+      totalDeletions += stats.deletions;
+
+      files.push({
+        path,
+        status: statusInfo.status,
+        additions: stats.additions,
+        deletions: stats.deletions,
+        diff,
+        ...(statusInfo.oldPath && { oldPath: statusInfo.oldPath }),
+      });
+    }
+
+    // Add untracked files (new files)
+    const untrackedFiles = untrackedResult.stdout
+      .trim()
+      .split("\n")
+      .filter((line) => line.length > 0);
+
+    // Fetch content for untracked files to generate diff
+    const untrackedFileContents = await Promise.all(
+      untrackedFiles.map(async (filePath) => {
+        const fullPath = `${cwd}/${filePath}`;
+        try {
+          const content = await sandbox.readFile(fullPath, "utf-8");
+          return { path: filePath, content };
+        } catch {
+          // Skip files we can't read (binary, permissions, etc.)
+          return { path: filePath, content: null };
+        }
+      }),
+    );
+
+    for (const { path, content } of untrackedFileContents) {
+      // Skip binary files or files we couldn't read
+      if (content === null) continue;
+
+      const lines = content.split("\n");
+      const lineCount = lines.length;
+
+      // Generate a synthetic diff for the new file
+      const diffLines = lines.map((line, i) => `+${line}`).join("\n");
+      const syntheticDiff = `diff --git a/${path} b/${path}
+new file mode 100644
+--- /dev/null
++++ b/${path}
+@@ -0,0 +1,${lineCount} @@
+${diffLines}`;
+
+      totalAdditions += lineCount;
+
+      files.push({
+        path,
+        status: "added",
+        additions: lineCount,
+        deletions: 0,
+        diff: syntheticDiff,
+      });
+    }
+
+    // Sort files: modified first, then added, then renamed, then deleted
+    const statusOrder = { modified: 0, added: 1, renamed: 2, deleted: 3 };
+    files.sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
+
+    const response: DiffResponse = {
+      files,
+      summary: {
+        totalFiles: files.length,
+        totalAdditions,
+        totalDeletions,
+      },
+    };
+
+    return Response.json(response);
+  } catch (error) {
+    console.error("Failed to get diff:", error);
+    return Response.json(
+      { error: "Failed to connect to sandbox" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/tasks/[id]/diff/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/route.ts
@@ -199,6 +199,20 @@ export async function GET(req: NextRequest, context: RouteContext) {
         sandbox.exec("git ls-files --others --exclude-standard", cwd, 30000),
       ]);
 
+    // Check if git commands failed (e.g., not a git repo or HEAD doesn't exist)
+    if (!nameStatusResult.success || !diffResult.success) {
+      const stderr =
+        nameStatusResult.stderr || diffResult.stderr || "Unknown git error";
+      console.error("Git command failed:", stderr);
+      return Response.json(
+        {
+          error:
+            "Git command failed. Ensure this is a git repository with at least one commit.",
+        },
+        { status: 400 },
+      );
+    }
+
     // Parse outputs
     const fileStatuses = parseNameStatus(nameStatusResult.stdout);
     const fileStats = parseStats(numstatResult.stdout);

--- a/apps/web/app/api/tasks/[id]/diff/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/route.ts
@@ -238,7 +238,9 @@ export async function GET(req: NextRequest, context: RouteContext) {
       // Skip binary files or files we couldn't read
       if (content === null) continue;
 
-      const lines = content.split("\n");
+      // Remove trailing newlines before splitting to get accurate line count
+      const trimmed = content.trimEnd();
+      const lines = trimmed.length === 0 ? [] : trimmed.split("\n");
       const lineCount = lines.length;
 
       // Generate a synthetic diff for the new file

--- a/apps/web/app/tasks/[id]/diff-viewer.tsx
+++ b/apps/web/app/tasks/[id]/diff-viewer.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChevronDown, ChevronRight, X, FileText, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import type { DiffResponse, DiffFile } from "@/app/api/tasks/[id]/diff/route";
+
+type DiffViewerProps = {
+  taskId: string;
+  sandboxId: string;
+  refreshKey: number;
+  onClose: () => void;
+};
+
+type DiffLineType = "context" | "addition" | "deletion" | "header" | "info";
+
+type ParsedDiffLine = {
+  type: DiffLineType;
+  content: string;
+  oldLineNum?: number;
+  newLineNum?: number;
+};
+
+function parseDiffContent(diff: string): ParsedDiffLine[] {
+  const lines: ParsedDiffLine[] = [];
+  let oldLine = 0;
+  let newLine = 0;
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("diff --git")) {
+      lines.push({ type: "header", content: line });
+    } else if (
+      line.startsWith("index ") ||
+      line.startsWith("---") ||
+      line.startsWith("+++")
+    ) {
+      lines.push({ type: "info", content: line });
+    } else if (line.startsWith("@@")) {
+      // Parse hunk header: @@ -start,count +start,count @@
+      const match = line.match(/@@ -(\d+),?\d* \+(\d+),?\d* @@/);
+      if (match) {
+        oldLine = parseInt(match[1] ?? "1", 10);
+        newLine = parseInt(match[2] ?? "1", 10);
+      }
+      lines.push({ type: "info", content: line });
+    } else if (line.startsWith("+")) {
+      lines.push({
+        type: "addition",
+        content: line.slice(1),
+        newLineNum: newLine++,
+      });
+    } else if (line.startsWith("-")) {
+      lines.push({
+        type: "deletion",
+        content: line.slice(1),
+        oldLineNum: oldLine++,
+      });
+    } else if (line.startsWith(" ") || line === "") {
+      lines.push({
+        type: "context",
+        content: line.slice(1) || "",
+        oldLineNum: oldLine++,
+        newLineNum: newLine++,
+      });
+    }
+  }
+
+  return lines;
+}
+
+function StatusBadge({ status }: { status: DiffFile["status"] }) {
+  const styles = {
+    added: "bg-green-500/20 text-green-400",
+    modified: "bg-blue-500/20 text-blue-400",
+    deleted: "bg-red-500/20 text-red-400",
+    renamed: "bg-yellow-500/20 text-yellow-400",
+  };
+
+  const labels = {
+    added: "New",
+    modified: "Modified",
+    deleted: "Deleted",
+    renamed: "Renamed",
+  };
+
+  return (
+    <span
+      className={cn(
+        "rounded px-1.5 py-0.5 text-[10px] font-medium uppercase",
+        styles[status],
+      )}
+    >
+      {labels[status]}
+    </span>
+  );
+}
+
+function FileEntry({
+  file,
+  isExpanded,
+  onToggle,
+}: {
+  file: DiffFile;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const parsedLines = parseDiffContent(file.diff);
+  const fileName = file.path.split("/").pop() ?? file.path;
+  const dirPath = file.path.slice(0, -fileName.length);
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/50"
+      >
+        {isExpanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+        <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="truncate text-sm">
+            {dirPath && (
+              <span className="text-muted-foreground">{dirPath}</span>
+            )}
+            <span className="font-medium text-foreground">{fileName}</span>
+          </span>
+          <StatusBadge status={file.status} />
+        </div>
+        <div className="flex shrink-0 items-center gap-2 text-xs">
+          {file.additions > 0 && (
+            <span className="text-green-500">+{file.additions}</span>
+          )}
+          {file.deletions > 0 && (
+            <span className="text-red-400">-{file.deletions}</span>
+          )}
+        </div>
+      </button>
+
+      {isExpanded && parsedLines.length > 0 && (
+        <div className="overflow-x-auto border-t border-border bg-muted/30">
+          <div className="min-w-max font-mono text-xs">
+            {parsedLines.map((line, i) => {
+              if (line.type === "header" || line.type === "info") {
+                return (
+                  <div
+                    key={i}
+                    className="flex bg-muted/50 px-2 py-0.5 text-muted-foreground"
+                  >
+                    <span className="w-16 shrink-0" />
+                    <span className="truncate">{line.content}</span>
+                  </div>
+                );
+              }
+
+              return (
+                <div
+                  key={i}
+                  className={cn(
+                    "flex",
+                    line.type === "addition" && "bg-green-950/40",
+                    line.type === "deletion" && "bg-red-950/40",
+                  )}
+                >
+                  <span className="w-8 shrink-0 select-none border-r border-border px-1 py-0.5 text-right text-muted-foreground">
+                    {line.oldLineNum ?? ""}
+                  </span>
+                  <span className="w-8 shrink-0 select-none border-r border-border px-1 py-0.5 text-right text-muted-foreground">
+                    {line.newLineNum ?? ""}
+                  </span>
+                  <span
+                    className={cn(
+                      "w-4 shrink-0 select-none py-0.5 text-center",
+                      line.type === "addition" && "text-green-500",
+                      line.type === "deletion" && "text-red-400",
+                    )}
+                  >
+                    {line.type === "addition"
+                      ? "+"
+                      : line.type === "deletion"
+                        ? "-"
+                        : " "}
+                  </span>
+                  <span className="flex-1 whitespace-pre py-0.5 pr-2">
+                    {line.content}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DiffViewer({
+  taskId,
+  sandboxId,
+  refreshKey,
+  onClose,
+}: DiffViewerProps) {
+  const [data, setData] = useState<DiffResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    async function fetchDiff() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch(
+          `/api/tasks/${taskId}/diff?sandboxId=${sandboxId}`,
+        );
+
+        if (!res.ok) {
+          const errorData = (await res.json()) as { error?: string };
+          throw new Error(errorData.error ?? "Failed to fetch diff");
+        }
+
+        const diffData = (await res.json()) as DiffResponse;
+        setData(diffData);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to fetch diff");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchDiff();
+  }, [taskId, sandboxId, refreshKey]);
+
+  const toggleFile = (path: string) => {
+    setExpandedFiles((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  };
+
+  const expandAll = () => {
+    if (data) {
+      setExpandedFiles(new Set(data.files.map((f) => f.path)));
+    }
+  };
+
+  const collapseAll = () => {
+    setExpandedFiles(new Set());
+  };
+
+  return (
+    <div className="flex h-full w-[500px] flex-col border-l border-border bg-card">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <div className="flex items-center gap-3">
+          <h2 className="font-medium text-foreground">Changes</h2>
+          {data && data.summary.totalFiles > 0 && (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-green-500">
+                +{data.summary.totalAdditions}
+              </span>
+              <span className="text-red-400">
+                -{data.summary.totalDeletions}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {data && data.files.length > 0 && (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={expandAll}
+                className="h-7 px-2 text-xs"
+              >
+                Expand all
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={collapseAll}
+                className="h-7 px-2 text-xs"
+              >
+                Collapse
+              </Button>
+            </>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            className="h-7 w-7"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {error && (
+          <div className="px-4 py-8 text-center">
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        )}
+
+        {!isLoading && !error && data && data.files.length === 0 && (
+          <div className="px-4 py-8 text-center">
+            <p className="text-sm text-muted-foreground">No changes detected</p>
+          </div>
+        )}
+
+        {!isLoading && !error && data && data.files.length > 0 && (
+          <div>
+            {data.files.map((file) => (
+              <FileEntry
+                key={file.path}
+                file={file}
+                isExpanded={expandedFiles.has(file.path)}
+                onToggle={() => toggleFile(file.path)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Footer with file count */}
+      {data && data.files.length > 0 && (
+        <div className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
+          {data.summary.totalFiles} file{data.summary.totalFiles !== 1 && "s"}{" "}
+          changed
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/tasks/[id]/diff-viewer.tsx
+++ b/apps/web/app/tasks/[id]/diff-viewer.tsx
@@ -4,10 +4,10 @@ import { useEffect, useState } from "react";
 import { ChevronDown, ChevronRight, X, FileText, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import type { DiffResponse, DiffFile } from "@/app/api/tasks/[id]/diff/route";
+import type { DiffFile } from "@/app/api/tasks/[id]/diff/route";
+import { useTaskChatContext } from "./task-context";
 
 type DiffViewerProps = {
-  taskId: string;
   sandboxId: string;
   refreshKey: number;
   onClose: () => void;
@@ -199,42 +199,20 @@ function FileEntry({
 }
 
 export function DiffViewer({
-  taskId,
   sandboxId,
   refreshKey,
   onClose,
 }: DiffViewerProps) {
-  const [data, setData] = useState<DiffResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const { diffCache, fetchDiff, diffRefreshKey } = useTaskChatContext();
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
 
+  const { data, error, isLoading } = diffCache;
+
+  // Fetch diff on mount and when refreshKey changes
+  // The fetchDiff function will skip if cache is still valid
   useEffect(() => {
-    async function fetchDiff() {
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const res = await fetch(
-          `/api/tasks/${taskId}/diff?sandboxId=${sandboxId}`,
-        );
-
-        if (!res.ok) {
-          const errorData = (await res.json()) as { error?: string };
-          throw new Error(errorData.error ?? "Failed to fetch diff");
-        }
-
-        const diffData = (await res.json()) as DiffResponse;
-        setData(diffData);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to fetch diff");
-      } finally {
-        setIsLoading(false);
-      }
-    }
-
-    fetchDiff();
-  }, [taskId, sandboxId, refreshKey]);
+    fetchDiff(sandboxId);
+  }, [fetchDiff, sandboxId, refreshKey, diffRefreshKey]);
 
   const toggleFile = (path: string) => {
     setExpandedFiles((prev) => {

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -16,12 +16,21 @@ import {
 import { useChat, type UseChatHelpers } from "@ai-sdk/react";
 import type { WebAgentUIMessage } from "@/app/types";
 import type { Task } from "@/lib/db/schema";
+import type { DiffResponse } from "@/app/api/tasks/[id]/diff/route";
 
 export type SandboxInfo = {
   sandboxId: string;
   createdAt: number;
   timeout: number;
   currentBranch?: string;
+};
+
+type DiffCacheState = {
+  data: DiffResponse | null;
+  error: string | null;
+  isLoading: boolean;
+  /** The refreshKey value when this data was last fetched */
+  lastFetchedKey: number;
 };
 
 type TaskChatContextValue = {
@@ -35,8 +44,12 @@ type TaskChatContextValue = {
   hadInitialMessages: boolean;
   /** Counter that increments when diff should be refreshed */
   diffRefreshKey: number;
-  /** Trigger a diff refresh */
+  /** Trigger a diff refresh (invalidates cache) */
   triggerDiffRefresh: () => void;
+  /** Cached diff state */
+  diffCache: DiffCacheState;
+  /** Fetch diff data (uses cache if valid) */
+  fetchDiff: (sandboxId: string) => Promise<void>;
 };
 
 const TaskChatContext = createContext<TaskChatContextValue | undefined>(
@@ -93,6 +106,55 @@ export function TaskChatProvider({
     setDiffRefreshKey((prev) => prev + 1);
   }, []);
 
+  const [diffCache, setDiffCache] = useState<DiffCacheState>({
+    data: null,
+    error: null,
+    isLoading: false,
+    lastFetchedKey: -1, // -1 means never fetched
+  });
+
+  const fetchDiff = useCallback(
+    async (sandboxId: string) => {
+      // If we already have data for the current refreshKey, skip fetching
+      if (diffCache.lastFetchedKey === diffRefreshKey && !diffCache.isLoading) {
+        return;
+      }
+
+      setDiffCache((prev) => ({
+        ...prev,
+        isLoading: true,
+        error: null,
+      }));
+
+      try {
+        const res = await fetch(
+          `/api/tasks/${task.id}/diff?sandboxId=${sandboxId}`,
+        );
+
+        if (!res.ok) {
+          const errorData = (await res.json()) as { error?: string };
+          throw new Error(errorData.error ?? "Failed to fetch diff");
+        }
+
+        const data = (await res.json()) as DiffResponse;
+        setDiffCache({
+          data,
+          error: null,
+          isLoading: false,
+          lastFetchedKey: diffRefreshKey,
+        });
+      } catch (err) {
+        setDiffCache((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : "Failed to fetch diff",
+          isLoading: false,
+          lastFetchedKey: diffRefreshKey,
+        }));
+      }
+    },
+    [task.id, diffRefreshKey, diffCache.lastFetchedKey, diffCache.isLoading],
+  );
+
   const archiveTask = useCallback(async () => {
     const res = await fetch(`/api/tasks/${task.id}`, {
       method: "PATCH",
@@ -126,6 +188,8 @@ export function TaskChatProvider({
         hadInitialMessages,
         diffRefreshKey,
         triggerDiffRefresh,
+        diffCache,
+        fetchDiff,
       }}
     >
       {children}

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -113,34 +113,30 @@ export function TaskChatProvider({
     lastFetchedKey: -1, // -1 means never fetched
   });
 
-  // Track which refresh key we're currently fetching for (prevents duplicate fetches)
-  const fetchingForKeyRef = useRef<number | null>(null);
+  // Track the current fetch to prevent duplicates and handle race conditions
+  const fetchCounterRef = useRef(0);
+  const lastFetchedKeyRef = useRef<number>(-1);
+  const fetchingKeyRef = useRef<number | null>(null);
 
   const fetchDiff = useCallback(
     async (sandboxId: string) => {
-      // Synchronous check using ref - prevents duplicate fetches for same key
-      if (fetchingForKeyRef.current === diffRefreshKey) {
+      // Skip if we already have data for this key or are already fetching it
+      if (
+        lastFetchedKeyRef.current === diffRefreshKey ||
+        fetchingKeyRef.current === diffRefreshKey
+      ) {
         return;
       }
-      fetchingForKeyRef.current = diffRefreshKey;
+      fetchingKeyRef.current = diffRefreshKey;
 
-      // Check if we already have cached data for this key
-      let shouldFetch = false;
-      setDiffCache((prev) => {
-        if (prev.lastFetchedKey === diffRefreshKey) {
-          return prev; // Already have data for this key
-        }
-        shouldFetch = true;
-        return {
-          ...prev,
-          isLoading: true,
-          error: null,
-        };
-      });
+      // Increment counter and capture this fetch's ID
+      const thisFetchId = ++fetchCounterRef.current;
 
-      if (!shouldFetch) {
-        return;
-      }
+      setDiffCache((prev) => ({
+        ...prev,
+        isLoading: true,
+        error: null,
+      }));
 
       try {
         const res = await fetch(
@@ -154,9 +150,9 @@ export function TaskChatProvider({
 
         const data = (await res.json()) as DiffResponse;
 
-        // Only update state if this fetch is still relevant
-        // (a newer fetch might have started while we were waiting)
-        if (fetchingForKeyRef.current === diffRefreshKey) {
+        // Only update if this is still the latest fetch
+        if (thisFetchId === fetchCounterRef.current) {
+          lastFetchedKeyRef.current = diffRefreshKey;
           setDiffCache({
             data,
             error: null,
@@ -164,8 +160,11 @@ export function TaskChatProvider({
             lastFetchedKey: diffRefreshKey,
           });
         }
+        // If not the latest fetch, don't update - the newer fetch will handle it
       } catch (err) {
-        if (fetchingForKeyRef.current === diffRefreshKey) {
+        // Only update if this is still the latest fetch
+        if (thisFetchId === fetchCounterRef.current) {
+          lastFetchedKeyRef.current = diffRefreshKey;
           setDiffCache((prev) => ({
             ...prev,
             error: err instanceof Error ? err.message : "Failed to fetch diff",

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -113,18 +113,34 @@ export function TaskChatProvider({
     lastFetchedKey: -1, // -1 means never fetched
   });
 
+  // Track which refresh key we're currently fetching for (prevents duplicate fetches)
+  const fetchingForKeyRef = useRef<number | null>(null);
+
   const fetchDiff = useCallback(
     async (sandboxId: string) => {
-      // If we already have data for the current refreshKey, skip fetching
-      if (diffCache.lastFetchedKey === diffRefreshKey && !diffCache.isLoading) {
+      // Synchronous check using ref - prevents duplicate fetches for same key
+      if (fetchingForKeyRef.current === diffRefreshKey) {
         return;
       }
+      fetchingForKeyRef.current = diffRefreshKey;
 
-      setDiffCache((prev) => ({
-        ...prev,
-        isLoading: true,
-        error: null,
-      }));
+      // Check if we already have cached data for this key
+      let shouldFetch = false;
+      setDiffCache((prev) => {
+        if (prev.lastFetchedKey === diffRefreshKey) {
+          return prev; // Already have data for this key
+        }
+        shouldFetch = true;
+        return {
+          ...prev,
+          isLoading: true,
+          error: null,
+        };
+      });
+
+      if (!shouldFetch) {
+        return;
+      }
 
       try {
         const res = await fetch(
@@ -137,22 +153,29 @@ export function TaskChatProvider({
         }
 
         const data = (await res.json()) as DiffResponse;
-        setDiffCache({
-          data,
-          error: null,
-          isLoading: false,
-          lastFetchedKey: diffRefreshKey,
-        });
+
+        // Only update state if this fetch is still relevant
+        // (a newer fetch might have started while we were waiting)
+        if (fetchingForKeyRef.current === diffRefreshKey) {
+          setDiffCache({
+            data,
+            error: null,
+            isLoading: false,
+            lastFetchedKey: diffRefreshKey,
+          });
+        }
       } catch (err) {
-        setDiffCache((prev) => ({
-          ...prev,
-          error: err instanceof Error ? err.message : "Failed to fetch diff",
-          isLoading: false,
-          lastFetchedKey: diffRefreshKey,
-        }));
+        if (fetchingForKeyRef.current === diffRefreshKey) {
+          setDiffCache((prev) => ({
+            ...prev,
+            error: err instanceof Error ? err.message : "Failed to fetch diff",
+            isLoading: false,
+            lastFetchedKey: diffRefreshKey,
+          }));
+        }
       }
     },
-    [task.id, diffRefreshKey, diffCache.lastFetchedKey, diffCache.isLoading],
+    [task.id, diffRefreshKey],
   );
 
   const archiveTask = useCallback(async () => {

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -33,6 +33,10 @@ type TaskChatContextValue = {
   archiveTask: () => Promise<void>;
   /** Whether the task had persisted messages when it was loaded */
   hadInitialMessages: boolean;
+  /** Counter that increments when diff should be refreshed */
+  diffRefreshKey: number;
+  /** Trigger a diff refresh */
+  triggerDiffRefresh: () => void;
 };
 
 const TaskChatContext = createContext<TaskChatContextValue | undefined>(
@@ -83,6 +87,12 @@ export function TaskChatProvider({
     setSandboxInfoState(null);
   }, []);
 
+  const [diffRefreshKey, setDiffRefreshKey] = useState(0);
+
+  const triggerDiffRefresh = useCallback(() => {
+    setDiffRefreshKey((prev) => prev + 1);
+  }, []);
+
   const archiveTask = useCallback(async () => {
     const res = await fetch(`/api/tasks/${task.id}`, {
       method: "PATCH",
@@ -114,6 +124,8 @@ export function TaskChatProvider({
         clearSandboxInfo,
         archiveTask,
         hadInitialMessages,
+        diffRefreshKey,
+        triggerDiffRefresh,
       }}
     >
       {children}

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -295,7 +295,7 @@ export function TaskDetailContent() {
 
   useEffect(() => {
     let hasFileChange = false;
-    const fileModifyingTools = ["tool-write", "tool-edit", "tool-bash"];
+    const fileModifyingTools = ["tool-write", "tool-edit"];
 
     for (const message of messages) {
       if (message.role !== "assistant") continue;

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { isToolUIPart } from "ai";
 import type { ComponentProps, ReactNode } from "react";
@@ -17,6 +17,7 @@ import {
   Share2,
   GitPullRequest,
   MoreVertical,
+  GitCompare,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -28,6 +29,7 @@ import type { WebAgentUIToolPart, WebAgentUIMessagePart } from "@/app/types";
 import type { TaskToolUIPart } from "@open-harness/agent";
 
 import { useTaskChatContext, type SandboxInfo } from "./task-context";
+import { DiffViewer } from "./diff-viewer";
 
 const customComponents = {
   pre: ({ children, ...props }: ComponentProps<"pre">) => {
@@ -170,6 +172,7 @@ export function TaskDetailContent() {
   const [input, setInput] = useState("");
   const [isCreatingSandbox, setIsCreatingSandbox] = useState(false);
   const [prDialogOpen, setPrDialogOpen] = useState(false);
+  const [showDiffPanel, setShowDiffPanel] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const { containerRef, isAtBottom, scrollToBottom } =
     useScrollToBottom<HTMLDivElement>();
@@ -181,6 +184,8 @@ export function TaskDetailContent() {
     clearSandboxInfo,
     archiveTask,
     hadInitialMessages,
+    diffRefreshKey,
+    triggerDiffRefresh,
   } = useTaskChatContext();
   const {
     messages,
@@ -269,6 +274,59 @@ export function TaskDetailContent() {
     task.title,
   ]);
 
+  // Track tool completions to trigger diff refresh
+  const prevToolStatesRef = useRef<Map<string, string>>(new Map());
+
+  // Extract current tool states from messages
+  const currentToolStates = useMemo(() => {
+    const states = new Map<string, string>();
+    for (const message of messages) {
+      if (message.role !== "assistant") continue;
+      for (const part of message.parts) {
+        if (isToolUIPart(part)) {
+          states.set(part.toolCallId, part.state);
+        }
+      }
+    }
+    return states;
+  }, [messages]);
+
+  useEffect(() => {
+    // Only trigger refresh if diff panel is visible
+    if (!showDiffPanel) {
+      prevToolStatesRef.current = currentToolStates;
+      return;
+    }
+
+    let shouldRefresh = false;
+    const fileModifyingTools = ["tool-write", "tool-edit", "tool-bash"];
+
+    for (const message of messages) {
+      if (message.role !== "assistant") continue;
+
+      for (const part of message.parts) {
+        if (!isToolUIPart(part)) continue;
+
+        const toolId = part.toolCallId;
+        const toolState = part.state;
+        const prevState = prevToolStatesRef.current.get(toolId);
+        const isFileModifyingTool = fileModifyingTools.includes(part.type);
+        const justCompleted =
+          toolState === "output-available" && prevState !== "output-available";
+
+        if (isFileModifyingTool && justCompleted) {
+          shouldRefresh = true;
+        }
+      }
+    }
+
+    prevToolStatesRef.current = currentToolStates;
+
+    if (shouldRefresh) {
+      triggerDiffRefresh();
+    }
+  }, [currentToolStates, messages, showDiffPanel, triggerDiffRefresh]);
+
   if (error) {
     return (
       <div className="flex h-screen items-center justify-center bg-background">
@@ -327,6 +385,15 @@ export function TaskDetailContent() {
             <Button variant="ghost" size="sm">
               <Share2 className="mr-2 h-4 w-4" />
               Share
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowDiffPanel(!showDiffPanel)}
+              disabled={!sandboxInfo}
+            >
+              <GitCompare className="mr-2 h-4 w-4" />
+              Diff
             </Button>
             {task?.prNumber ? (
               <Button
@@ -591,6 +658,16 @@ export function TaskDetailContent() {
           onOpenChange={setPrDialogOpen}
           task={task}
           sandboxId={sandboxInfo?.sandboxId ?? null}
+        />
+      )}
+
+      {/* Diff Viewer Panel */}
+      {showDiffPanel && sandboxInfo && (
+        <DiffViewer
+          taskId={task.id}
+          sandboxId={sandboxInfo.sandboxId}
+          refreshKey={diffRefreshKey}
+          onClose={() => setShowDiffPanel(false)}
         />
       )}
     </div>

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -276,6 +276,8 @@ export function TaskDetailContent() {
 
   // Track tool completions to trigger diff refresh
   const prevToolStatesRef = useRef<Map<string, string>>(new Map());
+  // Track if we've auto-opened the diff panel (don't re-open if user closed it)
+  const hasAutoOpenedDiffRef = useRef(false);
 
   // Extract current tool states from messages
   const currentToolStates = useMemo(() => {
@@ -292,13 +294,7 @@ export function TaskDetailContent() {
   }, [messages]);
 
   useEffect(() => {
-    // Only trigger refresh if diff panel is visible
-    if (!showDiffPanel) {
-      prevToolStatesRef.current = currentToolStates;
-      return;
-    }
-
-    let shouldRefresh = false;
+    let hasFileChange = false;
     const fileModifyingTools = ["tool-write", "tool-edit", "tool-bash"];
 
     for (const message of messages) {
@@ -315,17 +311,29 @@ export function TaskDetailContent() {
           toolState === "output-available" && prevState !== "output-available";
 
         if (isFileModifyingTool && justCompleted) {
-          shouldRefresh = true;
+          hasFileChange = true;
         }
       }
     }
 
     prevToolStatesRef.current = currentToolStates;
 
-    if (shouldRefresh) {
+    if (hasFileChange) {
+      // Auto-open diff panel on first file change
+      if (!showDiffPanel && !hasAutoOpenedDiffRef.current && sandboxInfo) {
+        hasAutoOpenedDiffRef.current = true;
+        setShowDiffPanel(true);
+      }
+      // Always invalidate cache when files change
       triggerDiffRefresh();
     }
-  }, [currentToolStates, messages, showDiffPanel, triggerDiffRefresh]);
+  }, [
+    currentToolStates,
+    messages,
+    showDiffPanel,
+    sandboxInfo,
+    triggerDiffRefresh,
+  ]);
 
   if (error) {
     return (
@@ -664,7 +672,6 @@ export function TaskDetailContent() {
       {/* Diff Viewer Panel */}
       {showDiffPanel && sandboxInfo && (
         <DiffViewer
-          taskId={task.id}
           sandboxId={sandboxInfo.sandboxId}
           refreshKey={diffRefreshKey}
           onClose={() => setShowDiffPanel(false)}


### PR DESCRIPTION
Adds a new diff viewing interface that displays git changes in the task editor.

- Created `/api/tasks/[id]/diff` endpoint that parses git diff output and returns structured file change data including additions/deletions
- Built client-side `DiffViewer` component with expandable file entries, syntax highlighting, and line numbers
- Integrated diff panel that auto-opens when file-modifying tools complete and updates when changes are detected
- Added caching logic to prevent redundant API calls and deduplication of concurrent fetch requests