### PR TITLE
Add auto-resize textarea with 7-line maximum height

### DIFF
--- a/apps/web/components/task-input.tsx
+++ b/apps/web/components/task-input.tsx
@@ -45,6 +45,23 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [prompt]);
 
+  // Auto-resize textarea up to 7 lines
+  useEffect(() => {
+    const textarea = inputRef.current;
+    if (!textarea) return;
+
+    // Reset height to auto to get accurate scrollHeight
+    textarea.style.height = "auto";
+
+    // Calculate max height (7 lines, ~24px per line for text-base)
+    const lineHeight = 24;
+    const maxHeight = lineHeight * 7;
+
+    // Set new height, capped at max
+    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+    textarea.style.height = `${newHeight}px`;
+  }, [prompt]);
+
   const handleSubmit = () => {
     if (!prompt.trim() || isLoading) return;
 
@@ -99,10 +116,9 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
           onKeyDown={handleKeyDown}
           placeholder="Ask a question with /plan"
           rows={1}
-          className="w-full resize-none bg-transparent text-base text-foreground placeholder:text-neutral-500 focus:outline-none"
+          className="w-full resize-none overflow-y-auto bg-transparent text-base text-foreground placeholder:text-neutral-500 focus:outline-none"
           style={{
             minHeight: "24px",
-            height: "auto",
           }}
         />
       </div>

--- a/apps/web/components/task-input.tsx
+++ b/apps/web/components/task-input.tsx
@@ -50,16 +50,29 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
     const textarea = inputRef.current;
     if (!textarea) return;
 
-    // Reset height to auto to get accurate scrollHeight
-    textarea.style.height = "auto";
+    // Get actual line height from computed styles
+    const computedStyle = getComputedStyle(textarea);
+    const lineHeight = parseFloat(computedStyle.lineHeight) || 24;
+    const maxLines = 7;
+    const maxHeight = lineHeight * maxLines;
 
-    // Calculate max height (7 lines, ~24px per line for text-base)
-    const lineHeight = 24;
-    const maxHeight = lineHeight * 7;
+    // Store current height to avoid flicker
+    const currentHeight = textarea.offsetHeight;
+
+    // Temporarily set height to 0 to measure scrollHeight accurately
+    // Using 0 instead of 'auto' prevents visible collapse
+    textarea.style.height = "0";
+    const scrollHeight = textarea.scrollHeight;
 
     // Set new height, capped at max
-    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
-    textarea.style.height = `${newHeight}px`;
+    const newHeight = Math.min(scrollHeight, maxHeight);
+
+    // Only update if height actually changed to minimize reflows
+    if (Math.abs(newHeight - currentHeight) > 1) {
+      textarea.style.height = `${newHeight}px`;
+    } else {
+      textarea.style.height = `${currentHeight}px`;
+    }
   }, [prompt]);
 
   const handleSubmit = () => {


### PR DESCRIPTION
Implements dynamic textarea height adjustment based on content while preventing excessive growth.

- Added useEffect hook to auto-resize textarea up to 7 lines based on computed line height
- Changed textarea height styling from `auto` to dynamic pixel values to enable precise control
- Added `overflow-y-auto` class to show scrollbar when content exceeds max height
- Optimized performance by only updating DOM when height change exceeds 1px threshold to minimize reflows