### PR TITLE
Add image attachment support to task and message input

### DIFF
--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -19,6 +19,7 @@ import {
   FolderGit2,
   MoreVertical,
   GitCompare,
+  Paperclip,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -26,7 +27,10 @@ import { ToolCall } from "@/components/tool-call";
 import { TaskGroupView } from "@/components/task-group-view";
 import { CreatePRDialog } from "@/components/create-pr-dialog";
 import { CreateRepoDialog } from "@/components/create-repo-dialog";
+import { ImageAttachmentsPreview } from "@/components/image-attachments-preview";
 import { useScrollToBottom } from "@/hooks/use-scroll-to-bottom";
+import { useImageAttachments } from "@/hooks/use-image-attachments";
+import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
 import type { WebAgentUIToolPart, WebAgentUIMessagePart } from "@/app/types";
 import type { TaskToolUIPart } from "@open-harness/agent";
 
@@ -176,7 +180,19 @@ export function TaskDetailContent() {
   const [prDialogOpen, setPrDialogOpen] = useState(false);
   const [repoDialogOpen, setRepoDialogOpen] = useState(false);
   const [showDiffPanel, setShowDiffPanel] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    images,
+    addImage,
+    addImages,
+    removeImage,
+    clearImages,
+    getFileParts,
+    fileInputRef,
+    openFilePicker,
+  } = useImageAttachments();
   const { containerRef, isAtBottom, scrollToBottom } =
     useScrollToBottom<HTMLDivElement>();
   const {
@@ -578,6 +594,25 @@ export function TaskDetailContent() {
                       );
                     }
 
+                    // Render image attachments
+                    if (
+                      p.type === "file" &&
+                      p.mediaType?.startsWith("image/")
+                    ) {
+                      return (
+                        <div key={`${m.id}-${i}`} className="flex justify-end">
+                          <div className="max-w-[80%]">
+                            {/* eslint-disable-next-line @next/next/no-img-element -- Data URLs not supported by next/image */}
+                            <img
+                              src={p.url}
+                              alt={p.filename ?? "Attached image"}
+                              className="max-h-64 rounded-lg"
+                            />
+                          </div>
+                        </div>
+                      );
+                    }
+
                     return null;
                   });
                 })}
@@ -606,13 +641,31 @@ export function TaskDetailContent() {
                 onKill={handleKillSandbox}
               />
             </div>
+            {/* Hidden file input */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPT_IMAGE_TYPES}
+              multiple
+              onChange={(e) => {
+                const files = e.target.files;
+                if (files && files.length > 0) {
+                  addImages(files);
+                }
+                e.target.value = "";
+              }}
+              className="hidden"
+            />
             <form
               onSubmit={async (e) => {
                 e.preventDefault();
-                if (!input.trim()) return;
+                const hasContent = input.trim() || images.length > 0;
+                if (!hasContent) return;
 
                 const messageText = input;
+                const files = getFileParts();
                 setInput("");
+                clearImages();
 
                 // Recreate sandbox if expired
                 if (!isSandboxValid(sandboxInfo)) {
@@ -638,37 +691,80 @@ export function TaskDetailContent() {
                   }
                 }
 
-                sendMessage({ text: messageText });
+                sendMessage({ text: messageText, files });
               }}
-              className="flex items-center gap-2 rounded-full bg-muted px-4 py-2"
+              onDragOver={(e) => {
+                e.preventDefault();
+                setIsDragging(true);
+              }}
+              onDragLeave={(e) => {
+                e.preventDefault();
+                setIsDragging(false);
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                setIsDragging(false);
+                const files = e.dataTransfer.files;
+                if (files.length > 0) {
+                  addImages(files);
+                }
+              }}
+              className={`overflow-hidden rounded-2xl bg-muted transition-colors ${isDragging ? "ring-2 ring-blue-500/50" : ""}`}
             >
-              <input
-                ref={inputRef}
-                value={input}
-                placeholder="Request changes or ask a ..."
-                onChange={(e) => setInput(e.currentTarget.value)}
-                disabled={status === "streaming"}
-                className="flex-1 bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none"
-              />
-              {status === "streaming" ? (
+              {/* Image attachments preview */}
+              <ImageAttachmentsPreview images={images} onRemove={removeImage} />
+
+              <div className="flex items-center gap-2 px-4 py-2">
                 <Button
                   type="button"
+                  variant="ghost"
                   size="icon"
-                  onClick={stop}
-                  className="h-8 w-8 rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  onClick={openFilePicker}
+                  className="h-8 w-8 rounded-full text-muted-foreground hover:text-foreground"
                 >
-                  <Square className="h-3 w-3 fill-current" />
+                  <Paperclip className="h-4 w-4" />
                 </Button>
-              ) : (
-                <Button
-                  type="submit"
-                  size="icon"
-                  disabled={!input.trim()}
-                  className="h-8 w-8 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-30"
-                >
-                  <ArrowUp className="h-4 w-4" />
-                </Button>
-              )}
+                <input
+                  ref={inputRef}
+                  value={input}
+                  placeholder="Request changes or ask a ..."
+                  onChange={(e) => setInput(e.currentTarget.value)}
+                  onPaste={(e) => {
+                    const items = e.clipboardData?.items;
+                    if (!items) return;
+                    for (const item of items) {
+                      if (isValidImageType(item.type)) {
+                        const file = item.getAsFile();
+                        if (file) {
+                          e.preventDefault();
+                          addImage(file);
+                        }
+                      }
+                    }
+                  }}
+                  disabled={status === "streaming"}
+                  className="flex-1 bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none"
+                />
+                {status === "streaming" ? (
+                  <Button
+                    type="button"
+                    size="icon"
+                    onClick={stop}
+                    className="h-8 w-8 rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    <Square className="h-3 w-3 fill-current" />
+                  </Button>
+                ) : (
+                  <Button
+                    type="submit"
+                    size="icon"
+                    disabled={!input.trim() && images.length === 0}
+                    className="h-8 w-8 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-30"
+                  >
+                    <ArrowUp className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
             </form>
           </div>
         </div>

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -950,7 +950,11 @@ export function TaskDetailContent() {
               }}
               onDragLeave={(e) => {
                 e.preventDefault();
-                setIsDragging(false);
+                // Only set isDragging to false if we're leaving the form entirely
+                // (not just moving to a child element)
+                if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                  setIsDragging(false);
+                }
               }}
               onDrop={(e) => {
                 e.preventDefault();
@@ -988,7 +992,9 @@ export function TaskDetailContent() {
                         const file = item.getAsFile();
                         if (file) {
                           e.preventDefault();
-                          addImage(file);
+                          addImage(file).catch(() => {
+                            // Silently ignore paste errors - rare edge case
+                          });
                         }
                       }
                     }

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -293,6 +293,7 @@ export function TaskDetailContent() {
     getFileParts,
     fileInputRef,
     openFilePicker,
+    addImageAttachments,
   } = useImageAttachments();
   const { containerRef, isAtBottom, scrollToBottom } =
     useScrollToBottom<HTMLDivElement>();
@@ -913,6 +914,7 @@ export function TaskDetailContent() {
                 if (!hasContent) return;
 
                 const messageText = input;
+                const savedImages = images;
                 const files = getFileParts();
                 setInput("");
                 clearImages();
@@ -936,6 +938,7 @@ export function TaskDetailContent() {
                     setSandboxInfo(newSandbox);
                   } catch {
                     setInput(messageText);
+                    addImageAttachments(savedImages);
                     return;
                   } finally {
                     setIsCreatingSandbox(false);

--- a/apps/web/components/image-attachments-preview.tsx
+++ b/apps/web/components/image-attachments-preview.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { X } from "lucide-react";
+import type { ImageAttachment } from "@/lib/image-utils";
+import { cn } from "@/lib/utils";
+
+interface ImageAttachmentItemProps {
+  image: ImageAttachment;
+  onRemove: () => void;
+}
+
+function ImageAttachmentItem({ image, onRemove }: ImageAttachmentItemProps) {
+  return (
+    <div className="group relative flex-shrink-0">
+      {/* eslint-disable-next-line @next/next/no-img-element -- Data URLs not supported by next/image */}
+      <img
+        src={image.dataUrl}
+        alt={image.filename ?? "Attached image"}
+        className="h-16 w-16 rounded-lg object-cover"
+      />
+      <button
+        type="button"
+        onClick={onRemove}
+        className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-neutral-700 text-neutral-300 opacity-0 transition-opacity hover:bg-neutral-600 group-hover:opacity-100"
+        aria-label="Remove image"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+interface ImageAttachmentsPreviewProps {
+  images: ImageAttachment[];
+  onRemove: (id: string) => void;
+  className?: string;
+}
+
+export function ImageAttachmentsPreview({
+  images,
+  onRemove,
+  className,
+}: ImageAttachmentsPreviewProps) {
+  if (images.length === 0) return null;
+
+  return (
+    <div className={cn("flex gap-2 overflow-x-auto px-3 pb-2 pt-3", className)}>
+      {images.map((image) => (
+        <ImageAttachmentItem
+          key={image.id}
+          image={image}
+          onRemove={() => onRemove(image.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/task-input.tsx
+++ b/apps/web/components/task-input.tsx
@@ -140,7 +140,9 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
         const file = item.getAsFile();
         if (file) {
           e.preventDefault();
-          addImage(file);
+          addImage(file).catch(() => {
+            // Silently ignore paste errors - rare edge case
+          });
         }
       }
     }
@@ -153,7 +155,14 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
-    setIsDragging(false);
+    // Only set isDragging to false if we're leaving the container entirely
+    // (not just moving to a child element)
+    if (
+      containerRef.current &&
+      !containerRef.current.contains(e.relatedTarget as Node)
+    ) {
+      setIsDragging(false);
+    }
   };
 
   const handleDrop = (e: React.DragEvent) => {

--- a/apps/web/components/task-input.tsx
+++ b/apps/web/components/task-input.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import type { FileUIPart } from "ai";
 import { Plus, Mic, ArrowUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
+import { useImageAttachments } from "@/hooks/use-image-attachments";
 import { RepoSelectorCompact } from "./repo-selector-compact";
 import { BranchSelectorCompact } from "./branch-selector-compact";
+import { ImageAttachmentsPreview } from "./image-attachments-preview";
 
 interface TaskInputProps {
   onSubmit: (task: {
@@ -14,6 +18,7 @@ interface TaskInputProps {
     branch?: string;
     cloneUrl?: string;
     isNewBranch: boolean;
+    files?: FileUIPart[];
   }) => void;
   isLoading?: boolean;
 }
@@ -25,8 +30,20 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
   const [selectedRepo, setSelectedRepo] = useState("");
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
   const [isNewBranch, setIsNewBranch] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const {
+    images,
+    addImage,
+    addImages,
+    removeImage,
+    clearImages,
+    getFileParts,
+    fileInputRef,
+    openFilePicker,
+  } = useImageAttachments();
 
   // Handle click outside to collapse
   useEffect(() => {
@@ -76,7 +93,8 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
   }, [prompt]);
 
   const handleSubmit = () => {
-    if (!prompt.trim() || isLoading) return;
+    const hasContent = prompt.trim() || images.length > 0;
+    if (!hasContent || isLoading) return;
 
     onSubmit({
       prompt: prompt.trim(),
@@ -88,8 +106,10 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
           ? `https://github.com/${selectedOwner}/${selectedRepo}`
           : undefined,
       isNewBranch,
+      files: getFileParts(),
     });
     setPrompt("");
+    clearImages();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -111,22 +131,85 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
     setIsNewBranch(newBranch);
   };
 
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    for (const item of items) {
+      if (isValidImageType(item.type)) {
+        const file = item.getAsFile();
+        if (file) {
+          e.preventDefault();
+          addImage(file);
+        }
+      }
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      addImages(files);
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      addImages(files);
+    }
+    // Reset input so the same file can be selected again
+    e.target.value = "";
+  };
+
+  const hasContent = prompt.trim() || images.length > 0;
+
   return (
     <div
       ref={containerRef}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
       className={cn(
         "w-full max-w-2xl overflow-hidden rounded-xl border border-white/10 bg-neutral-800/60 transition-all duration-200",
         isFocused && "border-white/15 bg-neutral-800/80",
+        isDragging && "border-blue-500/50 bg-blue-500/5",
       )}
     >
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPT_IMAGE_TYPES}
+        multiple
+        onChange={handleFileChange}
+        className="hidden"
+      />
+
+      {/* Image attachments preview */}
+      <ImageAttachmentsPreview images={images} onRemove={removeImage} />
+
       {/* Input area */}
-      <div className="px-5 pb-3 pt-4">
+      <div className={cn("px-5 pb-3", images.length > 0 ? "pt-0" : "pt-4")}>
         <textarea
           ref={inputRef}
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           onFocus={() => setIsFocused(true)}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           placeholder="Ask a question with /plan"
           rows={1}
           className="w-full resize-none overflow-y-auto bg-transparent text-base text-foreground placeholder:text-neutral-500 focus:outline-none"
@@ -141,6 +224,7 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
         <div className="flex items-center">
           <button
             type="button"
+            onClick={openFilePicker}
             className="flex h-8 w-8 items-center justify-center rounded-md text-neutral-500 transition-colors hover:bg-white/5 hover:text-neutral-300"
           >
             <Plus className="h-4 w-4" />
@@ -174,10 +258,10 @@ export function TaskInput({ onSubmit, isLoading }: TaskInputProps) {
           <button
             type="button"
             onClick={handleSubmit}
-            disabled={!prompt.trim() || isLoading}
+            disabled={!hasContent || isLoading}
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
-              prompt.trim() && !isLoading
+              hasContent && !isLoading
                 ? "bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
                 : "bg-neutral-700 text-neutral-500",
             )}

--- a/apps/web/components/ui/switch.tsx
+++ b/apps/web/components/ui/switch.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SwitchPrimitive from "@radix-ui/react-switch"
+import * as React from "react";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Switch({
   className,
@@ -14,18 +14,18 @@ function Switch({
       data-slot="switch"
       className={cn(
         "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
         )}
       />
     </SwitchPrimitive.Root>
-  )
+  );
 }
 
-export { Switch }
+export { Switch };

--- a/apps/web/hooks/use-image-attachments.ts
+++ b/apps/web/hooks/use-image-attachments.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import type { FileUIPart } from "ai";
+import { nanoid } from "nanoid";
+import {
+  type ImageAttachment,
+  type ImageMediaType,
+  imageAttachmentToFilePart,
+  fileToDataUrl,
+  isValidImageType,
+} from "@/lib/image-utils";
+
+export function useImageAttachments() {
+  const [images, setImages] = useState<ImageAttachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const addImage = useCallback(async (file: File) => {
+    if (!isValidImageType(file.type)) return false;
+
+    const dataUrl = await fileToDataUrl(file);
+    const attachment: ImageAttachment = {
+      id: nanoid(),
+      dataUrl,
+      mediaType: file.type as ImageMediaType,
+      filename: file.name,
+    };
+    setImages((prev) => [...prev, attachment]);
+    return true;
+  }, []);
+
+  const addImages = useCallback(
+    async (files: FileList | File[]) => {
+      const fileArray = Array.from(files);
+      await Promise.all(fileArray.map(addImage));
+    },
+    [addImage],
+  );
+
+  const removeImage = useCallback((id: string) => {
+    setImages((prev) => prev.filter((img) => img.id !== id));
+  }, []);
+
+  const clearImages = useCallback(() => {
+    setImages([]);
+  }, []);
+
+  const getFileParts = useCallback((): FileUIPart[] | undefined => {
+    return images.length > 0
+      ? images.map(imageAttachmentToFilePart)
+      : undefined;
+  }, [images]);
+
+  const openFilePicker = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  return {
+    images,
+    addImage,
+    addImages,
+    removeImage,
+    clearImages,
+    getFileParts,
+    fileInputRef,
+    openFilePicker,
+    hasImages: images.length > 0,
+  };
+}

--- a/apps/web/hooks/use-image-attachments.ts
+++ b/apps/web/hooks/use-image-attachments.ts
@@ -55,6 +55,10 @@ export function useImageAttachments() {
     fileInputRef.current?.click();
   }, []);
 
+  const addImageAttachments = useCallback((attachments: ImageAttachment[]) => {
+    setImages((prev) => [...prev, ...attachments]);
+  }, []);
+
   return {
     images,
     addImage,
@@ -64,6 +68,7 @@ export function useImageAttachments() {
     getFileParts,
     fileInputRef,
     openFilePicker,
+    addImageAttachments,
     hasImages: images.length > 0,
   };
 }

--- a/apps/web/lib/image-utils.ts
+++ b/apps/web/lib/image-utils.ts
@@ -40,6 +40,9 @@ export function fileToDataUrl(file: File): Promise<string> {
     const reader = new FileReader();
     reader.addEventListener("load", () => resolve(reader.result as string));
     reader.addEventListener("error", () => reject(reader.error));
+    reader.addEventListener("abort", () =>
+      reject(new Error("File read aborted")),
+    );
     reader.readAsDataURL(file);
   });
 }

--- a/apps/web/lib/image-utils.ts
+++ b/apps/web/lib/image-utils.ts
@@ -1,0 +1,45 @@
+import type { FileUIPart } from "ai";
+
+export type ImageMediaType =
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif"
+  | "image/webp";
+
+export type ImageAttachment = {
+  id: string;
+  dataUrl: string;
+  mediaType: ImageMediaType;
+  filename?: string;
+};
+
+export const SUPPORTED_IMAGE_TYPES: ImageMediaType[] = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+];
+
+export const ACCEPT_IMAGE_TYPES = SUPPORTED_IMAGE_TYPES.join(",");
+
+export function isValidImageType(type: string): type is ImageMediaType {
+  return SUPPORTED_IMAGE_TYPES.includes(type as ImageMediaType);
+}
+
+export function imageAttachmentToFilePart(image: ImageAttachment): FileUIPart {
+  return {
+    type: "file",
+    filename: image.filename ?? `image-${image.id}.png`,
+    mediaType: image.mediaType,
+    url: image.dataUrl,
+  };
+}
+
+export function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => resolve(reader.result as string));
+    reader.addEventListener("error", () => reject(reader.error));
+    reader.readAsDataURL(file);
+  });
+}


### PR DESCRIPTION
Implement image file uploads with drag-and-drop, paste, and file picker support in both task creation and message input forms.

- Created `useImageAttachments` hook to manage image state, conversion to data URLs, and file parts
- Added `ImageAttachmentsPreview` component to display and remove attached images with hover controls
- Integrated image attachment utilities in `task-detail-content.tsx` with drag-over visual feedback and form submission support
- Updated `task-input.tsx` to support image attachments alongside text input with consistent drag-and-drop behavior
- Added paste event handling to accept images from clipboard in both components