### PR TITLE
Allow format and turbo commands in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,8 @@
     "allow": [
       "Bash(bun add:*)",
       "Bash(bun run typecheck:*)",
+      "Bash(bun run format:*)",
+      "Bash(turbo:*)",
       "Bash(ls:*)",
       "Bash(bun -e:*)",
       "WebSearch",


### PR DESCRIPTION
Update allowed commands to enable formatting and build tooling within Claude.

- Add `Bash(bun run format:*)` to allow code formatting operations
- Add `Bash(turbo:*)` to allow turbo monorepo build commands
- Maintains existing command permissions for package management and type checking