### PR TITLE
Add GitHub repository creation feature for tasks

### DIFF
--- a/apps/web/app/api/github/create-repo/route.ts
+++ b/apps/web/app/api/github/create-repo/route.ts
@@ -8,6 +8,9 @@ import { getUserGitHubToken } from "@/lib/github/user-token";
 // Allow up to 2 minutes for git operations
 export const maxDuration = 120;
 
+// Escape shell metacharacters to prevent command injection
+const escapeShellArg = (arg: string) => `'${arg.replace(/'/g, "'\\''")}'`;
+
 interface CreateRepoRequest {
   taskId: string;
   sandboxId: string;
@@ -117,6 +120,23 @@ export async function POST(req: Request) {
     );
   }
 
+  // Ensure we have required fields from repo creation
+  if (!repoResult.cloneUrl || !repoResult.owner || !repoResult.repoName) {
+    return Response.json(
+      { error: "Repository created but missing required fields" },
+      { status: 500 },
+    );
+  }
+
+  // Helper to create error response with context about created repo
+  const repoCreatedError = (message: string) =>
+    Response.json(
+      {
+        error: `${message}. Note: Repository "${repoResult.owner}/${repoResult.repoName}" was created on GitHub. You may need to delete it manually before retrying.`,
+      },
+      { status: 500 },
+    );
+
   // 8. Initialize git if not already initialized
   const gitCheckResult = await sandbox.exec(
     "git rev-parse --git-dir",
@@ -127,21 +147,22 @@ export async function POST(req: Request) {
     // Initialize git
     const initResult = await sandbox.exec("git init", cwd, 10000);
     if (!initResult.success) {
-      return Response.json(
-        { error: "Failed to initialize git repository" },
-        { status: 500 },
-      );
+      return repoCreatedError("Failed to initialize git repository");
     }
   }
 
   // 9. Configure git user (in case not already configured)
+  const userName = session.user.name ?? session.user.username;
+  const userEmail =
+    session.user.email ?? `${session.user.username}@users.noreply.github.com`;
+
   await sandbox.exec(
-    `git config user.name "${session.user.name ?? session.user.username}"`,
+    `git config user.name ${escapeShellArg(userName)}`,
     cwd,
     5000,
   );
   await sandbox.exec(
-    `git config user.email "${session.user.email ?? `${session.user.username}@users.noreply.github.com`}"`,
+    `git config user.email ${escapeShellArg(userEmail)}`,
     cwd,
     5000,
   );
@@ -161,28 +182,30 @@ export async function POST(req: Request) {
     5000,
   );
   if (!addRemoteResult.success) {
-    return Response.json(
-      { error: "Failed to add remote origin" },
-      { status: 500 },
-    );
+    return repoCreatedError("Failed to add remote origin");
   }
 
   // 11. Stage all files
   const addResult = await sandbox.exec("git add -A", cwd, 10000);
   if (!addResult.success) {
-    return Response.json({ error: "Failed to stage files" }, { status: 500 });
+    return repoCreatedError("Failed to stage files");
   }
 
   // 12. Generate commit message with AI
   const diffResult = await sandbox.exec("git diff --cached --stat", cwd, 30000);
   let commitMessage = "Initial commit";
 
+  // Sanitize taskTitle to prevent prompt injection and limit length
+  const sanitizedTaskTitle = taskTitle
+    .slice(0, 200)
+    .replace(/[^\w\s.,!?-]/g, "");
+
   try {
     const commitMsgResult = await generateText({
       model: gateway("anthropic/claude-haiku-4.5"),
       prompt: `Generate a concise git commit message for an initial commit of a new project. Use conventional commit format. One line only, max 72 characters.
 
-Task context: ${taskTitle}
+Task context: ${sanitizedTaskTitle}
 
 Files being committed:
 ${diffResult.stdout.slice(0, 4000)}
@@ -203,9 +226,8 @@ Respond with ONLY the commit message, nothing else.`,
     10000,
   );
   if (!commitResult.success) {
-    return Response.json(
-      { error: `Failed to commit: ${commitResult.stdout}` },
-      { status: 500 },
+    return repoCreatedError(
+      `Failed to commit: ${commitResult.stdout.slice(0, 100)}`,
     );
   }
 
@@ -216,10 +238,7 @@ Respond with ONLY the commit message, nothing else.`,
   const pushResult = await sandbox.exec("git push -u origin main", cwd, 60000);
   if (!pushResult.success) {
     const pushOutput = pushResult.stdout + (pushResult.stderr ?? "");
-    return Response.json(
-      { error: `Failed to push: ${pushOutput.slice(0, 200)}` },
-      { status: 500 },
-    );
+    return repoCreatedError(`Failed to push: ${pushOutput.slice(0, 100)}`);
   }
 
   // 16. Update task with new repo info

--- a/apps/web/app/api/github/create-repo/route.ts
+++ b/apps/web/app/api/github/create-repo/route.ts
@@ -172,12 +172,19 @@ export async function POST(req: Request) {
   await sandbox.exec("git remote remove origin 2>/dev/null || true", cwd, 5000);
 
   // Add origin with token for auth
-  const authUrl = repoResult.cloneUrl?.replace(
+  if (!repoResult.cloneUrl) {
+    return Response.json(
+      { error: "Repository clone URL is missing" },
+      { status: 500 },
+    );
+  }
+
+  const authUrl = repoResult.cloneUrl.replace(
     "https://",
     `https://${githubToken}@`,
   );
   const addRemoteResult = await sandbox.exec(
-    `git remote add origin ${authUrl}`,
+    `git remote add origin "${authUrl}"`,
     cwd,
     5000,
   );

--- a/apps/web/app/api/github/create-repo/route.ts
+++ b/apps/web/app/api/github/create-repo/route.ts
@@ -1,0 +1,243 @@
+import { connectVercelSandbox } from "@open-harness/sandbox";
+import { generateText, gateway } from "ai";
+import { getTaskById, updateTask } from "@/lib/db/tasks";
+import { getServerSession } from "@/lib/session/get-server-session";
+import { createRepository } from "@/lib/github/client";
+import { getUserGitHubToken } from "@/lib/github/user-token";
+
+// Allow up to 2 minutes for git operations
+export const maxDuration = 120;
+
+interface CreateRepoRequest {
+  taskId: string;
+  sandboxId: string;
+  repoName: string;
+  description?: string;
+  isPrivate?: boolean;
+  taskTitle: string;
+}
+
+export async function POST(req: Request) {
+  // 1. Validate session
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  // 2. Parse request
+  let body: CreateRepoRequest;
+  try {
+    body = (await req.json()) as CreateRepoRequest;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { taskId, sandboxId, repoName, description, isPrivate, taskTitle } =
+    body;
+
+  if (!taskId) {
+    return Response.json({ error: "Task ID is required" }, { status: 400 });
+  }
+  if (!repoName) {
+    return Response.json(
+      { error: "Repository name is required" },
+      { status: 400 },
+    );
+  }
+
+  // 3. Verify task ownership
+  const task = await getTaskById(taskId);
+  if (!task) {
+    return Response.json({ error: "Task not found" }, { status: 404 });
+  }
+  if (task.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Task should not already have a repo
+  if (task.cloneUrl) {
+    return Response.json(
+      { error: "Task already has a repository" },
+      { status: 400 },
+    );
+  }
+
+  if (!sandboxId) {
+    return Response.json(
+      { error: "Sandbox not active. Please wait for sandbox to start." },
+      { status: 400 },
+    );
+  }
+  if (!task.sandboxId) {
+    return Response.json(
+      { error: "Sandbox not linked to task" },
+      { status: 400 },
+    );
+  }
+  if (task.sandboxId !== sandboxId) {
+    return Response.json(
+      { error: "Sandbox does not belong to this task" },
+      { status: 403 },
+    );
+  }
+
+  // 4. Get GitHub token for git operations
+  const githubToken = await getUserGitHubToken();
+  if (!githubToken) {
+    return Response.json({ error: "GitHub not connected" }, { status: 401 });
+  }
+
+  // 5. Connect to sandbox
+  const sandbox = await connectVercelSandbox({ sandboxId });
+  const cwd = sandbox.workingDirectory;
+
+  // 6. Check if there are any files to push
+  const filesResult = await sandbox.exec("ls -A", cwd, 10000);
+  if (!filesResult.success || !filesResult.stdout.trim()) {
+    return Response.json(
+      {
+        error:
+          "No files in sandbox. Create some files before creating a repository.",
+      },
+      { status: 400 },
+    );
+  }
+
+  // 7. Create GitHub repository
+  const repoResult = await createRepository({
+    name: repoName,
+    description,
+    isPrivate,
+  });
+
+  if (!repoResult.success) {
+    return Response.json(
+      { error: repoResult.error ?? "Failed to create repository" },
+      { status: 400 },
+    );
+  }
+
+  // 8. Initialize git if not already initialized
+  const gitCheckResult = await sandbox.exec(
+    "git rev-parse --git-dir",
+    cwd,
+    5000,
+  );
+  if (!gitCheckResult.success) {
+    // Initialize git
+    const initResult = await sandbox.exec("git init", cwd, 10000);
+    if (!initResult.success) {
+      return Response.json(
+        { error: "Failed to initialize git repository" },
+        { status: 500 },
+      );
+    }
+  }
+
+  // 9. Configure git user (in case not already configured)
+  await sandbox.exec(
+    `git config user.name "${session.user.name ?? session.user.username}"`,
+    cwd,
+    5000,
+  );
+  await sandbox.exec(
+    `git config user.email "${session.user.email ?? `${session.user.username}@users.noreply.github.com`}"`,
+    cwd,
+    5000,
+  );
+
+  // 10. Add remote origin with authentication
+  // First remove existing origin if any
+  await sandbox.exec("git remote remove origin 2>/dev/null || true", cwd, 5000);
+
+  // Add origin with token for auth
+  const authUrl = repoResult.cloneUrl?.replace(
+    "https://",
+    `https://${githubToken}@`,
+  );
+  const addRemoteResult = await sandbox.exec(
+    `git remote add origin ${authUrl}`,
+    cwd,
+    5000,
+  );
+  if (!addRemoteResult.success) {
+    return Response.json(
+      { error: "Failed to add remote origin" },
+      { status: 500 },
+    );
+  }
+
+  // 11. Stage all files
+  const addResult = await sandbox.exec("git add -A", cwd, 10000);
+  if (!addResult.success) {
+    return Response.json({ error: "Failed to stage files" }, { status: 500 });
+  }
+
+  // 12. Generate commit message with AI
+  const diffResult = await sandbox.exec("git diff --cached --stat", cwd, 30000);
+  let commitMessage = "Initial commit";
+
+  try {
+    const commitMsgResult = await generateText({
+      model: gateway("anthropic/claude-haiku-4.5"),
+      prompt: `Generate a concise git commit message for an initial commit of a new project. Use conventional commit format. One line only, max 72 characters.
+
+Task context: ${taskTitle}
+
+Files being committed:
+${diffResult.stdout.slice(0, 4000)}
+
+Respond with ONLY the commit message, nothing else.`,
+    });
+    commitMessage = commitMsgResult.text.trim() || "Initial commit";
+  } catch {
+    // Use fallback message if AI generation fails
+    commitMessage = "feat: initial commit";
+  }
+
+  // 13. Create commit
+  const escapedMessage = commitMessage.replace(/'/g, "'\\''");
+  const commitResult = await sandbox.exec(
+    `git commit -m '${escapedMessage}'`,
+    cwd,
+    10000,
+  );
+  if (!commitResult.success) {
+    return Response.json(
+      { error: `Failed to commit: ${commitResult.stdout}` },
+      { status: 500 },
+    );
+  }
+
+  // 14. Rename branch to main if needed
+  await sandbox.exec("git branch -M main", cwd, 5000);
+
+  // 15. Push to remote
+  const pushResult = await sandbox.exec("git push -u origin main", cwd, 60000);
+  if (!pushResult.success) {
+    const pushOutput = pushResult.stdout + (pushResult.stderr ?? "");
+    return Response.json(
+      { error: `Failed to push: ${pushOutput.slice(0, 200)}` },
+      { status: 500 },
+    );
+  }
+
+  // 16. Update task with new repo info
+  await updateTask(taskId, {
+    repoOwner: repoResult.owner,
+    repoName: repoResult.repoName,
+    cloneUrl: `https://github.com/${repoResult.owner}/${repoResult.repoName}`,
+    branch: "main",
+    isNewBranch: false,
+  });
+
+  // 17. Return success response
+  return Response.json({
+    success: true,
+    repoUrl: repoResult.repoUrl,
+    cloneUrl: repoResult.cloneUrl,
+    owner: repoResult.owner,
+    repoName: repoResult.repoName,
+    branch: "main",
+  });
+}

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -6,7 +6,7 @@ import { getTaskById, updateTask } from "@/lib/db/tasks";
 const DEFAULT_TIMEOUT = 300_000; // 5 minutes
 
 interface CreateSandboxRequest {
-  repoUrl: string;
+  repoUrl?: string;
   branch?: string;
   isNewBranch?: boolean;
   taskId?: string;
@@ -28,10 +28,6 @@ export async function POST(req: Request) {
     taskId,
     sandboxId: providedSandboxId,
   } = body;
-
-  if (!repoUrl) {
-    return Response.json({ error: "repoUrl is required" }, { status: 400 });
-  }
 
   // Get user's GitHub token
   const githubToken = await getUserGitHubToken();
@@ -75,15 +71,9 @@ export async function POST(req: Request) {
   // Only create new branch on first sandbox creation (no existing sandboxId)
   const shouldCreateNewBranch = isNewBranch && !taskSandboxId;
 
-  const sandbox = await connectVercelSandbox({
+  // Build sandbox options - source is only included when repoUrl is provided
+  const sandboxOptions: Parameters<typeof connectVercelSandbox>[0] = {
     timeout: DEFAULT_TIMEOUT,
-    source: {
-      url: repoUrl,
-      token: githubToken,
-      // If creating new branch: don't specify branch (clone default), use newBranch
-      // Otherwise: clone the specified branch
-      ...(shouldCreateNewBranch ? { newBranch: branch } : { branch }),
-    },
     gitUser: {
       name: session.user.name ?? session.user.username,
       email:
@@ -93,7 +83,20 @@ export async function POST(req: Request) {
     env: {
       GITHUB_TOKEN: githubToken,
     },
-  });
+  };
+
+  // Only add source when we have a repo to clone
+  if (repoUrl) {
+    sandboxOptions.source = {
+      url: repoUrl,
+      token: githubToken,
+      // If creating new branch: don't specify branch (clone default), use newBranch
+      // Otherwise: clone the specified branch
+      ...(shouldCreateNewBranch ? { newBranch: branch } : { branch }),
+    };
+  }
+
+  const sandbox = await connectVercelSandbox(sandboxOptions);
 
   // Update task with sandboxId if this is a new sandbox
   // Verify task ownership before updating

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -16,6 +16,7 @@ import {
   Archive,
   Share2,
   GitPullRequest,
+  FolderGit2,
   MoreVertical,
 } from "lucide-react";
 
@@ -23,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { ToolCall } from "@/components/tool-call";
 import { TaskGroupView } from "@/components/task-group-view";
 import { CreatePRDialog } from "@/components/create-pr-dialog";
+import { CreateRepoDialog } from "@/components/create-repo-dialog";
 import { useScrollToBottom } from "@/hooks/use-scroll-to-bottom";
 import type { WebAgentUIToolPart, WebAgentUIMessagePart } from "@/app/types";
 import type { TaskToolUIPart } from "@open-harness/agent";
@@ -52,7 +54,7 @@ const shikiThemes = ["github-dark", "github-dark"] as [
 ];
 
 async function createSandbox(
-  cloneUrl: string,
+  cloneUrl: string | undefined,
   branch: string | undefined,
   isNewBranch: boolean,
   taskId: string,
@@ -63,8 +65,8 @@ async function createSandbox(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       repoUrl: cloneUrl,
-      branch: branch ?? "main",
-      isNewBranch,
+      branch: cloneUrl ? (branch ?? "main") : undefined,
+      isNewBranch: cloneUrl ? isNewBranch : false,
       taskId,
       sandboxId: existingSandboxId,
     }),
@@ -170,6 +172,7 @@ export function TaskDetailContent() {
   const [input, setInput] = useState("");
   const [isCreatingSandbox, setIsCreatingSandbox] = useState(false);
   const [prDialogOpen, setPrDialogOpen] = useState(false);
+  const [repoDialogOpen, setRepoDialogOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const { containerRef, isAtBottom, scrollToBottom } =
     useScrollToBottom<HTMLDivElement>();
@@ -228,31 +231,29 @@ export function TaskDetailContent() {
 
       // Create sandbox and send first message
       const initTask = async () => {
-        if (task.cloneUrl) {
-          setIsCreatingSandbox(true);
-          try {
-            // Only create new branch on first sandbox creation
-            // If task already has a sandboxId, branch was already created
-            const shouldCreateNewBranch = task.isNewBranch && !task.sandboxId;
-            const newSandbox = await createSandbox(
-              task.cloneUrl,
-              task.branch ?? undefined,
-              shouldCreateNewBranch,
-              task.id,
-              task.sandboxId ?? undefined,
-            );
-            setSandboxInfo(newSandbox);
-          } catch (err) {
-            console.error("Failed to create sandbox:", err);
-            return;
-          } finally {
-            setIsCreatingSandbox(false);
-          }
+        // Always create a sandbox - either with repo or empty
+        setIsCreatingSandbox(true);
+        try {
+          // Only create new branch on first sandbox creation
+          // If task already has a sandboxId, branch was already created
+          const shouldCreateNewBranch = task.isNewBranch && !task.sandboxId;
+          const newSandbox = await createSandbox(
+            task.cloneUrl ?? undefined,
+            task.branch ?? undefined,
+            shouldCreateNewBranch,
+            task.id,
+            task.sandboxId ?? undefined,
+          );
+          setSandboxInfo(newSandbox);
+        } catch (err) {
+          console.error("Failed to create sandbox:", err);
+          return;
+        } finally {
+          setIsCreatingSandbox(false);
         }
 
-        if (task.cloneUrl || task.sandboxId) {
-          sendMessage({ text: task.title });
-        }
+        // Send initial message for all tasks (with or without repo)
+        sendMessage({ text: task.title });
       };
 
       initTask();
@@ -328,27 +329,40 @@ export function TaskDetailContent() {
               <Share2 className="mr-2 h-4 w-4" />
               Share
             </Button>
-            {task?.prNumber ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const prUrl = `https://github.com/${task.repoOwner}/${task.repoName}/pull/${task.prNumber}`;
-                  window.open(prUrl, "_blank");
-                }}
-              >
-                <GitPullRequest className="mr-2 h-4 w-4" />
-                View PR #{task.prNumber}
-              </Button>
+            {task?.cloneUrl ? (
+              // Task has a repo - show PR buttons
+              task?.prNumber ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    const prUrl = `https://github.com/${task.repoOwner}/${task.repoName}/pull/${task.prNumber}`;
+                    window.open(prUrl, "_blank");
+                  }}
+                >
+                  <GitPullRequest className="mr-2 h-4 w-4" />
+                  View PR #{task.prNumber}
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPrDialogOpen(true)}
+                  disabled={!task?.branch}
+                >
+                  <GitPullRequest className="mr-2 h-4 w-4" />
+                  Create PR
+                </Button>
+              )
             ) : (
+              // Task has no repo - show Create Repo button
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => setPrDialogOpen(true)}
-                disabled={!task?.branch || !task?.cloneUrl}
+                onClick={() => setRepoDialogOpen(true)}
               >
-                <GitPullRequest className="mr-2 h-4 w-4" />
-                Create PR
+                <FolderGit2 className="mr-2 h-4 w-4" />
+                Create Repo
               </Button>
             )}
             <Button variant="ghost" size="icon">
@@ -525,7 +539,8 @@ export function TaskDetailContent() {
                 const messageText = input;
                 setInput("");
 
-                if (!isSandboxValid(sandboxInfo) && task.cloneUrl) {
+                // Recreate sandbox if expired
+                if (!isSandboxValid(sandboxInfo)) {
                   setIsCreatingSandbox(true);
                   try {
                     // Only create new branch on first sandbox creation
@@ -533,7 +548,7 @@ export function TaskDetailContent() {
                     const shouldCreateNewBranch =
                       task.isNewBranch && !task.sandboxId;
                     const newSandbox = await createSandbox(
-                      task.cloneUrl,
+                      task.cloneUrl ?? undefined,
                       task.branch ?? undefined,
                       shouldCreateNewBranch,
                       task.id,
@@ -589,6 +604,16 @@ export function TaskDetailContent() {
         <CreatePRDialog
           open={prDialogOpen}
           onOpenChange={setPrDialogOpen}
+          task={task}
+          sandboxId={sandboxInfo?.sandboxId ?? null}
+        />
+      )}
+
+      {/* Create Repo Dialog */}
+      {task && (
+        <CreateRepoDialog
+          open={repoDialogOpen}
+          onOpenChange={setRepoDialogOpen}
           task={task}
           sandboxId={sandboxInfo?.sandboxId ?? null}
         />

--- a/apps/web/components/create-repo-dialog.tsx
+++ b/apps/web/components/create-repo-dialog.tsx
@@ -177,7 +177,7 @@ export function CreateRepoDialog({
                   disabled={isCreating}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Use letters, numbers, hyphens, and underscores only.
+                  Use letters, numbers, hyphens, underscores, and periods only.
                 </p>
               </div>
 

--- a/apps/web/components/create-repo-dialog.tsx
+++ b/apps/web/components/create-repo-dialog.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { ExternalLink, Check, Loader2, FolderGit2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import type { Task } from "@/lib/db/schema";
+
+interface CreateRepoDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  task: Task;
+  sandboxId: string | null;
+}
+
+interface CreateRepoResult {
+  repoUrl: string;
+  owner: string;
+  repoName: string;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/--+/g, "-")
+    .trim()
+    .slice(0, 50);
+}
+
+export function CreateRepoDialog({
+  open,
+  onOpenChange,
+  task,
+  sandboxId,
+}: CreateRepoDialogProps) {
+  const [repoName, setRepoName] = useState("");
+  const [description, setDescription] = useState("");
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [result, setResult] = useState<CreateRepoResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      // Generate a suggested repo name from the task title
+      const suggestedName = slugify(task.title);
+      setRepoName(suggestedName);
+      setDescription("");
+      setIsPrivate(false);
+      setResult(null);
+      setError(null);
+    }
+  }, [open, task.title]);
+
+  const handleCreate = async () => {
+    if (!repoName.trim()) {
+      setError("Repository name is required");
+      return;
+    }
+
+    if (!sandboxId) {
+      setError("Sandbox not active. Please wait for sandbox to start.");
+      return;
+    }
+
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/github/create-repo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          taskId: task.id,
+          sandboxId,
+          repoName: repoName.trim(),
+          description: description.trim() || undefined,
+          isPrivate,
+          taskTitle: task.title,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to create repository");
+      }
+
+      setResult({
+        repoUrl: data.repoUrl,
+        owner: data.owner,
+        repoName: data.repoName,
+      });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create repository",
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+    // If repo was created, reload the page to update task state
+    if (result) {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FolderGit2 className="h-5 w-5" />
+            Create Repository
+          </DialogTitle>
+          <DialogDescription>
+            Create a new GitHub repository from your work in this sandbox.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result ? (
+          // Success state
+          <div className="flex flex-col items-center gap-4 py-6">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10">
+              <Check className="h-6 w-6 text-green-500" />
+            </div>
+            <div className="text-center">
+              <p className="font-medium">Repository created successfully!</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {result.owner}/{result.repoName}
+              </p>
+              {/* External link to GitHub - not internal navigation */}
+              {/* oxlint-disable-next-line nextjs/no-html-link-for-pages */}
+              <a
+                href={result.repoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex items-center gap-1 text-sm text-blue-500 hover:underline"
+              >
+                View on GitHub
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+            <Button variant="outline" onClick={handleClose}>
+              Close
+            </Button>
+          </div>
+        ) : (
+          // Form
+          <>
+            <div className="grid gap-4 py-4">
+              {/* Repository Name */}
+              <div className="grid gap-2">
+                <Label htmlFor="repo-name">Repository name</Label>
+                <Input
+                  id="repo-name"
+                  placeholder="my-awesome-project"
+                  value={repoName}
+                  onChange={(e) => setRepoName(e.target.value)}
+                  disabled={isCreating}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Use letters, numbers, hyphens, and underscores only.
+                </p>
+              </div>
+
+              {/* Description */}
+              <div className="grid gap-2">
+                <Label htmlFor="repo-description">Description (optional)</Label>
+                <Textarea
+                  id="repo-description"
+                  placeholder="A short description of your project"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  disabled={isCreating}
+                  rows={3}
+                  className="resize-none"
+                />
+              </div>
+
+              {/* Private Toggle */}
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="repo-private">Private repository</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Only you can see this repository
+                  </p>
+                </div>
+                <Switch
+                  id="repo-private"
+                  checked={isPrivate}
+                  onCheckedChange={setIsPrivate}
+                  disabled={isCreating}
+                />
+              </div>
+
+              {/* Error Alert */}
+              {error && (
+                <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  {error}
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isCreating}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleCreate}
+                disabled={isCreating || !repoName.trim() || !sandboxId}
+              >
+                {isCreating ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  "Create Repository"
+                )}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/ui/switch.tsx
+++ b/apps/web/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -180,3 +180,67 @@ export async function getPullRequestStatus(params: {
     return { success: false, error: "Failed to get PR status" };
   }
 }
+
+export async function createRepository(params: {
+  name: string;
+  description?: string;
+  isPrivate?: boolean;
+}): Promise<{
+  success: boolean;
+  repoUrl?: string;
+  cloneUrl?: string;
+  owner?: string;
+  repoName?: string;
+  error?: string;
+}> {
+  const { name, description = "", isPrivate = false } = params;
+
+  try {
+    const result = await getOctokit();
+
+    if (!result.authenticated) {
+      return { success: false, error: "GitHub account not connected" };
+    }
+
+    // Validate repo name
+    if (!/^[\w.-]+$/.test(name)) {
+      return {
+        success: false,
+        error:
+          "Invalid repository name. Use only letters, numbers, hyphens, underscores, and periods.",
+      };
+    }
+
+    const response = await result.octokit.rest.repos.createForAuthenticatedUser(
+      {
+        name,
+        description,
+        private: isPrivate,
+        auto_init: false, // Don't initialize with README - we'll push our content
+      },
+    );
+
+    return {
+      success: true,
+      repoUrl: response.data.html_url,
+      cloneUrl: response.data.clone_url,
+      owner: response.data.owner.login,
+      repoName: response.data.name,
+    };
+  } catch (error: unknown) {
+    console.error("Error creating repository:", error);
+
+    const httpError = error as { status?: number };
+    if (httpError.status === 422) {
+      return {
+        success: false,
+        error: "Repository name already exists or is invalid",
+      };
+    }
+    if (httpError.status === 403) {
+      return { success: false, error: "Permission denied" };
+    }
+
+    return { success: false, error: "Failed to create repository" };
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "ai": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "ai": "catalog:",
@@ -500,6 +501,8 @@
     "@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-switch": ["@radix-ui/react-switch@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ=="],
 
     "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -177,6 +177,16 @@ export class VercelSandbox implements Sandbox {
 
     const workingDirectory = DEFAULT_WORKING_DIRECTORY;
 
+    // Initialize git repo for empty sandboxes (no source provided)
+    // This ensures git commands work consistently (e.g., for diff viewing)
+    if (!source) {
+      await sdk.runCommand({
+        cmd: "git",
+        args: ["init"],
+        cwd: workingDirectory,
+      });
+    }
+
     // Configure git to use the token for push operations if provided
     // We modify the remote URL to embed credentials directly (standard CI/CD approach)
     if (source?.token) {
@@ -205,6 +215,17 @@ export class VercelSandbox implements Sandbox {
       await sdk.runCommand({
         cmd: "git",
         args: ["config", "user.email", gitUser.email],
+        cwd: workingDirectory,
+      });
+    }
+
+    // Create initial empty commit for empty sandboxes so HEAD exists
+    // This is required for git diff HEAD to work (e.g., diff viewer)
+    // Must be done after gitUser config since git commit requires user info
+    if (!source && gitUser) {
+      await sdk.runCommand({
+        cmd: "git",
+        args: ["commit", "--allow-empty", "-m", "Initial commit"],
         cwd: workingDirectory,
       });
     }


### PR DESCRIPTION
Implement ability to create GitHub repositories directly from sandboxes, allowing users to initialize git and push code without needing an existing repo.

- **New API endpoint** (`/api/github/create-repo`) handles repository creation, git initialization, and code push with AI-generated commit messages
- **Updated sandbox creation** to support optional `repoUrl` parameter, enabling empty sandbox creation for new projects
- **New CreateRepoDialog component** with form for repository name, description, and privacy settings
- **Updated task UI** to show "Create Repo" button for tasks without a repository, and automatically recreate sandboxes when expired