### PR TITLE
Add sandbox snapshot support with Vercel Blob storage

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -28,29 +28,39 @@ export async function POST(req: Request) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const { messages, sandboxId, taskId }: ChatRequestBody = await req.json();
+  let body: ChatRequestBody;
+  try {
+    body = (await req.json()) as ChatRequestBody;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-  // 2. Verify task ownership if taskId is provided
-  if (taskId) {
-    const task = await getTaskById(taskId);
-    if (!task) {
-      return Response.json({ error: "Task not found" }, { status: 404 });
-    }
-    if (task.userId !== session.user.id) {
-      return Response.json({ error: "Unauthorized" }, { status: 403 });
-    }
-    if (!task.sandboxId) {
-      return Response.json(
-        { error: "Sandbox not linked to task" },
-        { status: 400 },
-      );
-    }
-    if (task.sandboxId !== sandboxId) {
-      return Response.json(
-        { error: "Sandbox does not belong to this task" },
-        { status: 403 },
-      );
-    }
+  const { messages, sandboxId, taskId } = body;
+
+  // 2. Require taskId to ensure sandbox ownership verification
+  if (!taskId) {
+    return Response.json({ error: "taskId is required" }, { status: 400 });
+  }
+
+  // 3. Verify task ownership and sandbox association
+  const task = await getTaskById(taskId);
+  if (!task) {
+    return Response.json({ error: "Task not found" }, { status: 404 });
+  }
+  if (task.userId !== session.user.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 403 });
+  }
+  if (!task.sandboxId) {
+    return Response.json(
+      { error: "Sandbox not linked to task" },
+      { status: 400 },
+    );
+  }
+  if (task.sandboxId !== sandboxId) {
+    return Response.json(
+      { error: "Sandbox does not belong to this task" },
+      { status: 403 },
+    );
   }
 
   const modelMessages = await convertToModelMessages(messages, {

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -99,8 +99,8 @@ export async function POST(req: Request) {
   const sandbox = await connectVercelSandbox(sandboxOptions);
 
   // Update task with sandboxId if this is a new sandbox
-  // Verify task ownership before updating
-  if (taskId && !taskSandboxId) {
+  // This handles both first-time creation and sandbox recreation after expiry/restore
+  if (taskId && sandbox.id !== taskSandboxId) {
     await updateTask(taskId, { sandboxId: sandbox.id });
   }
 

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -159,5 +159,8 @@ export async function DELETE(req: Request) {
   const sandbox = await connectVercelSandbox({ sandboxId });
   await sandbox.stop();
 
+  // Clear sandboxId from task so future sandbox creation doesn't fail validation
+  await updateTask(taskId, { sandboxId: null });
+
   return Response.json({ success: true });
 }

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -68,8 +68,11 @@ export async function POST(req: Request) {
   }
 
   // Determine if we should create a new branch
-  // Only create new branch on first sandbox creation (no existing sandboxId)
-  const shouldCreateNewBranch = isNewBranch && !taskSandboxId;
+  // Frontend is responsible for deciding when to pass isNewBranch: true based on:
+  // - First sandbox creation for a new branch task
+  // - Snapshot restore when branch doesn't exist on origin (no PR created yet)
+  // - Expired sandbox recreation when branch doesn't exist on origin
+  const shouldCreateNewBranch = isNewBranch;
 
   // Build sandbox options - source is only included when repoUrl is provided
   const sandboxOptions: Parameters<typeof connectVercelSandbox>[0] = {

--- a/apps/web/app/api/sandbox/snapshot/route.ts
+++ b/apps/web/app/api/sandbox/snapshot/route.ts
@@ -129,6 +129,12 @@ export async function PUT(req: Request) {
   if (task.userId !== session.user.id) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
+  if (task.sandboxId !== sandboxId) {
+    return Response.json(
+      { error: "Sandbox does not belong to this task" },
+      { status: 403 },
+    );
+  }
   if (!task.snapshotUrl) {
     return Response.json(
       { error: "No snapshot available for this task" },

--- a/apps/web/app/api/sandbox/snapshot/route.ts
+++ b/apps/web/app/api/sandbox/snapshot/route.ts
@@ -1,0 +1,165 @@
+import { connectVercelSandbox } from "@open-harness/sandbox";
+import { getServerSession } from "@/lib/session/get-server-session";
+import { getTaskById, updateTask } from "@/lib/db/tasks";
+
+interface CreateSnapshotRequest {
+  sandboxId: string;
+  taskId: string;
+}
+
+interface RestoreSnapshotRequest {
+  sandboxId: string;
+  taskId: string;
+}
+
+/**
+ * POST - Create a snapshot of the sandbox filesystem
+ */
+export async function POST(req: Request) {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!blobToken) {
+    return Response.json(
+      { error: "BLOB_READ_WRITE_TOKEN not configured" },
+      { status: 500 },
+    );
+  }
+
+  let body: CreateSnapshotRequest;
+  try {
+    body = (await req.json()) as CreateSnapshotRequest;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { sandboxId, taskId } = body;
+
+  if (!sandboxId || !taskId) {
+    return Response.json(
+      { error: "Missing sandboxId or taskId" },
+      { status: 400 },
+    );
+  }
+
+  // Verify task ownership
+  const task = await getTaskById(taskId);
+  if (!task) {
+    return Response.json({ error: "Task not found" }, { status: 404 });
+  }
+  if (task.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (task.sandboxId !== sandboxId) {
+    return Response.json(
+      { error: "Sandbox does not belong to this task" },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const sandbox = await connectVercelSandbox({ sandboxId });
+
+    if (!sandbox.snapshot) {
+      return Response.json(
+        { error: "Snapshot not supported by this sandbox type" },
+        { status: 400 },
+      );
+    }
+
+    const pathname = `snapshots/${taskId}/${Date.now()}.tgz`;
+    const result = await sandbox.snapshot({
+      blobToken,
+      pathname,
+    });
+
+    // Update task with snapshot info
+    await updateTask(taskId, {
+      snapshotUrl: result.downloadUrl,
+      snapshotCreatedAt: new Date(),
+    });
+
+    return Response.json({
+      url: result.url,
+      downloadUrl: result.downloadUrl,
+      createdAt: Date.now(),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Response.json(
+      { error: `Failed to create snapshot: ${message}` },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * PUT - Restore a snapshot to the sandbox filesystem
+ */
+export async function PUT(req: Request) {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  let body: RestoreSnapshotRequest;
+  try {
+    body = (await req.json()) as RestoreSnapshotRequest;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { sandboxId, taskId } = body;
+
+  if (!sandboxId || !taskId) {
+    return Response.json(
+      { error: "Missing sandboxId or taskId" },
+      { status: 400 },
+    );
+  }
+
+  // Verify task ownership and get snapshot URL
+  const task = await getTaskById(taskId);
+  if (!task) {
+    return Response.json({ error: "Task not found" }, { status: 404 });
+  }
+  if (task.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (!task.snapshotUrl) {
+    return Response.json(
+      { error: "No snapshot available for this task" },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const sandbox = await connectVercelSandbox({ sandboxId });
+
+    if (!sandbox.restoreSnapshot) {
+      return Response.json(
+        { error: "Restore not supported by this sandbox type" },
+        { status: 400 },
+      );
+    }
+
+    await sandbox.restoreSnapshot({
+      downloadUrl: task.snapshotUrl,
+      clean: true,
+    });
+
+    return Response.json({
+      success: true,
+      restoredFrom: task.snapshotUrl,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Response.json(
+      { error: `Failed to restore snapshot: ${message}` },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/sandbox/snapshot/route.ts
+++ b/apps/web/app/api/sandbox/snapshot/route.ts
@@ -1,4 +1,5 @@
 import { connectVercelSandbox } from "@open-harness/sandbox";
+import { generateClientTokenFromReadWriteToken } from "@vercel/blob/client";
 import { getServerSession } from "@/lib/session/get-server-session";
 import { getTaskById, updateTask } from "@/lib/db/tasks";
 
@@ -70,9 +71,19 @@ export async function POST(req: Request) {
       );
     }
 
+    // Generate a scoped, short-lived client token for the upload
+    // This is safer than passing the full BLOB_READ_WRITE_TOKEN to the sandbox
     const pathname = `snapshots/${taskId}/${Date.now()}.tgz`;
+    const clientToken = await generateClientTokenFromReadWriteToken({
+      token: blobToken,
+      pathname,
+      allowedContentTypes: ["application/gzip", "application/x-gzip"],
+      maximumSizeInBytes: 500 * 1024 * 1024, // 500MB max
+      validUntil: Date.now() + 5 * 60 * 1000, // 5 minutes
+    });
+
     const result = await sandbox.snapshot({
-      blobToken,
+      blobToken: clientToken,
       pathname,
     });
 

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -50,6 +50,8 @@ type TaskChatContextValue = {
   diffCache: DiffCacheState;
   /** Fetch diff data (uses cache if valid) */
   fetchDiff: (sandboxId: string) => Promise<void>;
+  /** Update task snapshot info after saving */
+  updateTaskSnapshot: (snapshotUrl: string, snapshotCreatedAt: Date) => void;
 };
 
 const TaskChatContext = createContext<TaskChatContextValue | undefined>(
@@ -93,12 +95,23 @@ export function TaskChatProvider({
   const setSandboxInfo = useCallback((info: SandboxInfo) => {
     sandboxIdRef.current = info.sandboxId;
     setSandboxInfoState(info);
+    // Keep task.sandboxId in sync so it doesn't become stale
+    setTask((prev) => ({ ...prev, sandboxId: info.sandboxId }));
   }, []);
 
   const clearSandboxInfo = useCallback(() => {
     sandboxIdRef.current = null;
     setSandboxInfoState(null);
+    // Keep task.sandboxId in sync so it doesn't become stale
+    setTask((prev) => ({ ...prev, sandboxId: null }));
   }, []);
+
+  const updateTaskSnapshot = useCallback(
+    (snapshotUrl: string, snapshotCreatedAt: Date) => {
+      setTask((prev) => ({ ...prev, snapshotUrl, snapshotCreatedAt }));
+    },
+    [],
+  );
 
   const [diffRefreshKey, setDiffRefreshKey] = useState(0);
 
@@ -212,6 +225,7 @@ export function TaskChatProvider({
         triggerDiffRefresh,
         diffCache,
         fetchDiff,
+        updateTaskSnapshot,
       }}
     >
       {children}

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -290,6 +290,7 @@ export function TaskDetailContent() {
     hadInitialMessages,
     diffRefreshKey,
     triggerDiffRefresh,
+    updateTaskSnapshot,
   } = useTaskChatContext();
   const {
     messages,
@@ -318,7 +319,11 @@ export function TaskDetailContent() {
 
   const saveSnapshot = async (
     sandboxId: string,
-  ): Promise<{ success: boolean }> => {
+  ): Promise<{
+    success: boolean;
+    downloadUrl?: string;
+    createdAt?: number;
+  }> => {
     try {
       const response = await fetch("/api/sandbox/snapshot", {
         method: "POST",
@@ -334,7 +339,15 @@ export function TaskDetailContent() {
         console.error("Failed to save snapshot:", error.error);
         return { success: false };
       }
-      return { success: true };
+      const data = (await response.json()) as {
+        downloadUrl: string;
+        createdAt: number;
+      };
+      return {
+        success: true,
+        downloadUrl: data.downloadUrl,
+        createdAt: data.createdAt,
+      };
     } catch (err) {
       console.error("Failed to save snapshot:", err);
       return { success: false };
@@ -345,7 +358,10 @@ export function TaskDetailContent() {
     if (!sandboxInfo) return;
     setIsSavingSnapshot(true);
     try {
-      await saveSnapshot(sandboxInfo.sandboxId);
+      const result = await saveSnapshot(sandboxInfo.sandboxId);
+      if (result.success && result.downloadUrl && result.createdAt) {
+        updateTaskSnapshot(result.downloadUrl, new Date(result.createdAt));
+      }
     } finally {
       setIsSavingSnapshot(false);
     }
@@ -355,7 +371,10 @@ export function TaskDetailContent() {
     if (!sandboxInfo) return;
     setIsSavingSnapshot(true);
     try {
-      await saveSnapshot(sandboxInfo.sandboxId);
+      const result = await saveSnapshot(sandboxInfo.sandboxId);
+      if (result.success && result.downloadUrl && result.createdAt) {
+        updateTaskSnapshot(result.downloadUrl, new Date(result.createdAt));
+      }
     } finally {
       setIsSavingSnapshot(false);
     }
@@ -374,12 +393,14 @@ export function TaskDetailContent() {
     let newSandbox: SandboxInfo | null = null;
     try {
       // First create a new sandbox
+      // Don't pass task.sandboxId - we're creating a fresh sandbox for restore,
+      // and the React state may be stale (not synced with DB after discard)
       newSandbox = await createSandbox(
         task.cloneUrl ?? undefined,
         task.branch ?? undefined,
         false, // Don't create new branch when restoring
         task.id,
-        task.sandboxId ?? undefined,
+        undefined,
       );
       setSandboxInfo(newSandbox);
 

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -19,6 +19,8 @@ import {
   FolderGit2,
   MoreVertical,
   GitCompare,
+  Save,
+  Loader2,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -99,13 +101,26 @@ function formatTimeRemaining(ms: number): string {
 function SandboxStatus({
   sandboxInfo,
   isCreating,
+  isSavingSnapshot,
+  isRestoring,
+  hasSnapshot,
   onKill,
+  onSaveAndKill,
+  onSaveSnapshot,
+  onRestore,
 }: {
   sandboxInfo: SandboxInfo | null;
   isCreating: boolean;
+  isSavingSnapshot: boolean;
+  isRestoring: boolean;
+  hasSnapshot: boolean;
   onKill: () => void;
+  onSaveAndKill: () => void;
+  onSaveSnapshot: () => void;
+  onRestore: () => void;
 }) {
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
+  const [showStopConfirm, setShowStopConfirm] = useState(false);
 
   useEffect(() => {
     if (!sandboxInfo) {
@@ -124,11 +139,30 @@ function SandboxStatus({
     return () => clearInterval(interval);
   }, [sandboxInfo]);
 
-  if (isCreating) {
+  if (isCreating || isRestoring) {
     return (
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <span className="h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
-        <span>Creating sandbox...</span>
+        <span>
+          {isRestoring ? "Restoring snapshot..." : "Creating sandbox..."}
+        </span>
+      </div>
+    );
+  }
+
+  // No sandbox and has snapshot - show restore option
+  if (!sandboxInfo && hasSnapshot) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="h-2 w-2 rounded-full bg-amber-500" />
+        <span>Sandbox stopped</span>
+        <button
+          type="button"
+          onClick={onRestore}
+          className="flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-primary hover:bg-primary/20"
+        >
+          <span>Restore snapshot</span>
+        </button>
       </div>
     );
   }
@@ -142,6 +176,57 @@ function SandboxStatus({
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <span className="h-2 w-2 rounded-full bg-red-500" />
         <span>Sandbox expired</span>
+        {hasSnapshot && (
+          <button
+            type="button"
+            onClick={onRestore}
+            className="flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-primary hover:bg-primary/20"
+          >
+            <span>Restore snapshot</span>
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (showStopConfirm) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span>Save before stopping?</span>
+        <button
+          type="button"
+          onClick={() => {
+            setShowStopConfirm(false);
+            onSaveAndKill();
+          }}
+          disabled={isSavingSnapshot}
+          className="flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-primary hover:bg-primary/20 disabled:opacity-50"
+        >
+          {isSavingSnapshot ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Save className="h-3 w-3" />
+          )}
+          <span>Save</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setShowStopConfirm(false);
+            onKill();
+          }}
+          className="rounded px-1.5 py-0.5 hover:bg-muted-foreground/20"
+        >
+          <span>Discard</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowStopConfirm(false)}
+          className="rounded p-0.5 hover:bg-muted-foreground/20"
+          title="Cancel"
+        >
+          <X className="h-3 w-3" />
+        </button>
       </div>
     );
   }
@@ -152,7 +237,21 @@ function SandboxStatus({
       <span>{formatTimeRemaining(timeRemaining)}</span>
       <button
         type="button"
-        onClick={onKill}
+        onClick={onSaveSnapshot}
+        disabled={isSavingSnapshot}
+        className="flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-muted-foreground/20 disabled:opacity-50"
+        title="Save snapshot"
+      >
+        {isSavingSnapshot ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : (
+          <Save className="h-3 w-3" />
+        )}
+        <span>Save</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => setShowStopConfirm(true)}
         className="rounded p-0.5 hover:bg-muted-foreground/20"
         title="Stop sandbox"
       >
@@ -173,6 +272,8 @@ export function TaskDetailContent() {
   const router = useRouter();
   const [input, setInput] = useState("");
   const [isCreatingSandbox, setIsCreatingSandbox] = useState(false);
+  const [isSavingSnapshot, setIsSavingSnapshot] = useState(false);
+  const [isRestoringSnapshot, setIsRestoringSnapshot] = useState(false);
   const [prDialogOpen, setPrDialogOpen] = useState(false);
   const [repoDialogOpen, setRepoDialogOpen] = useState(false);
   const [showDiffPanel, setShowDiffPanel] = useState(false);
@@ -212,6 +313,92 @@ export function TaskDetailContent() {
       });
     } finally {
       clearSandboxInfo();
+    }
+  };
+
+  const handleSaveSnapshot = async () => {
+    if (!sandboxInfo) return;
+    setIsSavingSnapshot(true);
+    try {
+      const response = await fetch("/api/sandbox/snapshot", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sandboxId: sandboxInfo.sandboxId,
+          taskId: task.id,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = (await response.json()) as { error?: string };
+        console.error("Failed to save snapshot:", error.error);
+      }
+    } catch (err) {
+      console.error("Failed to save snapshot:", err);
+    } finally {
+      setIsSavingSnapshot(false);
+    }
+  };
+
+  const handleSaveAndKill = async () => {
+    if (!sandboxInfo) return;
+    setIsSavingSnapshot(true);
+    try {
+      const response = await fetch("/api/sandbox/snapshot", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sandboxId: sandboxInfo.sandboxId,
+          taskId: task.id,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = (await response.json()) as { error?: string };
+        console.error("Failed to save snapshot:", error.error);
+      }
+    } catch (err) {
+      console.error("Failed to save snapshot:", err);
+    } finally {
+      setIsSavingSnapshot(false);
+    }
+    // Kill sandbox after saving (regardless of save success)
+    await handleKillSandbox();
+  };
+
+  const handleRestoreSnapshot = async () => {
+    if (!task.snapshotUrl) return;
+
+    setIsRestoringSnapshot(true);
+    try {
+      // First create a new sandbox
+      const newSandbox = await createSandbox(
+        task.cloneUrl ?? undefined,
+        task.branch ?? undefined,
+        false, // Don't create new branch when restoring
+        task.id,
+        task.sandboxId ?? undefined,
+      );
+      setSandboxInfo(newSandbox);
+
+      // Then restore the snapshot
+      const response = await fetch("/api/sandbox/snapshot", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sandboxId: newSandbox.sandboxId,
+          taskId: task.id,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = (await response.json()) as { error?: string };
+        console.error("Failed to restore snapshot:", error.error);
+      }
+    } catch (err) {
+      console.error("Failed to restore snapshot:", err);
+    } finally {
+      setIsRestoringSnapshot(false);
     }
   };
 
@@ -603,7 +790,13 @@ export function TaskDetailContent() {
               <SandboxStatus
                 sandboxInfo={sandboxInfo}
                 isCreating={isCreatingSandbox}
+                isSavingSnapshot={isSavingSnapshot}
+                isRestoring={isRestoringSnapshot}
+                hasSnapshot={!!task.snapshotUrl}
                 onKill={handleKillSandbox}
+                onSaveAndKill={handleSaveAndKill}
+                onSaveSnapshot={handleSaveSnapshot}
+                onRestore={handleRestoreSnapshot}
               />
             </div>
             <form

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -316,15 +316,15 @@ export function TaskDetailContent() {
     }
   };
 
-  const handleSaveSnapshot = async () => {
-    if (!sandboxInfo) return;
-    setIsSavingSnapshot(true);
+  const saveSnapshot = async (
+    sandboxId: string,
+  ): Promise<{ success: boolean }> => {
     try {
       const response = await fetch("/api/sandbox/snapshot", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          sandboxId: sandboxInfo.sandboxId,
+          sandboxId,
           taskId: task.id,
         }),
       });
@@ -332,9 +332,20 @@ export function TaskDetailContent() {
       if (!response.ok) {
         const error = (await response.json()) as { error?: string };
         console.error("Failed to save snapshot:", error.error);
+        return { success: false };
       }
+      return { success: true };
     } catch (err) {
       console.error("Failed to save snapshot:", err);
+      return { success: false };
+    }
+  };
+
+  const handleSaveSnapshot = async () => {
+    if (!sandboxInfo) return;
+    setIsSavingSnapshot(true);
+    try {
+      await saveSnapshot(sandboxInfo.sandboxId);
     } finally {
       setIsSavingSnapshot(false);
     }
@@ -344,21 +355,7 @@ export function TaskDetailContent() {
     if (!sandboxInfo) return;
     setIsSavingSnapshot(true);
     try {
-      const response = await fetch("/api/sandbox/snapshot", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sandboxId: sandboxInfo.sandboxId,
-          taskId: task.id,
-        }),
-      });
-
-      if (!response.ok) {
-        const error = (await response.json()) as { error?: string };
-        console.error("Failed to save snapshot:", error.error);
-      }
-    } catch (err) {
-      console.error("Failed to save snapshot:", err);
+      await saveSnapshot(sandboxInfo.sandboxId);
     } finally {
       setIsSavingSnapshot(false);
     }
@@ -366,13 +363,18 @@ export function TaskDetailContent() {
     await handleKillSandbox();
   };
 
+  const [restoreError, setRestoreError] = useState<string | null>(null);
+
   const handleRestoreSnapshot = async () => {
     if (!task.snapshotUrl) return;
 
     setIsRestoringSnapshot(true);
+    setRestoreError(null);
+
+    let newSandbox: SandboxInfo | null = null;
     try {
       // First create a new sandbox
-      const newSandbox = await createSandbox(
+      newSandbox = await createSandbox(
         task.cloneUrl ?? undefined,
         task.branch ?? undefined,
         false, // Don't create new branch when restoring
@@ -393,10 +395,23 @@ export function TaskDetailContent() {
 
       if (!response.ok) {
         const error = (await response.json()) as { error?: string };
-        console.error("Failed to restore snapshot:", error.error);
+        const errorMsg = error.error ?? "Unknown error";
+        console.error("Failed to restore snapshot:", errorMsg);
+        setRestoreError(
+          `Snapshot restore failed: ${errorMsg}. Sandbox is running but may be empty.`,
+        );
       }
     } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
       console.error("Failed to restore snapshot:", err);
+      // If sandbox was created but restore failed, show warning
+      if (newSandbox) {
+        setRestoreError(
+          `Snapshot restore failed: ${errorMsg}. Sandbox is running but may be empty.`,
+        );
+      } else {
+        setRestoreError(`Failed to create sandbox: ${errorMsg}`);
+      }
     } finally {
       setIsRestoringSnapshot(false);
     }
@@ -786,6 +801,18 @@ export function TaskDetailContent() {
         {/* Input */}
         <div className="p-4 pb-8">
           <div className="mx-auto max-w-3xl space-y-2">
+            {restoreError && (
+              <div className="flex items-center justify-between rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                <span>{restoreError}</span>
+                <button
+                  type="button"
+                  onClick={() => setRestoreError(null)}
+                  className="ml-2 rounded p-0.5 hover:bg-destructive/20"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            )}
             <div className="flex justify-end px-2">
               <SandboxStatus
                 sandboxInfo={sandboxInfo}

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -395,10 +395,17 @@ export function TaskDetailContent() {
       // First create a new sandbox
       // Don't pass task.sandboxId - we're creating a fresh sandbox for restore,
       // and the React state may be stale (not synced with DB after discard)
+      //
+      // For isNewBranch tasks: if no PR exists, the branch was never pushed to origin.
+      // We need to use the newBranch pattern (clone default, create branch locally).
+      // If a PR exists, the branch was pushed and we can clone it directly.
+      const branchExistsOnOrigin = task.prNumber != null;
+      const useNewBranch = task.isNewBranch && !branchExistsOnOrigin;
+
       newSandbox = await createSandbox(
         task.cloneUrl ?? undefined,
         task.branch ?? undefined,
-        false, // Don't create new branch when restoring
+        useNewBranch,
         task.id,
         undefined,
       );
@@ -462,9 +469,11 @@ export function TaskDetailContent() {
         // Always create a sandbox - either with repo or empty
         setIsCreatingSandbox(true);
         try {
-          // Only create new branch on first sandbox creation
-          // If task already has a sandboxId, branch was already created
-          const shouldCreateNewBranch = task.isNewBranch && !task.sandboxId;
+          // For isNewBranch tasks: use newBranch pattern if branch doesn't exist on origin.
+          // Branch only exists on origin if a PR was created (which pushes the branch).
+          const branchExistsOnOrigin = task.prNumber != null;
+          const shouldCreateNewBranch =
+            task.isNewBranch && !branchExistsOnOrigin;
           const newSandbox = await createSandbox(
             task.cloneUrl ?? undefined,
             task.branch ?? undefined,
@@ -859,10 +868,11 @@ export function TaskDetailContent() {
                 if (!isSandboxValid(sandboxInfo)) {
                   setIsCreatingSandbox(true);
                   try {
-                    // Only create new branch on first sandbox creation
-                    // If task already has a sandboxId, branch was already created
+                    // For isNewBranch tasks: use newBranch pattern if branch doesn't exist on origin.
+                    // Branch only exists on origin if a PR was created (which pushes the branch).
+                    const branchExistsOnOrigin = task.prNumber != null;
                     const shouldCreateNewBranch =
-                      task.isNewBranch && !task.sandboxId;
+                      task.isNewBranch && !branchExistsOnOrigin;
                     const newSandbox = await createSandbox(
                       task.cloneUrl ?? undefined,
                       task.branch ?? undefined,

--- a/apps/web/lib/db/migrations/0003_serious_george_stacy.sql
+++ b/apps/web/lib/db/migrations/0003_serious_george_stacy.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "tasks" ADD COLUMN "snapshot_url" text;--> statement-breakpoint
+ALTER TABLE "tasks" ADD COLUMN "snapshot_created_at" timestamp;--> statement-breakpoint
+ALTER TABLE "tasks" ADD COLUMN "snapshot_size_bytes" integer;

--- a/apps/web/lib/db/migrations/meta/0003_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,458 @@
+{
+  "id": "3a3787f3-0643-4b9d-9c8a-451aeb0bf25d",
+  "prevId": "e988cd43-a856-4053-ad1c-b892e6e54af7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_provider_idx": {
+          "name": "accounts_user_id_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_messages": {
+      "name": "task_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_messages_task_id_tasks_id_fk": {
+          "name": "task_messages_task_id_tasks_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new_branch": {
+          "name": "is_new_branch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines_added": {
+          "name": "lines_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lines_removed": {
+          "name": "lines_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_url": {
+          "name": "snapshot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_size_bytes": {
+          "name": "snapshot_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_provider_external_id_idx": {
+          "name": "users_provider_external_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1768167365004,
       "tag": "0002_uneven_aaron_stack",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1768251380500,
+      "tag": "0003_serious_george_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -92,6 +92,10 @@ export const tasks = pgTable("tasks", {
   prStatus: text("pr_status", {
     enum: ["open", "merged", "closed"],
   }),
+  // Snapshot info
+  snapshotUrl: text("snapshot_url"),
+  snapshotCreatedAt: timestamp("snapshot_created_at"),
+  snapshotSizeBytes: integer("snapshot_size_bytes"),
   // Timestamps
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@vercel/blob": "^2.0.0",
     "ai": "catalog:",
     "arctic": "^3.7.0",
     "class-variance-authority": "^0.7.1",

--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "cc-clone-ai-sdk",
+      "dependencies": {
+        "@vercel/blob": "^2.0.0",
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
         "turbo": "^2.5.4",
@@ -54,6 +57,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@vercel/blob": "^2.0.0",
         "ai": "catalog:",
         "arctic": "^3.7.0",
         "class-variance-authority": "^0.7.1",
@@ -289,6 +293,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
 
@@ -674,6 +680,8 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
+    "@vercel/blob": ["@vercel/blob@2.0.0", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^5.28.4" } }, "sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw=="],
+
     "@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
 
     "@vercel/sandbox": ["@vercel/sandbox@1.1.2", "", { "dependencies": { "@vercel/oidc": "^3.0.5", "async-retry": "1.3.3", "jsonlines": "0.1.1", "ms": "2.1.3", "tar-stream": "3.1.7", "undici": "^7.16.0", "zod": "3.24.4" } }, "sha512-+YG9Xseqqf2+Da5qjHWAORizxIVHZba/1790hkDbCtRGniz/NaqUYsy4dN5OQEeYqEOwCcI3gqu0XOwLU0E/zg=="],
@@ -972,6 +980,8 @@
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
+    "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
+
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
@@ -979,6 +989,8 @@
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
+
+    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
@@ -1356,7 +1368,7 @@
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
-    "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -1471,6 +1483,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@vercel/sandbox/undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
     "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw=="],
 

--- a/docs/sandbox-snapshot.md
+++ b/docs/sandbox-snapshot.md
@@ -22,84 +22,292 @@ extracting the tarball in a new sandbox.
 
 ```ts
 export interface SnapshotOptions {
-  uploadUrl: string;
-  downloadUrl: string;
+  /** Vercel Blob read-write token for upload */
+  blobToken: string;
+  /** Blob pathname for the snapshot (e.g., "snapshots/task-123/snapshot.tgz") */
+  pathname: string;
+  /** Working directory to snapshot (defaults to sandbox.workingDirectory) */
   workingDirectory?: string;
+  /** Local path for temporary archive (defaults to /tmp/sandbox-snapshot.tgz) */
   archivePath?: string;
+  /** Glob patterns to exclude from snapshot */
   exclude?: string[];
+  /** Timeout in milliseconds */
   timeoutMs?: number;
 }
 
-export interface RestoreOptions {
+export interface SnapshotResult {
+  /** Public URL of the uploaded snapshot */
+  url: string;
+  /** Download URL with Content-Disposition: attachment */
   downloadUrl: string;
+}
+
+export interface RestoreOptions {
+  /** Download URL of the snapshot to restore */
+  downloadUrl: string;
+  /** Working directory to restore into (defaults to sandbox.workingDirectory) */
   workingDirectory?: string;
+  /** Timeout in milliseconds */
   timeoutMs?: number;
+  /** If true, clean the directory before restoring */
   clean?: boolean;
 }
 
 export interface Sandbox {
-  // ...
-  snapshot?(options: SnapshotOptions): Promise<{ downloadUrl: string }>;
+  // ...existing methods...
+  snapshot?(options: SnapshotOptions): Promise<SnapshotResult>;
   restoreSnapshot?(options: RestoreOptions): Promise<void>;
+}
+```
+
+## Vercel Blob API Details
+
+The `@vercel/blob` SDK makes HTTP requests to `https://vercel.com/api/blob/`.
+For sandbox operations (where the SDK isn't available), use curl directly:
+
+**Upload endpoint:**
+```
+PUT https://vercel.com/api/blob/?pathname=<encoded-pathname>
+```
+
+**Required headers:**
+```
+Authorization: Bearer <BLOB_READ_WRITE_TOKEN>
+x-api-version: 11
+x-add-random-suffix: 0
+Content-Type: application/gzip
+```
+
+**Response (JSON):**
+```json
+{
+  "url": "https://<store>.public.blob.vercel-storage.com/<pathname>",
+  "downloadUrl": "https://<store>.public.blob.vercel-storage.com/<pathname>?download=1",
+  "pathname": "<pathname>",
+  "contentType": "application/gzip",
+  "contentDisposition": "attachment; filename=\"snapshot.tgz\""
 }
 ```
 
 ## VercelSandbox Implementation (packages/sandbox/vercel.ts)
 
-Snapshot:
-
-```bash
-tar -czf /tmp/sandbox-snapshot.tgz -C /vercel/sandbox .
-curl -fsSL -X PUT -T /tmp/sandbox-snapshot.tgz "$UPLOAD_URL"
-```
-
-Exclude flag construction (TypeScript sketch):
+### Snapshot
 
 ```ts
-const defaultExclude = ["./node_modules", "*/node_modules", "./dist*", "./.next"];
-const exclude = options.exclude ?? defaultExclude;
-const excludeFlags = exclude.map((pattern) => `--exclude="${pattern}"`).join(" ");
-const tarCommand = `tar -czf "${archivePath}" ${excludeFlags} -C "${cwd}" .`;
+async snapshot(options: SnapshotOptions): Promise<SnapshotResult> {
+  const cwd = options.workingDirectory ?? this.workingDirectory;
+  const archivePath = options.archivePath ?? "/tmp/sandbox-snapshot.tgz";
+  const timeoutMs = options.timeoutMs ?? 120_000;
+
+  // Build exclude flags
+  const defaultExclude = ["./node_modules", "*/node_modules", "./dist*", "./.next"];
+  const exclude = options.exclude ?? defaultExclude;
+  const excludeFlags = exclude.map((p) => `--exclude="${p}"`).join(" ");
+
+  // Create tarball
+  const tarCommand = `tar -czf "${archivePath}" ${excludeFlags} -C "${cwd}" .`;
+  const tarResult = await this.exec(tarCommand, cwd, timeoutMs);
+  if (!tarResult.success) {
+    throw new Error(`Failed to create snapshot archive: ${tarResult.stderr}`);
+  }
+
+  // Upload to Vercel Blob via curl
+  const encodedPathname = encodeURIComponent(options.pathname);
+  const uploadCommand = `curl -fsSL -X PUT \\
+    -H "Authorization: Bearer ${options.blobToken}" \\
+    -H "x-api-version: 11" \\
+    -H "x-add-random-suffix: 0" \\
+    -H "Content-Type: application/gzip" \\
+    --data-binary "@${archivePath}" \\
+    "https://vercel.com/api/blob/?pathname=${encodedPathname}"`;
+
+  const uploadResult = await this.exec(uploadCommand, cwd, timeoutMs);
+  if (!uploadResult.success) {
+    throw new Error(`Failed to upload snapshot: ${uploadResult.stderr}`);
+  }
+
+  // Parse response
+  const response = JSON.parse(uploadResult.stdout);
+  return {
+    url: response.url,
+    downloadUrl: response.downloadUrl,
+  };
+}
 ```
 
-Restore:
+### Restore
 
-```bash
-curl -fsSL "$DOWNLOAD_URL" | tar -xzf - -C /vercel/sandbox
+```ts
+async restoreSnapshot(options: RestoreOptions): Promise<void> {
+  const cwd = options.workingDirectory ?? this.workingDirectory;
+  const timeoutMs = options.timeoutMs ?? 120_000;
+
+  // Optionally clean directory first
+  if (options.clean) {
+    await this.exec(`rm -rf "${cwd}"/*`, cwd, 30_000);
+  }
+
+  // Download and extract
+  const restoreCommand = `curl -fsSL "${options.downloadUrl}" | tar -xzf - -C "${cwd}"`;
+  const result = await this.exec(restoreCommand, cwd, timeoutMs);
+  if (!result.success) {
+    throw new Error(`Failed to restore snapshot: ${result.stderr}`);
+  }
+}
 ```
-
-Notes:
-
-- Use `exclude` to skip directories like `node_modules` if desired.
-- Use `timeoutMs` to allow larger snapshots.
-- Default excludes (if options.exclude is undefined) should be:
-  - `./node_modules`
-  - `*/node_modules`
-  - `./dist*`
-  - `./.next`
 
 ## LocalSandbox Implementation (packages/sandbox/local.ts)
 
-Local sandboxes can use the same tar + curl flow to Vercel Blob, or implement
-direct file IO for the tarball on disk if Blob is not needed.
+Local sandboxes can use the same tar + curl flow to Vercel Blob. The
+implementation is nearly identical to VercelSandbox since both have full
+shell access.
 
 ## JustBashSandbox Implementation (packages/sandbox/just-bash.ts)
 
-- Likely unsupported (no `tar`/`curl`).
-- Return a structured error:
-  `return { success: false, error: "Snapshot not supported by just-bash" }`
+- Not supported (simulated shell lacks `tar`/`curl`).
+- Throw an error with clear message:
+  ```ts
+  async snapshot(): Promise<never> {
+    throw new Error("Snapshot is not supported by JustBashSandbox");
+  }
+  async restoreSnapshot(): Promise<never> {
+    throw new Error("Restore is not supported by JustBashSandbox");
+  }
+  ```
 
-## Host-Side Blob URL Generation
+## Host-Side Integration
 
-The host (CLI/server) should generate a presigned Blob upload URL and stable
-download URL using `@vercel/blob`, then pass those URLs into the sandbox.
+The host (web app API routes) handles:
+
+1. **Generating snapshot pathname:** `snapshots/${taskId}/${timestamp}.tgz`
+2. **Passing blob token:** From environment variable `BLOB_READ_WRITE_TOKEN`
+3. **Storing snapshot metadata:** Save URL to task record in database
+
+Example API route (`/api/sandbox/snapshot`):
+```ts
+// POST - Create snapshot
+const result = await sandbox.snapshot({
+  blobToken: process.env.BLOB_READ_WRITE_TOKEN!,
+  pathname: `snapshots/${taskId}/${Date.now()}.tgz`,
+});
+// Save result.downloadUrl to task in database
+
+// POST - Restore snapshot (during sandbox creation)
+if (task.snapshotUrl) {
+  await sandbox.restoreSnapshot({ downloadUrl: task.snapshotUrl });
+}
+```
+
+## Web App UI/UX
+
+### Sandbox Status Area (existing component)
+
+Extend the `SandboxStatus` component to show snapshot state:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  🟢 4:32 remaining  [Save Snapshot] [×]                 │
+└─────────────────────────────────────────────────────────┘
+```
+
+- **Save Snapshot button:** Manual snapshot creation
+- Shows spinner during snapshot upload
+- Toast notification on success/failure
+
+### Timeout Warning
+
+When sandbox is about to expire (e.g., < 1 minute remaining):
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  ⚠️ Sandbox expiring in 0:45                            │
+│                                                         │
+│  Save your work before the sandbox times out.           │
+│                                                         │
+│  [Save Snapshot]  [Extend Time]  [Dismiss]              │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Sandbox Expired State
+
+When sandbox expires, show restore option:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  🔴 Sandbox expired                                     │
+│                                                         │
+│  Last snapshot: 2 minutes ago (1.2 MB)                  │
+│                                                         │
+│  [Restore & Continue]  [Start Fresh]                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Auto-Snapshot on Timeout
+
+Add a setting (per-task or global) for automatic snapshots:
+
+- When `onTimeout` hook fires, automatically create snapshot
+- Store snapshot URL in task record
+- Show "Auto-saved" indicator in UI
+
+### Task Header Enhancement
+
+Show snapshot availability in task header:
+
+```
+Task Title
+Jan 12 - owner/repo - feature-branch
+📦 Snapshot available (saved 5 min ago)
+```
+
+### Snapshot Creation Flow
+
+1. User clicks "Save Snapshot"
+2. Button shows loading spinner
+3. Progress toast: "Creating snapshot..."
+4. On success: "Snapshot saved" toast with size info
+5. On failure: Error toast with retry option
+
+### Restore Flow (on sandbox recreation)
+
+1. User sends message after sandbox expired
+2. System detects expired sandbox with available snapshot
+3. Dialog appears:
+   ```
+   ┌─────────────────────────────────────────────────────┐
+   │  Restore Previous Work?                             │
+   │                                                     │
+   │  A snapshot from your previous session is           │
+   │  available. Would you like to restore it?           │
+   │                                                     │
+   │  Snapshot: Jan 12, 3:45 PM (1.2 MB)                 │
+   │                                                     │
+   │  [Restore Snapshot]  [Start Fresh]                  │
+   └─────────────────────────────────────────────────────┘
+   ```
+4. On restore: Show progress, then continue with message
+
+### Database Schema Addition
+
+Add to tasks table:
+```sql
+ALTER TABLE tasks ADD COLUMN snapshot_url TEXT;
+ALTER TABLE tasks ADD COLUMN snapshot_created_at TIMESTAMP;
+ALTER TABLE tasks ADD COLUMN snapshot_size_bytes INTEGER;
+```
 
 ## Error Handling
 
 - If snapshot upload fails, return a clear error message with context.
 - If restore fails, surface the command stderr and URL used.
+- Network errors should be retried with exponential backoff.
+- Partial uploads should be cleaned up.
 
 ## Optional Enhancements
 
-- Add snapshot metadata (size, createdAt, excludes) as a JSON manifest.
-- Support multiple snapshots by prefixing Blob keys with sandbox ID.
+- **Snapshot history:** Keep multiple snapshots per task, show list in UI.
+- **Snapshot size estimation:** Show estimated size before creating snapshot.
+- **Incremental snapshots:** Only upload changed files (more complex).
+- **Compression options:** Allow users to choose compression level.
+- **Snapshot expiration:** Auto-delete old snapshots after N days.

--- a/docs/sandbox-snapshot.md
+++ b/docs/sandbox-snapshot.md
@@ -1,0 +1,105 @@
+# Sandbox Snapshots (File System Only)
+
+This plan adds a sandbox-agnostic snapshot feature that captures the file
+system state (no processes/CPU/memory). The snapshot is a tarball of the
+working directory uploaded to Vercel Blob, then restored by downloading and
+extracting the tarball in a new sandbox.
+
+## Goals
+
+- Capture all files in `workingDirectory`.
+- Store snapshot in Vercel Blob for durability.
+- Restore into a fresh sandbox using a stable download URL.
+- Keep interface provider-agnostic, with per-provider implementation.
+
+## Non-Goals
+
+- No VM/process memory capture.
+- No exact reproduction of running processes.
+- No provider-specific hypervisor snapshots.
+
+## Proposed Interface (packages/sandbox/interface.ts)
+
+```ts
+export interface SnapshotOptions {
+  uploadUrl: string;
+  downloadUrl: string;
+  workingDirectory?: string;
+  archivePath?: string;
+  exclude?: string[];
+  timeoutMs?: number;
+}
+
+export interface RestoreOptions {
+  downloadUrl: string;
+  workingDirectory?: string;
+  timeoutMs?: number;
+  clean?: boolean;
+}
+
+export interface Sandbox {
+  // ...
+  snapshot?(options: SnapshotOptions): Promise<{ downloadUrl: string }>;
+  restoreSnapshot?(options: RestoreOptions): Promise<void>;
+}
+```
+
+## VercelSandbox Implementation (packages/sandbox/vercel.ts)
+
+Snapshot:
+
+```bash
+tar -czf /tmp/sandbox-snapshot.tgz -C /vercel/sandbox .
+curl -fsSL -X PUT -T /tmp/sandbox-snapshot.tgz "$UPLOAD_URL"
+```
+
+Exclude flag construction (TypeScript sketch):
+
+```ts
+const defaultExclude = ["./node_modules", "*/node_modules", "./dist*", "./.next"];
+const exclude = options.exclude ?? defaultExclude;
+const excludeFlags = exclude.map((pattern) => `--exclude="${pattern}"`).join(" ");
+const tarCommand = `tar -czf "${archivePath}" ${excludeFlags} -C "${cwd}" .`;
+```
+
+Restore:
+
+```bash
+curl -fsSL "$DOWNLOAD_URL" | tar -xzf - -C /vercel/sandbox
+```
+
+Notes:
+
+- Use `exclude` to skip directories like `node_modules` if desired.
+- Use `timeoutMs` to allow larger snapshots.
+- Default excludes (if options.exclude is undefined) should be:
+  - `./node_modules`
+  - `*/node_modules`
+  - `./dist*`
+  - `./.next`
+
+## LocalSandbox Implementation (packages/sandbox/local.ts)
+
+Local sandboxes can use the same tar + curl flow to Vercel Blob, or implement
+direct file IO for the tarball on disk if Blob is not needed.
+
+## JustBashSandbox Implementation (packages/sandbox/just-bash.ts)
+
+- Likely unsupported (no `tar`/`curl`).
+- Return a structured error:
+  `return { success: false, error: "Snapshot not supported by just-bash" }`
+
+## Host-Side Blob URL Generation
+
+The host (CLI/server) should generate a presigned Blob upload URL and stable
+download URL using `@vercel/blob`, then pass those URLs into the sandbox.
+
+## Error Handling
+
+- If snapshot upload fails, return a clear error message with context.
+- If restore fails, surface the command stderr and URL used.
+
+## Optional Enhancements
+
+- Add snapshot metadata (size, createdAt, excludes) as a JSON manifest.
+- Support multiple snapshots by prefixing Blob keys with sandbox ID.

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "turbo": "^2.5.4",
     "typescript": "^5"
   },
-  "packageManager": "bun@1.2.14"
+  "packageManager": "bun@1.2.14",
+  "dependencies": {
+    "@vercel/blob": "^2.0.0"
+  }
 }

--- a/packages/sandbox/index.ts
+++ b/packages/sandbox/index.ts
@@ -4,6 +4,9 @@ export type {
   ExecResult,
   SandboxHook,
   SandboxHooks,
+  SnapshotOptions,
+  SnapshotResult,
+  RestoreOptions,
 } from "./interface";
 export { LocalSandbox, createLocalSandbox } from "./local";
 export {

--- a/packages/sandbox/interface.ts
+++ b/packages/sandbox/interface.ts
@@ -1,6 +1,48 @@
 import type { Dirent } from "fs";
 
 /**
+ * Options for creating a snapshot of the sandbox filesystem.
+ */
+export interface SnapshotOptions {
+  /** Vercel Blob read-write token for upload */
+  blobToken: string;
+  /** Blob pathname for the snapshot (e.g., "snapshots/task-123/snapshot.tgz") */
+  pathname: string;
+  /** Working directory to snapshot (defaults to sandbox.workingDirectory) */
+  workingDirectory?: string;
+  /** Local path for temporary archive (defaults to /tmp/sandbox-snapshot.tgz) */
+  archivePath?: string;
+  /** Glob patterns to exclude from snapshot */
+  exclude?: string[];
+  /** Timeout in milliseconds */
+  timeoutMs?: number;
+}
+
+/**
+ * Result of a successful snapshot operation.
+ */
+export interface SnapshotResult {
+  /** Public URL of the uploaded snapshot */
+  url: string;
+  /** Download URL with Content-Disposition: attachment */
+  downloadUrl: string;
+}
+
+/**
+ * Options for restoring a snapshot to the sandbox filesystem.
+ */
+export interface RestoreOptions {
+  /** Download URL of the snapshot to restore */
+  downloadUrl: string;
+  /** Working directory to restore into (defaults to sandbox.workingDirectory) */
+  workingDirectory?: string;
+  /** Timeout in milliseconds */
+  timeoutMs?: number;
+  /** If true, clean the directory before restoring */
+  clean?: boolean;
+}
+
+/**
  * Lifecycle hook that receives the sandbox instance.
  * Use these to run arbitrary setup or teardown code.
  */
@@ -207,4 +249,21 @@ export interface Sandbox {
    * @returns New expiration timestamp
    */
   extendTimeout?(additionalMs: number): Promise<{ expiresAt: number }>;
+
+  /**
+   * Create a snapshot of the sandbox filesystem and upload to Vercel Blob.
+   * The snapshot is a tarball of the working directory.
+   * Only supported by sandboxes with shell access (Vercel, Local).
+   * @param options - Snapshot configuration including blob token and pathname
+   * @returns URLs for accessing the uploaded snapshot
+   */
+  snapshot?(options: SnapshotOptions): Promise<SnapshotResult>;
+
+  /**
+   * Restore a snapshot from Vercel Blob into the sandbox filesystem.
+   * Downloads and extracts the tarball into the working directory.
+   * Only supported by sandboxes with shell access (Vercel, Local).
+   * @param options - Restore configuration including download URL
+   */
+  restoreSnapshot?(options: RestoreOptions): Promise<void>;
 }

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -701,10 +701,17 @@ export class VercelSandbox implements Sandbox {
     await cleanup();
 
     // Parse response
-    const response = JSON.parse(uploadResult.stdout) as {
-      url: string;
-      downloadUrl: string;
-    };
+    let response: { url: string; downloadUrl: string };
+    try {
+      response = JSON.parse(uploadResult.stdout) as {
+        url: string;
+        downloadUrl: string;
+      };
+    } catch {
+      throw new Error(
+        `Failed to parse upload response (expected JSON): ${uploadResult.stdout.slice(0, 500)}`,
+      );
+    }
     return {
       url: response.url,
       downloadUrl: response.downloadUrl,

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -674,6 +674,11 @@ export class VercelSandbox implements Sandbox {
       );
     }
 
+    // Helper to clean up temporary archive
+    const cleanup = async () => {
+      await this.exec(`rm -f "${archivePath}"`, cwd, 10_000);
+    };
+
     // Upload to Vercel Blob via curl
     const encodedPathname = encodeURIComponent(options.pathname);
     const uploadCommand = `curl -fsSL -X PUT \
@@ -686,10 +691,14 @@ export class VercelSandbox implements Sandbox {
 
     const uploadResult = await this.exec(uploadCommand, cwd, timeoutMs);
     if (!uploadResult.success) {
+      await cleanup();
       throw new Error(
         `Failed to upload snapshot: ${uploadResult.stderr || uploadResult.stdout}`,
       );
     }
+
+    // Clean up temporary archive after successful upload
+    await cleanup();
 
     // Parse response
     const response = JSON.parse(uploadResult.stdout) as {

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -5,6 +5,9 @@ import type {
   SandboxStats,
   ExecResult,
   SandboxHooks,
+  SnapshotOptions,
+  SnapshotResult,
+  RestoreOptions,
 } from "./interface";
 
 const MAX_OUTPUT_LENGTH = 50_000;
@@ -642,6 +645,83 @@ export class VercelSandbox implements Sandbox {
    */
   domain(port: number): string {
     return this.sdk.domain(port);
+  }
+
+  /**
+   * Create a snapshot of the sandbox filesystem and upload to Vercel Blob.
+   */
+  async snapshot(options: SnapshotOptions): Promise<SnapshotResult> {
+    const cwd = options.workingDirectory ?? this.workingDirectory;
+    const archivePath = options.archivePath ?? "/tmp/sandbox-snapshot.tgz";
+    const timeoutMs = options.timeoutMs ?? 120_000;
+
+    // Build exclude flags
+    const defaultExclude = [
+      "./node_modules",
+      "*/node_modules",
+      "./dist*",
+      "./.next",
+    ];
+    const exclude = options.exclude ?? defaultExclude;
+    const excludeFlags = exclude.map((p) => `--exclude="${p}"`).join(" ");
+
+    // Create tarball
+    const tarCommand = `tar -czf "${archivePath}" ${excludeFlags} -C "${cwd}" .`;
+    const tarResult = await this.exec(tarCommand, cwd, timeoutMs);
+    if (!tarResult.success) {
+      throw new Error(
+        `Failed to create snapshot archive: ${tarResult.stderr || tarResult.stdout}`,
+      );
+    }
+
+    // Upload to Vercel Blob via curl
+    const encodedPathname = encodeURIComponent(options.pathname);
+    const uploadCommand = `curl -fsSL -X PUT \
+      -H "Authorization: Bearer ${options.blobToken}" \
+      -H "x-api-version: 11" \
+      -H "x-add-random-suffix: 0" \
+      -H "Content-Type: application/gzip" \
+      --data-binary "@${archivePath}" \
+      "https://vercel.com/api/blob/?pathname=${encodedPathname}"`;
+
+    const uploadResult = await this.exec(uploadCommand, cwd, timeoutMs);
+    if (!uploadResult.success) {
+      throw new Error(
+        `Failed to upload snapshot: ${uploadResult.stderr || uploadResult.stdout}`,
+      );
+    }
+
+    // Parse response
+    const response = JSON.parse(uploadResult.stdout) as {
+      url: string;
+      downloadUrl: string;
+    };
+    return {
+      url: response.url,
+      downloadUrl: response.downloadUrl,
+    };
+  }
+
+  /**
+   * Restore a snapshot from Vercel Blob into the sandbox filesystem.
+   */
+  async restoreSnapshot(options: RestoreOptions): Promise<void> {
+    const cwd = options.workingDirectory ?? this.workingDirectory;
+    const timeoutMs = options.timeoutMs ?? 120_000;
+
+    // Optionally clean directory first
+    if (options.clean) {
+      await this.exec(`rm -rf "${cwd}"/*`, cwd, 30_000);
+    }
+
+    // Download and extract
+    const restoreCommand = `curl -fsSL "${options.downloadUrl}" | tar -xzf - -C "${cwd}"`;
+    const result = await this.exec(restoreCommand, cwd, timeoutMs);
+    if (!result.success) {
+      throw new Error(
+        `Failed to restore snapshot: ${result.stderr || result.stdout}`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
This adds a complete sandbox snapshot feature enabling users to save and restore sandbox filesystem state.

- **New snapshot API** (`/api/sandbox/snapshot`): POST creates snapshots, PUT restores them with ownership verification
- **Sandbox interface updates**: Added `snapshot()` and `restoreSnapshot()` methods to the Sandbox interface, implemented in VercelSandbox using tar+curl
- **Database schema**: Added `snapshot_url`, `snapshot_created_at`, and `snapshot_size_bytes` columns to tasks table
- **UI enhancements**: Added Save/Restore snapshot buttons, confirmation dialogs, and loading states in SandboxStatus component
- **Improved sandbox creation logic**: Made taskId required in chat API, now uses `prNumber` to determine if branch exists on origin (cleaner than checking sandboxId)
- **Sandbox cleanup**: DELETE endpoint now clears sandboxId from task to prevent validation errors on recreation
- **Task context synchronization**: Added `updateTaskSnapshot` and improved sandboxId sync to prevent stale state