### PR TITLE
Add sandbox state persistence with capture and restore

### DIFF
--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -1,7 +1,12 @@
 import { connectVercelSandbox } from "@open-harness/sandbox";
+import type { Sandbox } from "@open-harness/sandbox";
+import { nanoid } from "nanoid";
 import { getUserGitHubToken } from "@/lib/github/user-token";
 import { getServerSession } from "@/lib/session/get-server-session";
 import { getTaskById, updateTask } from "@/lib/db/tasks";
+import { createTaskDiff, getLatestTaskDiff } from "@/lib/db/task-diffs";
+import { captureSandboxState } from "@/lib/sandbox/capture-state";
+import { restoreSandboxState } from "@/lib/sandbox/restore-state";
 
 const DEFAULT_TIMEOUT = 300_000; // 5 minutes
 
@@ -11,6 +16,30 @@ interface CreateSandboxRequest {
   isNewBranch?: boolean;
   taskId?: string;
   sandboxId?: string; // Existing sandbox ID if any
+}
+
+async function captureAndStoreTaskDiff(sandbox: Sandbox, taskId: string) {
+  try {
+    const state = await captureSandboxState(sandbox);
+    const hasChanges =
+      state.diffContent.trim().length > 0 || state.untrackedFiles.length > 0;
+
+    if (!hasChanges) {
+      return;
+    }
+
+    const baseCommit = state.baseCommit.trim();
+    await createTaskDiff({
+      id: nanoid(),
+      taskId,
+      diffContent: state.diffContent,
+      untrackedFiles: state.untrackedFiles,
+      baseCommit: baseCommit.length > 0 ? baseCommit : null,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Failed to capture sandbox state in beforeStop:", message);
+  }
 }
 
 export async function POST(req: Request) {
@@ -85,6 +114,14 @@ export async function POST(req: Request) {
     },
   };
 
+  if (taskId) {
+    sandboxOptions.hooks = {
+      beforeStop: async (sandboxInstance) => {
+        await captureAndStoreTaskDiff(sandboxInstance, taskId);
+      },
+    };
+  }
+
   // Only add source when we have a repo to clone
   if (repoUrl) {
     sandboxOptions.source = {
@@ -98,9 +135,31 @@ export async function POST(req: Request) {
 
   const sandbox = await connectVercelSandbox(sandboxOptions);
 
-  // Update task with sandboxId if this is a new sandbox
-  // Verify task ownership before updating
-  if (taskId && !taskSandboxId) {
+  // Restore workspace state if available
+  let stateRestored: boolean | undefined;
+  let stateRestoreError: string | undefined;
+  if (taskId) {
+    try {
+      const latestDiff = await getLatestTaskDiff(taskId);
+      if (latestDiff) {
+        const restoreResult = await restoreSandboxState(sandbox, latestDiff);
+        if (restoreResult.success) {
+          stateRestored = true;
+        } else {
+          stateRestored = false;
+          stateRestoreError = restoreResult.error;
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      stateRestored = false;
+      stateRestoreError = message;
+      console.warn("Failed to restore sandbox state:", message);
+    }
+  }
+
+  // Update task with latest sandboxId
+  if (taskId && sandbox.id !== taskSandboxId) {
     await updateTask(taskId, { sandboxId: sandbox.id });
   }
 
@@ -109,6 +168,8 @@ export async function POST(req: Request) {
     createdAt: Date.now(),
     timeout: DEFAULT_TIMEOUT,
     currentBranch: sandbox.currentBranch,
+    ...(stateRestored !== undefined && { stateRestored }),
+    ...(stateRestoreError && { stateRestoreError }),
   });
 }
 
@@ -156,7 +217,14 @@ export async function DELETE(req: Request) {
     );
   }
 
-  const sandbox = await connectVercelSandbox({ sandboxId });
+  const sandbox = await connectVercelSandbox({
+    sandboxId,
+    hooks: {
+      beforeStop: async (sandboxInstance) => {
+        await captureAndStoreTaskDiff(sandboxInstance, taskId);
+      },
+    },
+  });
   await sandbox.stop();
 
   return Response.json({ success: true });

--- a/apps/web/app/chat-context.tsx
+++ b/apps/web/app/chat-context.tsx
@@ -21,6 +21,8 @@ export type SandboxInfo = {
   createdAt: number;
   timeout: number;
   currentBranch?: string;
+  stateRestored?: boolean;
+  stateRestoreError?: string;
 };
 
 export type RepoInfo = {

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -23,6 +23,8 @@ export type SandboxInfo = {
   createdAt: number;
   timeout: number;
   currentBranch?: string;
+  stateRestored?: boolean;
+  stateRestoreError?: string;
 };
 
 type DiffCacheState = {
@@ -39,6 +41,7 @@ type TaskChatContextValue = {
   sandboxInfo: SandboxInfo | null;
   setSandboxInfo: (info: SandboxInfo) => void;
   clearSandboxInfo: () => void;
+  setTaskSandboxId: (sandboxId: string) => void;
   archiveTask: () => Promise<void>;
   /** Whether the task had persisted messages when it was loaded */
   hadInitialMessages: boolean;
@@ -98,6 +101,10 @@ export function TaskChatProvider({
   const clearSandboxInfo = useCallback(() => {
     sandboxIdRef.current = null;
     setSandboxInfoState(null);
+  }, []);
+
+  const setTaskSandboxId = useCallback((sandboxId: string) => {
+    setTask((prev) => ({ ...prev, sandboxId }));
   }, []);
 
   const [diffRefreshKey, setDiffRefreshKey] = useState(0);
@@ -206,6 +213,7 @@ export function TaskChatProvider({
         sandboxInfo,
         setSandboxInfo,
         clearSandboxInfo,
+        setTaskSandboxId,
         archiveTask,
         hadInitialMessages,
         diffRefreshKey,

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { isToolUIPart } from "ai";
 import type { ComponentProps, ReactNode } from "react";
@@ -13,6 +13,7 @@ import {
   ArrowUp,
   Square,
   X,
+  RotateCcw,
   Archive,
   Share2,
   GitPullRequest,
@@ -99,11 +100,15 @@ function formatTimeRemaining(ms: number): string {
 function SandboxStatus({
   sandboxInfo,
   isCreating,
+  isRestoring,
   onKill,
+  onStartNew,
 }: {
   sandboxInfo: SandboxInfo | null;
   isCreating: boolean;
+  isRestoring: boolean;
   onKill: () => void;
+  onStartNew: () => void;
 }) {
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
 
@@ -126,14 +131,32 @@ function SandboxStatus({
 
   if (isCreating) {
     return (
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <span className="h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
-        <span>Creating sandbox...</span>
+      <div className="flex flex-col items-end gap-1 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
+          <span>{isRestoring ? "Restoring workspace..." : "Creating sandbox..."}</span>
+        </div>
       </div>
     );
   }
 
-  if (!sandboxInfo || timeRemaining === null) {
+  if (!sandboxInfo) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="h-2 w-2 rounded-full bg-muted-foreground/40" />
+        <span>Sandbox stopped</span>
+        <button
+          type="button"
+          onClick={onStartNew}
+          className="rounded px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted-foreground/20"
+        >
+          Start sandbox
+        </button>
+      </div>
+    );
+  }
+
+  if (timeRemaining === null) {
     return null;
   }
 
@@ -142,22 +165,53 @@ function SandboxStatus({
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <span className="h-2 w-2 rounded-full bg-red-500" />
         <span>Sandbox expired</span>
+        <button
+          type="button"
+          onClick={onStartNew}
+          className="rounded px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted-foreground/20"
+        >
+          New sandbox
+        </button>
       </div>
     );
   }
 
+  const restoreWarning =
+    sandboxInfo.stateRestored === false
+      ? sandboxInfo.stateRestoreError ?? "Restore incomplete"
+      : null;
+
   return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <span className="h-2 w-2 rounded-full bg-green-500" />
-      <span>{formatTimeRemaining(timeRemaining)}</span>
-      <button
-        type="button"
-        onClick={onKill}
-        className="rounded p-0.5 hover:bg-muted-foreground/20"
-        title="Stop sandbox"
-      >
-        <X className="h-3 w-3" />
-      </button>
+    <div className="flex flex-col items-end gap-1 text-xs text-muted-foreground">
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full bg-green-500" />
+        <span>{formatTimeRemaining(timeRemaining)}</span>
+        <button
+          type="button"
+          onClick={onKill}
+          className="rounded p-0.5 hover:bg-muted-foreground/20"
+          title="Stop sandbox"
+        >
+          <X className="h-3 w-3" />
+        </button>
+        <button
+          type="button"
+          onClick={onStartNew}
+          className="rounded p-0.5 hover:bg-muted-foreground/20"
+          title="Start new sandbox"
+        >
+          <RotateCcw className="h-3 w-3" />
+        </button>
+      </div>
+      {restoreWarning && (
+        <div
+          className="flex items-center gap-1 text-[11px] text-amber-500"
+          title={restoreWarning}
+        >
+          <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+          <span>Restore incomplete</span>
+        </div>
+      )}
     </div>
   );
 }
@@ -173,6 +227,7 @@ export function TaskDetailContent() {
   const router = useRouter();
   const [input, setInput] = useState("");
   const [isCreatingSandbox, setIsCreatingSandbox] = useState(false);
+  const [isRestoringSandbox, setIsRestoringSandbox] = useState(false);
   const [prDialogOpen, setPrDialogOpen] = useState(false);
   const [repoDialogOpen, setRepoDialogOpen] = useState(false);
   const [showDiffPanel, setShowDiffPanel] = useState(false);
@@ -185,6 +240,7 @@ export function TaskDetailContent() {
     sandboxInfo,
     setSandboxInfo,
     clearSandboxInfo,
+    setTaskSandboxId,
     archiveTask,
     hadInitialMessages,
     diffRefreshKey,
@@ -215,6 +271,82 @@ export function TaskDetailContent() {
     }
   };
 
+  const createSandboxForTask = useCallback(
+    async (options?: { showRestoreIndicator?: boolean }) => {
+      const shouldRestore = options?.showRestoreIndicator ?? false;
+      setIsCreatingSandbox(true);
+      setIsRestoringSandbox(shouldRestore);
+
+      try {
+        // Only create new branch on first sandbox creation
+        // If task already has a sandboxId, branch was already created
+        const shouldCreateNewBranch = task.isNewBranch && !task.sandboxId;
+        const existingSandboxId =
+          sandboxInfo?.sandboxId ?? task.sandboxId ?? undefined;
+        const newSandbox = await createSandbox(
+          task.cloneUrl ?? undefined,
+          task.branch ?? undefined,
+          shouldCreateNewBranch,
+          task.id,
+          existingSandboxId,
+        );
+        setSandboxInfo(newSandbox);
+        setTaskSandboxId(newSandbox.sandboxId);
+        return newSandbox;
+      } finally {
+        setIsCreatingSandbox(false);
+        setIsRestoringSandbox(false);
+      }
+    },
+    [
+      sandboxInfo?.sandboxId,
+      setSandboxInfo,
+      setTaskSandboxId,
+      task.branch,
+      task.cloneUrl,
+      task.id,
+      task.isNewBranch,
+      task.sandboxId,
+    ],
+  );
+
+  const handleStartNewSandbox = useCallback(async () => {
+    if (isCreatingSandbox) return;
+
+    const shouldRestore = hadInitialMessages || messages.length > 0;
+
+    if (sandboxInfo) {
+      try {
+        await fetch("/api/sandbox", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sandboxId: sandboxInfo.sandboxId,
+            taskId: task.id,
+          }),
+        });
+      } catch (error) {
+        console.error("Failed to stop sandbox:", error);
+      } finally {
+        clearSandboxInfo();
+      }
+    }
+
+    try {
+      await createSandboxForTask({ showRestoreIndicator: shouldRestore });
+    } catch (error) {
+      console.error("Failed to create sandbox:", error);
+    }
+  }, [
+    clearSandboxInfo,
+    createSandboxForTask,
+    hadInitialMessages,
+    isCreatingSandbox,
+    messages.length,
+    sandboxInfo,
+    task.id,
+  ]);
+
   useEffect(() => {
     if (isAtBottom) {
       scrollToBottom();
@@ -236,25 +368,14 @@ export function TaskDetailContent() {
 
       // Create sandbox and send first message
       const initTask = async () => {
-        // Always create a sandbox - either with repo or empty
-        setIsCreatingSandbox(true);
         try {
-          // Only create new branch on first sandbox creation
-          // If task already has a sandboxId, branch was already created
-          const shouldCreateNewBranch = task.isNewBranch && !task.sandboxId;
-          const newSandbox = await createSandbox(
-            task.cloneUrl ?? undefined,
-            task.branch ?? undefined,
-            shouldCreateNewBranch,
-            task.id,
-            task.sandboxId ?? undefined,
-          );
-          setSandboxInfo(newSandbox);
+          // Always create a sandbox - either with repo or empty
+          await createSandboxForTask({
+            showRestoreIndicator: hadInitialMessages,
+          });
         } catch (err) {
           console.error("Failed to create sandbox:", err);
           return;
-        } finally {
-          setIsCreatingSandbox(false);
         }
 
         // Send initial message for all tasks (with or without repo)
@@ -266,13 +387,14 @@ export function TaskDetailContent() {
   }, [
     messages.length,
     sendMessage,
-    setSandboxInfo,
+    createSandboxForTask,
     task.id,
     task.cloneUrl,
     task.branch,
     task.isNewBranch,
     task.sandboxId,
     task.title,
+    hadInitialMessages,
   ]);
 
   // Track tool completions to trigger diff refresh
@@ -603,7 +725,9 @@ export function TaskDetailContent() {
               <SandboxStatus
                 sandboxInfo={sandboxInfo}
                 isCreating={isCreatingSandbox}
+                isRestoring={isRestoringSandbox}
                 onKill={handleKillSandbox}
+                onStartNew={handleStartNewSandbox}
               />
             </div>
             <form
@@ -616,25 +740,13 @@ export function TaskDetailContent() {
 
                 // Recreate sandbox if expired
                 if (!isSandboxValid(sandboxInfo)) {
-                  setIsCreatingSandbox(true);
                   try {
-                    // Only create new branch on first sandbox creation
-                    // If task already has a sandboxId, branch was already created
-                    const shouldCreateNewBranch =
-                      task.isNewBranch && !task.sandboxId;
-                    const newSandbox = await createSandbox(
-                      task.cloneUrl ?? undefined,
-                      task.branch ?? undefined,
-                      shouldCreateNewBranch,
-                      task.id,
-                      task.sandboxId ?? undefined,
-                    );
-                    setSandboxInfo(newSandbox);
+                    await createSandboxForTask({
+                      showRestoreIndicator: true,
+                    });
                   } catch {
                     setInput(messageText);
                     return;
-                  } finally {
-                    setIsCreatingSandbox(false);
                   }
                 }
 

--- a/apps/web/docs/sandbox-state-persistence-plan.md
+++ b/apps/web/docs/sandbox-state-persistence-plan.md
@@ -105,7 +105,7 @@ const sandbox = await connectVercelSandbox({
 });
 ```
 
-**Note:** This requires `taskId` to be available in the hook context. We'll need to capture it in a closure.
+**Note:** This requires `taskId` to be available in the hook context. We'll need to capture it in a closure. Also pass the same hook when reconnecting to stop a sandbox so manual stops persist state too.
 
 ---
 
@@ -167,6 +167,8 @@ return Response.json({
 });
 ```
 
+**Also:** Update the task's `sandboxId` on every new sandbox creation (not just the first) so subsequent API calls validate correctly.
+
 ---
 
 ### Phase 7: Client-Side UI Feedback
@@ -177,6 +179,7 @@ When `createSandbox` is called:
 1. Show "Restoring workspace..." text during sandbox creation (if task has messages)
 2. If `stateRestored: true` in response, continue normally
 3. If restoration failed, show subtle warning but continue
+4. Extend sandbox status UI to show stopped/expired state and provide a "Start new sandbox" / restart action
 
 ---
 

--- a/apps/web/lib/db/migrations/0003_sandbox_state.sql
+++ b/apps/web/lib/db/migrations/0003_sandbox_state.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "task_diffs" (
+  "id" text PRIMARY KEY NOT NULL,
+  "task_id" text NOT NULL REFERENCES "tasks"("id") ON DELETE cascade,
+  "diff_content" text NOT NULL,
+  "untracked_files" jsonb NOT NULL,
+  "base_commit" text,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);

--- a/apps/web/lib/db/migrations/meta/0003_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,492 @@
+{
+  "id": "1fdd3737-b0f6-4ce4-81d4-d839d09bece4",
+  "prevId": "e988cd43-a856-4053-ad1c-b892e6e54af7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_provider_idx": {
+          "name": "accounts_user_id_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_messages": {
+      "name": "task_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_messages_task_id_tasks_id_fk": {
+          "name": "task_messages_task_id_tasks_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_diffs": {
+      "name": "task_diffs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff_content": {
+          "name": "diff_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "untracked_files": {
+          "name": "untracked_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_commit": {
+          "name": "base_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_diffs_task_id_tasks_id_fk": {
+          "name": "task_diffs_task_id_tasks_id_fk",
+          "tableFrom": "task_diffs",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new_branch": {
+          "name": "is_new_branch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines_added": {
+          "name": "lines_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lines_removed": {
+          "name": "lines_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_provider_external_id_idx": {
+          "name": "users_provider_external_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1768167365004,
       "tag": "0002_uneven_aaron_stack",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1768248071000,
+      "tag": "0003_sandbox_state",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -97,6 +97,24 @@ export const tasks = pgTable("tasks", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
+export type TaskDiffUntrackedFile = {
+  path: string;
+  content: string;
+};
+
+export const taskDiffs = pgTable("task_diffs", {
+  id: text("id").primaryKey(),
+  taskId: text("task_id")
+    .notNull()
+    .references(() => tasks.id, { onDelete: "cascade" }),
+  diffContent: text("diff_content").notNull(),
+  untrackedFiles: jsonb("untracked_files")
+    .$type<TaskDiffUntrackedFile[]>()
+    .notNull(),
+  baseCommit: text("base_commit"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
 export const taskMessages = pgTable("task_messages", {
   id: text("id").primaryKey(),
   taskId: text("task_id")
@@ -112,5 +130,7 @@ export const taskMessages = pgTable("task_messages", {
 
 export type Task = typeof tasks.$inferSelect;
 export type NewTask = typeof tasks.$inferInsert;
+export type TaskDiff = typeof taskDiffs.$inferSelect;
+export type NewTaskDiff = typeof taskDiffs.$inferInsert;
 export type TaskMessage = typeof taskMessages.$inferSelect;
 export type NewTaskMessage = typeof taskMessages.$inferInsert;

--- a/apps/web/lib/db/task-diffs.ts
+++ b/apps/web/lib/db/task-diffs.ts
@@ -1,0 +1,42 @@
+import { and, desc, eq, notInArray } from "drizzle-orm";
+import { db } from "./client.js";
+import { taskDiffs, type NewTaskDiff, type TaskDiff } from "./schema.js";
+
+export async function createTaskDiff(data: NewTaskDiff): Promise<TaskDiff> {
+  const [diff] = await db.insert(taskDiffs).values(data).returning();
+  if (!diff) {
+    throw new Error("Failed to create task diff");
+  }
+
+  const diffsToKeep = await db
+    .select({ id: taskDiffs.id })
+    .from(taskDiffs)
+    .where(eq(taskDiffs.taskId, data.taskId))
+    .orderBy(desc(taskDiffs.createdAt), desc(taskDiffs.id))
+    .limit(3);
+
+  const keepIds = diffsToKeep.map((entry) => entry.id);
+  if (keepIds.length > 0) {
+    await db
+      .delete(taskDiffs)
+      .where(
+        and(
+          eq(taskDiffs.taskId, data.taskId),
+          notInArray(taskDiffs.id, keepIds),
+        ),
+      );
+  }
+
+  return diff;
+}
+
+export async function getLatestTaskDiff(taskId: string): Promise<TaskDiff | null> {
+  const [diff] = await db
+    .select()
+    .from(taskDiffs)
+    .where(eq(taskDiffs.taskId, taskId))
+    .orderBy(desc(taskDiffs.createdAt), desc(taskDiffs.id))
+    .limit(1);
+
+  return diff ?? null;
+}

--- a/apps/web/lib/sandbox/capture-state.ts
+++ b/apps/web/lib/sandbox/capture-state.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+import type { Sandbox } from "@open-harness/sandbox";
+
+const MAX_UNTRACKED_FILE_BYTES = 1_048_576;
+const COMMAND_TIMEOUT_MS = 30_000;
+const DIFF_TIMEOUT_MS = 60_000;
+
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+async function readFileAsBase64(
+  sandbox: Sandbox,
+  absolutePath: string,
+  cwd: string,
+): Promise<string | null> {
+  const result = await sandbox.exec(
+    `base64 ${shellEscape(absolutePath)}`,
+    cwd,
+    COMMAND_TIMEOUT_MS,
+  );
+
+  if (!result.success) {
+    return null;
+  }
+
+  return result.stdout.replace(/\s+/g, "");
+}
+
+export async function captureSandboxState(sandbox: Sandbox): Promise<{
+  diffContent: string;
+  untrackedFiles: Array<{ path: string; content: string }>;
+  baseCommit: string;
+}> {
+  const cwd = sandbox.workingDirectory;
+
+  const baseCommitResult = await sandbox.exec(
+    "git rev-parse HEAD",
+    cwd,
+    COMMAND_TIMEOUT_MS,
+  );
+  const baseCommit = baseCommitResult.success
+    ? baseCommitResult.stdout.trim()
+    : "";
+
+  const diffResult = await sandbox.exec("git diff HEAD", cwd, DIFF_TIMEOUT_MS);
+  const diffContent = diffResult.success ? diffResult.stdout : "";
+
+  const untrackedResult = await sandbox.exec(
+    "git ls-files --others --exclude-standard",
+    cwd,
+    COMMAND_TIMEOUT_MS,
+  );
+
+  if (!untrackedResult.success) {
+    return { diffContent, untrackedFiles: [], baseCommit };
+  }
+
+  const untrackedPaths = untrackedResult.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const untrackedFiles: Array<{ path: string; content: string }> = [];
+
+  for (const relativePath of untrackedPaths) {
+    const absolutePath = path.posix.join(cwd, relativePath);
+
+    let stats: Awaited<ReturnType<Sandbox["stat"]>>;
+    try {
+      stats = await sandbox.stat(absolutePath);
+    } catch {
+      continue;
+    }
+
+    if (!stats.isFile() || stats.size > MAX_UNTRACKED_FILE_BYTES) {
+      continue;
+    }
+
+    const content = await readFileAsBase64(sandbox, absolutePath, cwd);
+    if (content === null) {
+      continue;
+    }
+
+    untrackedFiles.push({ path: relativePath, content });
+  }
+
+  return { diffContent, untrackedFiles, baseCommit };
+}

--- a/apps/web/lib/sandbox/restore-state.ts
+++ b/apps/web/lib/sandbox/restore-state.ts
@@ -1,0 +1,135 @@
+import path from "node:path";
+import type { Sandbox } from "@open-harness/sandbox";
+import type { TaskDiff } from "@/lib/db/schema";
+
+const COMMAND_TIMEOUT_MS = 30_000;
+const DIFF_TIMEOUT_MS = 60_000;
+const RESTORE_DIR_NAME = ".open-harness";
+const PATCH_FILENAME = "restore.patch";
+const BASE64_FILENAME = "restore.b64";
+
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function isSafeRelativePath(filePath: string): boolean {
+  if (path.posix.isAbsolute(filePath)) {
+    return false;
+  }
+
+  const normalized = path.posix.normalize(filePath);
+  if (normalized.startsWith("..") || normalized.includes("/../")) {
+    return false;
+  }
+
+  return normalized.length > 0;
+}
+
+async function decodeBase64ToFile(
+  sandbox: Sandbox,
+  base64Path: string,
+  targetPath: string,
+  cwd: string,
+): Promise<boolean> {
+  const primary = await sandbox.exec(
+    `base64 -d ${shellEscape(base64Path)} > ${shellEscape(targetPath)}`,
+    cwd,
+    COMMAND_TIMEOUT_MS,
+  );
+
+  if (primary.success) {
+    return true;
+  }
+
+  const fallback = await sandbox.exec(
+    `base64 --decode ${shellEscape(base64Path)} > ${shellEscape(targetPath)}`,
+    cwd,
+    COMMAND_TIMEOUT_MS,
+  );
+
+  return fallback.success;
+}
+
+export async function restoreSandboxState(
+  sandbox: Sandbox,
+  diff: TaskDiff,
+): Promise<{ success: boolean; error?: string }> {
+  const cwd = sandbox.workingDirectory;
+  const errors: string[] = [];
+
+  const restoreDir = path.posix.join(cwd, RESTORE_DIR_NAME);
+  await sandbox.mkdir(restoreDir, { recursive: true });
+
+  if (diff.diffContent.trim().length > 0) {
+    const patchPath = path.posix.join(restoreDir, PATCH_FILENAME);
+    await sandbox.writeFile(patchPath, diff.diffContent, "utf-8");
+
+    const applyResult = await sandbox.exec(
+      `git apply --3way ${shellEscape(patchPath)}`,
+      cwd,
+      DIFF_TIMEOUT_MS,
+    );
+
+    if (!applyResult.success) {
+      const rejectResult = await sandbox.exec(
+        `git apply --reject ${shellEscape(patchPath)}`,
+        cwd,
+        DIFF_TIMEOUT_MS,
+      );
+
+      if (!rejectResult.success) {
+        errors.push("Failed to apply git diff");
+      } else {
+        errors.push("Git diff applied with rejects");
+      }
+    }
+  }
+
+  const untrackedFiles = diff.untrackedFiles ?? [];
+
+  for (const file of untrackedFiles) {
+    if (!isSafeRelativePath(file.path)) {
+      errors.push(`Skipped unsafe path: ${file.path}`);
+      continue;
+    }
+
+    const targetPath = path.posix.join(cwd, file.path);
+
+    try {
+      await sandbox.access(targetPath);
+      continue;
+    } catch {
+      // File does not exist; continue.
+    }
+
+    const targetDir = path.posix.dirname(targetPath);
+    await sandbox.mkdir(targetDir, { recursive: true });
+
+    const base64Path = path.posix.join(restoreDir, BASE64_FILENAME);
+    await sandbox.writeFile(base64Path, file.content, "utf-8");
+
+    const decoded = await decodeBase64ToFile(
+      sandbox,
+      base64Path,
+      targetPath,
+      cwd,
+    );
+
+    if (!decoded) {
+      errors.push(`Failed to restore ${file.path}`);
+    }
+  }
+
+  await sandbox.exec(
+    `rm -f ${shellEscape(path.posix.join(restoreDir, PATCH_FILENAME))} ` +
+      `${shellEscape(path.posix.join(restoreDir, BASE64_FILENAME))}`,
+    cwd,
+    COMMAND_TIMEOUT_MS,
+  );
+
+  if (errors.length > 0) {
+    return { success: false, error: errors.join("; ") };
+  }
+
+  return { success: true };
+}


### PR DESCRIPTION
Implement automatic sandbox state preservation across reconnections, enabling users to resume work after sandbox expiration or manual stops.

- **Database**: Add `task_diffs` table to store git diffs and untracked files for each task
- **API**: Capture sandbox state before stopping via `beforeStop` hook; restore latest diff when creating new sandbox
- **UI**: Show restore status during sandbox creation, warn if restoration fails, add "Start new sandbox" button for stopped/expired sandboxes
- **Client**: Track `stateRestored` and `stateRestoreError` in sandbox info; refactor sandbox creation logic into reusable `createSandboxForTask` function