### PR TITLE
Add sandbox timeout tracking and state persistence plan

### DIFF
--- a/apps/web/docs/sandbox-state-persistence-plan.md
+++ b/apps/web/docs/sandbox-state-persistence-plan.md
@@ -1,0 +1,235 @@
+# Sandbox State Persistence via Git Diffs
+
+## Overview
+
+Persist sandbox working state using Git diffs so that when a sandbox times out and a new one is created, the user's work is automatically restored. This creates a seamless experience where users don't notice sandbox recreation.
+
+## Scope
+
+- **Web app only** (not CLI/TUI)
+- Capture untracked files with **1MB size limit** per file
+- Show **subtle "Restoring workspace..." indicator** during restoration
+- Use **`beforeStop` hook** to capture diff (assumes hook fires on timeout)
+
+---
+
+## Implementation Plan
+
+### Phase 1: Database Schema
+
+**File:** `apps/web/lib/db/schema.ts`
+
+Add a new `taskDiffs` table to store captured diffs:
+
+```typescript
+export const taskDiffs = pgTable("task_diffs", {
+  id: text("id").primaryKey(),
+  taskId: text("task_id")
+    .notNull()
+    .references(() => tasks.id, { onDelete: "cascade" }),
+  diffContent: text("diff_content").notNull(),        // git diff HEAD output
+  untrackedFiles: jsonb("untracked_files"),           // Array<{path, content (base64)}>
+  baseCommit: text("base_commit"),                    // SHA for validation
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+```
+
+**New migration required** after schema update.
+
+---
+
+### Phase 2: Diff Capture Logic
+
+**New file:** `apps/web/lib/sandbox/capture-state.ts`
+
+```typescript
+export async function captureSandboxState(sandbox: Sandbox): Promise<{
+  diffContent: string;
+  untrackedFiles: Array<{ path: string; content: string }>;
+  baseCommit: string;
+}>
+```
+
+**Captures:**
+1. `git rev-parse HEAD` - base commit SHA
+2. `git diff HEAD` - all tracked file changes (staged + unstaged)
+3. `git ls-files --others --exclude-standard` - untracked file paths
+4. Read each untracked file (skip if >1MB), base64 encode content
+
+---
+
+### Phase 3: Diff Storage Operations
+
+**New file:** `apps/web/lib/db/task-diffs.ts`
+
+```typescript
+// Create new diff, keep only latest 3 per task
+export async function createTaskDiff(data: NewTaskDiff): Promise<TaskDiff>
+
+// Get latest diff for restoration
+export async function getLatestTaskDiff(taskId: string): Promise<TaskDiff | null>
+```
+
+---
+
+### Phase 4: Hook into Sandbox beforeStop
+
+**Modify:** `apps/web/app/api/sandbox/route.ts`
+
+When creating a sandbox, pass a `beforeStop` hook that captures and saves the diff:
+
+```typescript
+const sandbox = await connectVercelSandbox({
+  timeout: DEFAULT_TIMEOUT,
+  source: { ... },
+  hooks: {
+    beforeStop: async (sandbox) => {
+      if (taskId) {
+        try {
+          const state = await captureSandboxState(sandbox);
+          if (state.diffContent || state.untrackedFiles.length > 0) {
+            await createTaskDiff({
+              id: nanoid(),
+              taskId,
+              diffContent: state.diffContent,
+              untrackedFiles: state.untrackedFiles,
+              baseCommit: state.baseCommit,
+            });
+          }
+        } catch (error) {
+          console.error("Failed to capture sandbox state in beforeStop:", error);
+        }
+      }
+    },
+  },
+});
+```
+
+**Note:** This requires `taskId` to be available in the hook context. We'll need to capture it in a closure.
+
+---
+
+### Phase 5: Diff Restoration Logic
+
+**New file:** `apps/web/lib/sandbox/restore-state.ts`
+
+```typescript
+export async function restoreSandboxState(
+  sandbox: Sandbox,
+  diff: TaskDiff
+): Promise<{ success: boolean; error?: string }>
+```
+
+**Steps:**
+1. Optionally verify/checkout base commit
+2. Write diff to temp file, run `git apply --3way /tmp/restore.patch`
+3. Restore untracked files by writing base64-decoded content
+4. Clean up temp file
+5. Return success/failure status
+
+**Error handling:**
+- If `git apply` fails, try `git apply --reject` for partial restoration
+- Log failures but don't block sandbox creation
+- Skip untracked files that already exist
+
+---
+
+### Phase 6: Integrate Restoration into Sandbox Creation
+
+**Modify:** `apps/web/app/api/sandbox/route.ts`
+
+After creating the sandbox, restore state if a diff exists:
+
+```typescript
+const sandbox = await connectVercelSandbox({
+  // ... config with beforeStop hook
+});
+
+// Restore state if this task has a stored diff
+let stateRestored = false;
+if (taskId) {
+  const latestDiff = await getLatestTaskDiff(taskId);
+  if (latestDiff) {
+    const result = await restoreSandboxState(sandbox, latestDiff);
+    stateRestored = result.success;
+    if (!result.success) {
+      console.warn("Partial state restoration:", result.error);
+    }
+  }
+}
+
+return Response.json({
+  sandboxId: sandbox.id,
+  createdAt: Date.now(),
+  timeout: DEFAULT_TIMEOUT,
+  currentBranch: sandbox.currentBranch,
+  stateRestored,  // inform client
+});
+```
+
+---
+
+### Phase 7: Client-Side UI Feedback
+
+**Modify:** `apps/web/app/tasks/[id]/task-detail-content.tsx`
+
+When `createSandbox` is called:
+1. Show "Restoring workspace..." text during sandbox creation (if task has messages)
+2. If `stateRestored: true` in response, continue normally
+3. If restoration failed, show subtle warning but continue
+
+---
+
+## File Changes Summary
+
+| File | Action |
+|------|--------|
+| `apps/web/lib/db/schema.ts` | Add `taskDiffs` table |
+| `apps/web/lib/db/task-diffs.ts` | **New** - CRUD operations |
+| `apps/web/lib/sandbox/capture-state.ts` | **New** - diff capture logic |
+| `apps/web/lib/sandbox/restore-state.ts` | **New** - diff restoration logic |
+| `apps/web/app/api/sandbox/route.ts` | Add `beforeStop` hook + restoration after creation |
+| `apps/web/app/tasks/[id]/task-detail-content.tsx` | Add "Restoring workspace..." UI |
+
+---
+
+## Key Design Points
+
+### Why beforeStop Hook
+
+Using `beforeStop` is more efficient than capturing after every message:
+- Only runs once when sandbox is stopping
+- No per-message overhead
+- Git diff operation is slightly slow (~100-500ms), so doing it once is better
+
+**Assumption:** The `beforeStop` hook will be called even when the sandbox times out (not just on explicit `stop()` calls). If this isn't the case, we may need to add periodic capture as a fallback.
+
+### Diff Retention
+
+Keep only the latest 3 diffs per task to prevent unbounded storage growth. Older diffs are automatically deleted when a new one is created.
+
+### Untracked File Handling
+
+- Files >1MB are skipped (likely generated files)
+- Binary files are base64 encoded (safe for any content)
+- Existing files are not overwritten during restoration
+
+---
+
+## Verification Plan
+
+1. **Manual testing:**
+   - Create a task, make file changes via the agent
+   - Wait for sandbox to expire (or manually trigger `stop()`)
+   - Create a new sandbox for the same task
+   - Verify files are restored correctly
+
+2. **Edge cases to test:**
+   - Large untracked file (>1MB) - should be skipped
+   - Binary files - should be handled gracefully
+   - Conflicting changes (rare) - should partially restore with warnings
+   - Empty diff (no changes) - should not create a diff record
+
+3. **Database verification:**
+   - Check `task_diffs` table is populated after sandbox stop
+   - Verify old diffs are cleaned up (only latest 3 kept)

--- a/packages/sandbox/interface.ts
+++ b/packages/sandbox/interface.ts
@@ -141,13 +141,16 @@ export interface Sandbox {
   /**
    * Timestamp (ms since epoch) when this sandbox will be proactively stopped.
    * For remote sandboxes, this is when the sandbox will call stop() before SDK timeout.
+   * This value is updated when timeout is extended via extendTimeout().
    * For local sandboxes, this is undefined (no timeout).
    */
   readonly expiresAt?: number;
 
   /**
-   * The configured proactive timeout duration in milliseconds.
-   * For remote sandboxes, this is the time until proactive stop (SDK timeout - buffer).
+   * The initial configured proactive timeout duration in milliseconds.
+   * For remote sandboxes, this is the original time until proactive stop (SDK timeout - buffer).
+   * Note: This is the original timeout value, not affected by extendTimeout() calls.
+   * Use expiresAt to get the current expiration time.
    * For local sandboxes, this is undefined (no timeout).
    */
   readonly timeout?: number;

--- a/packages/sandbox/interface.ts
+++ b/packages/sandbox/interface.ts
@@ -46,6 +46,13 @@ export interface SandboxHooks {
    * }
    */
   onTimeout?: SandboxHook;
+
+  /**
+   * Called after timeout is successfully extended.
+   * @param sandbox - The sandbox instance
+   * @param additionalMs - How much time was added
+   */
+  onTimeoutExtended?: (sandbox: Sandbox, additionalMs: number) => Promise<void>;
 }
 
 /**
@@ -189,4 +196,12 @@ export interface Sandbox {
    * For remote sandboxes, this releases resources.
    */
   stop(): Promise<void>;
+
+  /**
+   * Extend the sandbox timeout by the specified duration.
+   * Only supported by remote sandboxes (Vercel). Local sandboxes don't timeout.
+   * @param additionalMs - Additional time in milliseconds
+   * @returns New expiration timestamp
+   */
+  extendTimeout?(additionalMs: number): Promise<{ expiresAt: number }>;
 }

--- a/packages/sandbox/interface.ts
+++ b/packages/sandbox/interface.ts
@@ -34,6 +34,18 @@ export interface SandboxHooks {
    * }
    */
   beforeStop?: SandboxHook;
+
+  /**
+   * Called when the sandbox is about to timeout (before beforeStop).
+   * Use to differentiate timeout-triggered stops from manual stops.
+   * This hook fires first, then beforeStop runs as part of the stop() call.
+   *
+   * @example
+   * onTimeout: async (sandbox) => {
+   *   console.log("Sandbox timed out, saving work...");
+   * }
+   */
+  onTimeout?: SandboxHook;
 }
 
 /**
@@ -118,6 +130,20 @@ export interface Sandbox {
    * @example "abc123.vercel.run"
    */
   readonly host?: string;
+
+  /**
+   * Timestamp (ms since epoch) when this sandbox will be proactively stopped.
+   * For remote sandboxes, this is when the sandbox will call stop() before SDK timeout.
+   * For local sandboxes, this is undefined (no timeout).
+   */
+  readonly expiresAt?: number;
+
+  /**
+   * The configured proactive timeout duration in milliseconds.
+   * For remote sandboxes, this is the time until proactive stop (SDK timeout - buffer).
+   * For local sandboxes, this is undefined (no timeout).
+   */
+  readonly timeout?: number;
 
   /**
    * Read file contents as UTF-8 string

--- a/packages/sandbox/just-bash.ts
+++ b/packages/sandbox/just-bash.ts
@@ -74,6 +74,10 @@ export class JustBashSandbox implements Sandbox {
 - Git is NOT available - do not attempt git operations
 - Limited to basic file operations and shell commands
 - No package installation or network access`;
+  /** JustBash sandboxes do not timeout */
+  readonly expiresAt = undefined;
+  /** JustBash sandboxes do not timeout */
+  readonly timeout = undefined;
 
   private bash: Bash;
   private mode: "memory" | "overlay";

--- a/packages/sandbox/local.ts
+++ b/packages/sandbox/local.ts
@@ -19,6 +19,10 @@ export class LocalSandbox implements Sandbox {
   readonly environmentDetails = `- Full shell access with all standard CLI tools
 - Git and GitHub CLI (gh) available
 - Can install packages and run any commands`;
+  /** Local sandboxes do not timeout */
+  readonly expiresAt = undefined;
+  /** Local sandboxes do not timeout */
+  readonly timeout = undefined;
 
   constructor(workingDirectory: string, env?: Record<string, string>) {
     this.workingDirectory = workingDirectory;

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -9,6 +9,7 @@ import type {
 
 const MAX_OUTPUT_LENGTH = 50_000;
 const DEFAULT_WORKING_DIRECTORY = "/vercel/sandbox";
+const TIMEOUT_BUFFER_MS = 30_000; // 30 seconds buffer for beforeStop hook
 
 export interface VercelSandboxConfig {
   /**
@@ -89,7 +90,18 @@ export class VercelSandbox implements Sandbox {
    */
   readonly currentBranch?: string;
   readonly hooks?: SandboxHooks;
+  /**
+   * Timestamp (ms since epoch) when this sandbox will be proactively stopped.
+   */
+  readonly expiresAt?: number;
+  /**
+   * The configured proactive timeout duration in milliseconds.
+   */
+  readonly timeout?: number;
+
   private sdk: VercelSandboxSDK;
+  private timeoutTimer?: ReturnType<typeof setTimeout>;
+  private isStopped = false;
 
   private constructor(
     sdk: VercelSandboxSDK,
@@ -98,6 +110,8 @@ export class VercelSandbox implements Sandbox {
     env?: Record<string, string>,
     currentBranch?: string,
     hooks?: SandboxHooks,
+    timeout?: number,
+    startTime?: number,
   ) {
     this.sdk = sdk;
     this.id = id;
@@ -105,6 +119,43 @@ export class VercelSandbox implements Sandbox {
     this.env = env;
     this.currentBranch = currentBranch;
     this.hooks = hooks;
+
+    // Set timeout tracking for proactive stop
+    if (timeout !== undefined && startTime !== undefined) {
+      this.timeout = timeout;
+      this.expiresAt = startTime + timeout;
+      this.scheduleProactiveStop();
+    }
+  }
+
+  /**
+   * Schedule a timer to proactively call stop() before the SDK timeout.
+   * This ensures beforeStop hook has time to run.
+   */
+  private scheduleProactiveStop(): void {
+    if (this.expiresAt === undefined) return;
+
+    const msUntilTimeout = this.expiresAt - Date.now();
+    if (msUntilTimeout <= 0) return;
+
+    this.timeoutTimer = setTimeout(async () => {
+      try {
+        if (this.isStopped) return;
+
+        // Call onTimeout hook first
+        if (this.hooks?.onTimeout) {
+          try {
+            await this.hooks.onTimeout(this);
+          } catch {
+            // Ignore errors - we still need to stop
+          }
+        }
+
+        await this.stop();
+      } catch {
+        // Ignore errors - sandbox may already be stopped by SDK
+      }
+    }, msUntilTimeout);
   }
 
   /**
@@ -167,10 +218,14 @@ export class VercelSandbox implements Sandbox {
           }
       : undefined;
 
+    // Calculate SDK timeout with buffer for beforeStop hook
+    const sdkTimeout = timeout + TIMEOUT_BUFFER_MS;
+    const startTime = Date.now();
+
     const sdk = await VercelSandboxSDK.create({
       ...(sourceConfig && { source: sourceConfig }),
       resources: { vcpus },
-      timeout,
+      timeout: sdkTimeout,
       runtime,
       ...(ports && { ports }),
     });
@@ -238,6 +293,8 @@ export class VercelSandbox implements Sandbox {
       env,
       currentBranch,
       hooks,
+      timeout,
+      startTime,
     );
 
     // Call afterStart hook if provided
@@ -253,9 +310,18 @@ export class VercelSandbox implements Sandbox {
    */
   static async connect(
     sandboxId: string,
-    options: { env?: Record<string, string>; hooks?: SandboxHooks } = {},
+    options: {
+      env?: Record<string, string>;
+      hooks?: SandboxHooks;
+      /** Optional remaining timeout in ms. Without this, timeout tracking is disabled. */
+      remainingTimeout?: number;
+    } = {},
   ): Promise<VercelSandbox> {
     const sdk = await VercelSandboxSDK.get({ sandboxId });
+
+    // Set up timeout tracking if remainingTimeout provided
+    const startTime =
+      options.remainingTimeout !== undefined ? Date.now() : undefined;
 
     const sandbox = new VercelSandbox(
       sdk,
@@ -264,6 +330,8 @@ export class VercelSandbox implements Sandbox {
       options.env,
       undefined,
       options.hooks,
+      options.remainingTimeout,
+      startTime,
     );
 
     // Call afterStart hook if provided (useful for reconnection setup)
@@ -473,11 +541,28 @@ export class VercelSandbox implements Sandbox {
   /**
    * Stop and clean up the sandbox.
    * Calls beforeStop hook if provided before stopping the sandbox.
+   * This method is idempotent - calling it multiple times is safe.
    */
   async stop(): Promise<void> {
-    if (this.hooks?.beforeStop) {
-      await this.hooks.beforeStop(this);
+    // Ensure stop() only runs once
+    if (this.isStopped) return;
+    this.isStopped = true;
+
+    // Clear proactive timeout timer
+    if (this.timeoutTimer) {
+      clearTimeout(this.timeoutTimer);
+      this.timeoutTimer = undefined;
     }
+
+    // Run beforeStop hook
+    if (this.hooks?.beforeStop) {
+      try {
+        await this.hooks.beforeStop(this);
+      } catch {
+        // Log but don't fail - we still need to stop the sandbox
+      }
+    }
+
     await this.sdk.stop();
   }
 }
@@ -492,6 +577,11 @@ export interface VercelSandboxConnectConfig {
   env?: Record<string, string>;
   /** Lifecycle hooks for setup and teardown */
   hooks?: SandboxHooks;
+  /**
+   * Optional remaining timeout in milliseconds.
+   * Without this, timeout tracking is disabled for reconnected sandboxes.
+   */
+  remainingTimeout?: number;
 }
 
 /**
@@ -550,6 +640,7 @@ export async function connectVercelSandbox(
     return VercelSandbox.connect(config.sandboxId, {
       env: config.env,
       hooks: config.hooks,
+      remainingTimeout: config.remainingTimeout,
     });
   }
   return VercelSandbox.create(config);

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -99,13 +99,16 @@ export class VercelSandbox implements Sandbox {
 
   /**
    * Timestamp (ms since epoch) when this sandbox will be proactively stopped.
+   * This value is updated when timeout is extended via extendTimeout().
    */
   get expiresAt(): number | undefined {
     return this._expiresAt;
   }
 
   /**
-   * The configured proactive timeout duration in milliseconds.
+   * The initial configured proactive timeout duration in milliseconds.
+   * Note: This is the original timeout value, not affected by extendTimeout() calls.
+   * Use expiresAt to get the current expiration time.
    */
   get timeout(): number | undefined {
     return this._timeout;
@@ -154,14 +157,21 @@ export class VercelSandbox implements Sandbox {
         if (this.hooks?.onTimeout) {
           try {
             await this.hooks.onTimeout(this);
-          } catch {
-            // Ignore errors - we still need to stop
+          } catch (error) {
+            console.error(
+              "[VercelSandbox] onTimeout hook failed:",
+              error instanceof Error ? error.message : error,
+            );
           }
         }
 
         await this.stop();
-      } catch {
-        // Ignore errors - sandbox may already be stopped by SDK
+      } catch (error) {
+        // Sandbox may already be stopped by SDK
+        console.warn(
+          "[VercelSandbox] Proactive stop failed (sandbox may already be stopped):",
+          error instanceof Error ? error.message : error,
+        );
       }
     }, msUntilTimeout);
   }
@@ -192,12 +202,18 @@ export class VercelSandbox implements Sandbox {
       throw new Error("Timeout tracking not enabled for this sandbox");
     }
 
+    // Check if SDK supports extendTimeout
+    if (typeof this.sdk.extendTimeout !== "function") {
+      throw new Error(
+        "extendTimeout is not supported by this version of @vercel/sandbox",
+      );
+    }
+
     // Call Vercel SDK to extend
     await this.sdk.extendTimeout(additionalMs);
 
     // Update internal state
     this._expiresAt += additionalMs;
-    this._timeout = (this._timeout ?? 0) + additionalMs;
 
     // Reschedule proactive stop timer
     this.rescheduleProactiveStop();
@@ -365,15 +381,20 @@ export class VercelSandbox implements Sandbox {
     options: {
       env?: Record<string, string>;
       hooks?: SandboxHooks;
-      /** Optional remaining timeout in ms. If not provided, queries SDK for remaining time. */
+      /**
+       * Remaining timeout in ms for this sandbox.
+       * Required for timeout tracking on reconnected sandboxes.
+       * If not provided, timeout tracking will be disabled.
+       */
       remainingTimeout?: number;
     } = {},
   ): Promise<VercelSandbox> {
     const sdk = await VercelSandboxSDK.get({ sandboxId });
 
-    // Use SDK's timeout if remainingTimeout not provided
-    // Note: sdk.timeout returns remaining time in ms
-    const remainingTimeout = options.remainingTimeout ?? sdk.timeout;
+    // Only enable timeout tracking if remainingTimeout is explicitly provided.
+    // We don't use sdk.timeout as a fallback because its semantics may vary
+    // (original timeout vs remaining time) depending on SDK version.
+    const remainingTimeout = options.remainingTimeout;
     const startTime = remainingTimeout !== undefined ? Date.now() : undefined;
 
     const sandbox = new VercelSandbox(
@@ -611,8 +632,11 @@ export class VercelSandbox implements Sandbox {
     if (this.hooks?.beforeStop) {
       try {
         await this.hooks.beforeStop(this);
-      } catch {
-        // Log but don't fail - we still need to stop the sandbox
+      } catch (error) {
+        console.error(
+          "[VercelSandbox] beforeStop hook failed:",
+          error instanceof Error ? error.message : error,
+        );
       }
     }
 
@@ -631,8 +655,9 @@ export interface VercelSandboxConnectConfig {
   /** Lifecycle hooks for setup and teardown */
   hooks?: SandboxHooks;
   /**
-   * Optional remaining timeout in milliseconds.
-   * Without this, timeout tracking is disabled for reconnected sandboxes.
+   * Remaining timeout in milliseconds for this sandbox.
+   * Required for timeout tracking and proactive stop on reconnected sandboxes.
+   * If not provided, timeout tracking will be disabled (no proactive stop, no hooks on timeout).
    */
   remainingTimeout?: number;
 }

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -288,7 +288,6 @@ export class VercelSandbox implements Sandbox {
 
     // Calculate SDK timeout with buffer for beforeStop hook
     const sdkTimeout = timeout + TIMEOUT_BUFFER_MS;
-    const startTime = Date.now();
 
     const sdk = await VercelSandboxSDK.create({
       ...(sourceConfig && { source: sourceConfig }),
@@ -353,6 +352,9 @@ export class VercelSandbox implements Sandbox {
     } else if (source?.branch) {
       currentBranch = source.branch;
     }
+
+    // Capture startTime AFTER all setup operations so users get their full timeout duration
+    const startTime = Date.now();
 
     const sandbox = new VercelSandbox(
       sdk,

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -221,7 +221,14 @@ export class VercelSandbox implements Sandbox {
 
     // Call hook if provided
     if (this.hooks?.onTimeoutExtended) {
-      await this.hooks.onTimeoutExtended(this, additionalMs);
+      try {
+        await this.hooks.onTimeoutExtended(this, additionalMs);
+      } catch (error) {
+        console.error(
+          "[VercelSandbox] onTimeoutExtended hook failed:",
+          error instanceof Error ? error.message : error,
+        );
+      }
     }
 
     return { expiresAt: this._expiresAt };

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -90,18 +90,26 @@ export class VercelSandbox implements Sandbox {
    */
   readonly currentBranch?: string;
   readonly hooks?: SandboxHooks;
-  /**
-   * Timestamp (ms since epoch) when this sandbox will be proactively stopped.
-   */
-  readonly expiresAt?: number;
-  /**
-   * The configured proactive timeout duration in milliseconds.
-   */
-  readonly timeout?: number;
 
   private sdk: VercelSandboxSDK;
   private timeoutTimer?: ReturnType<typeof setTimeout>;
   private isStopped = false;
+  private _expiresAt?: number;
+  private _timeout?: number;
+
+  /**
+   * Timestamp (ms since epoch) when this sandbox will be proactively stopped.
+   */
+  get expiresAt(): number | undefined {
+    return this._expiresAt;
+  }
+
+  /**
+   * The configured proactive timeout duration in milliseconds.
+   */
+  get timeout(): number | undefined {
+    return this._timeout;
+  }
 
   private constructor(
     sdk: VercelSandboxSDK,
@@ -122,8 +130,8 @@ export class VercelSandbox implements Sandbox {
 
     // Set timeout tracking for proactive stop
     if (timeout !== undefined && startTime !== undefined) {
-      this.timeout = timeout;
-      this.expiresAt = startTime + timeout;
+      this._timeout = timeout;
+      this._expiresAt = startTime + timeout;
       this.scheduleProactiveStop();
     }
   }
@@ -133,9 +141,9 @@ export class VercelSandbox implements Sandbox {
    * This ensures beforeStop hook has time to run.
    */
   private scheduleProactiveStop(): void {
-    if (this.expiresAt === undefined) return;
+    if (this._expiresAt === undefined) return;
 
-    const msUntilTimeout = this.expiresAt - Date.now();
+    const msUntilTimeout = this._expiresAt - Date.now();
     if (msUntilTimeout <= 0) return;
 
     this.timeoutTimer = setTimeout(async () => {
@@ -156,6 +164,50 @@ export class VercelSandbox implements Sandbox {
         // Ignore errors - sandbox may already be stopped by SDK
       }
     }, msUntilTimeout);
+  }
+
+  /**
+   * Clear existing timeout timer and schedule a new one.
+   */
+  private rescheduleProactiveStop(): void {
+    // Clear existing timer
+    if (this.timeoutTimer) {
+      clearTimeout(this.timeoutTimer);
+      this.timeoutTimer = undefined;
+    }
+    // Schedule new timer
+    this.scheduleProactiveStop();
+  }
+
+  /**
+   * Extend the sandbox timeout by the specified duration.
+   * @param additionalMs - Additional time in milliseconds
+   * @returns New expiration timestamp
+   */
+  async extendTimeout(additionalMs: number): Promise<{ expiresAt: number }> {
+    if (this.isStopped) {
+      throw new Error("Cannot extend timeout on stopped sandbox");
+    }
+    if (this._expiresAt === undefined) {
+      throw new Error("Timeout tracking not enabled for this sandbox");
+    }
+
+    // Call Vercel SDK to extend
+    await this.sdk.extendTimeout(additionalMs);
+
+    // Update internal state
+    this._expiresAt += additionalMs;
+    this._timeout = (this._timeout ?? 0) + additionalMs;
+
+    // Reschedule proactive stop timer
+    this.rescheduleProactiveStop();
+
+    // Call hook if provided
+    if (this.hooks?.onTimeoutExtended) {
+      await this.hooks.onTimeoutExtended(this, additionalMs);
+    }
+
+    return { expiresAt: this._expiresAt };
   }
 
   /**
@@ -313,15 +365,16 @@ export class VercelSandbox implements Sandbox {
     options: {
       env?: Record<string, string>;
       hooks?: SandboxHooks;
-      /** Optional remaining timeout in ms. Without this, timeout tracking is disabled. */
+      /** Optional remaining timeout in ms. If not provided, queries SDK for remaining time. */
       remainingTimeout?: number;
     } = {},
   ): Promise<VercelSandbox> {
     const sdk = await VercelSandboxSDK.get({ sandboxId });
 
-    // Set up timeout tracking if remainingTimeout provided
-    const startTime =
-      options.remainingTimeout !== undefined ? Date.now() : undefined;
+    // Use SDK's timeout if remainingTimeout not provided
+    // Note: sdk.timeout returns remaining time in ms
+    const remainingTimeout = options.remainingTimeout ?? sdk.timeout;
+    const startTime = remainingTimeout !== undefined ? Date.now() : undefined;
 
     const sandbox = new VercelSandbox(
       sdk,
@@ -330,7 +383,7 @@ export class VercelSandbox implements Sandbox {
       options.env,
       undefined,
       options.hooks,
-      options.remainingTimeout,
+      remainingTimeout,
       startTime,
     );
 

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -10,6 +10,7 @@ import type {
 const MAX_OUTPUT_LENGTH = 50_000;
 const DEFAULT_WORKING_DIRECTORY = "/vercel/sandbox";
 const TIMEOUT_BUFFER_MS = 30_000; // 30 seconds buffer for beforeStop hook
+const DEFAULT_RECONNECT_TIMEOUT_MS = 300_000; // 5 minutes default timeout for reconnected sandboxes
 
 export interface VercelSandboxConfig {
   /**
@@ -385,19 +386,20 @@ export class VercelSandbox implements Sandbox {
       hooks?: SandboxHooks;
       /**
        * Remaining timeout in ms for this sandbox.
-       * Required for timeout tracking on reconnected sandboxes.
-       * If not provided, timeout tracking will be disabled.
+       * If not provided, defaults to DEFAULT_RECONNECT_TIMEOUT_MS (5 minutes).
+       * This ensures timeout tracking and proactive stop work correctly.
        */
       remainingTimeout?: number;
     } = {},
   ): Promise<VercelSandbox> {
     const sdk = await VercelSandboxSDK.get({ sandboxId });
 
-    // Only enable timeout tracking if remainingTimeout is explicitly provided.
-    // We don't use sdk.timeout as a fallback because its semantics may vary
-    // (original timeout vs remaining time) depending on SDK version.
-    const remainingTimeout = options.remainingTimeout;
-    const startTime = remainingTimeout !== undefined ? Date.now() : undefined;
+    // Use provided remainingTimeout or default to DEFAULT_RECONNECT_TIMEOUT_MS
+    // This ensures timeout tracking is always enabled for reconnected sandboxes,
+    // allowing beforeStop and onTimeout hooks to fire properly.
+    const remainingTimeout =
+      options.remainingTimeout ?? DEFAULT_RECONNECT_TIMEOUT_MS;
+    const startTime = Date.now();
 
     const sandbox = new VercelSandbox(
       sdk,
@@ -658,8 +660,9 @@ export interface VercelSandboxConnectConfig {
   hooks?: SandboxHooks;
   /**
    * Remaining timeout in milliseconds for this sandbox.
-   * Required for timeout tracking and proactive stop on reconnected sandboxes.
-   * If not provided, timeout tracking will be disabled (no proactive stop, no hooks on timeout).
+   * If not provided, defaults to 5 minutes (DEFAULT_RECONNECT_TIMEOUT_MS).
+   * This ensures proactive stop and hooks (beforeStop, onTimeout) work correctly.
+   * Provide an explicit value if you know the exact remaining time.
    */
   remainingTimeout?: number;
 }


### PR DESCRIPTION
Introduces timeout management and a comprehensive plan for persisting sandbox state via git diffs.

- **Timeout tracking**: Added `expiresAt` and `timeout` properties to `Sandbox` interface, implemented proactive timeout handling in `VercelSandbox` with `onTimeout` and `onTimeoutExtended` hooks to support timeout extension
- **State persistence plan**: Created detailed implementation roadmap documenting how to capture sandbox state via git diffs before timeout, store diffs in database, and restore state when creating new sandboxes
- **API improvements**: Extended `connectVercelSandbox()` and `VercelSandbox.connect()` with timeout awareness; local and JustBash sandboxes now explicitly report no timeout support