### PR TITLE
Add file suggestion autocomplete for task input

### DIFF
--- a/apps/web/app/api/tasks/[id]/files/route.ts
+++ b/apps/web/app/api/tasks/[id]/files/route.ts
@@ -1,0 +1,141 @@
+import { connectVercelSandbox } from "@open-harness/sandbox";
+import { getTaskById } from "@/lib/db/tasks";
+import { getServerSession } from "@/lib/session/get-server-session";
+import type { NextRequest } from "next/server";
+
+export type FileSuggestion = {
+  value: string;
+  display: string;
+  isDirectory: boolean;
+};
+
+export type FilesResponse = {
+  files: FileSuggestion[];
+};
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Parse git ls-files output and extract files and directories
+ */
+function parseGitFiles(output: string): FileSuggestion[] {
+  const results: FileSuggestion[] = [];
+  const seenDirs = new Set<string>();
+
+  const files = output.trim().split("\n").filter(Boolean);
+
+  for (const file of files) {
+    // Add parent directories
+    const parts = file.split("/");
+    let dirPath = "";
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (!part) continue;
+      dirPath = dirPath ? `${dirPath}/${part}` : part;
+      if (!seenDirs.has(dirPath)) {
+        seenDirs.add(dirPath);
+        results.push({
+          value: `${dirPath}/`,
+          display: `${dirPath}/`,
+          isDirectory: true,
+        });
+      }
+    }
+
+    // Add the file
+    results.push({
+      value: file,
+      display: file,
+      isDirectory: false,
+    });
+  }
+
+  // Sort: directories first, then alphabetically
+  results.sort((a, b) => {
+    if (a.isDirectory && !b.isDirectory) return -1;
+    if (!a.isDirectory && b.isDirectory) return 1;
+    return a.display.localeCompare(b.display);
+  });
+
+  return results;
+}
+
+export async function GET(req: NextRequest, context: RouteContext) {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { id: taskId } = await context.params;
+  const sandboxId = req.nextUrl.searchParams.get("sandboxId");
+
+  if (!sandboxId) {
+    return Response.json(
+      { error: "sandboxId query parameter is required" },
+      { status: 400 },
+    );
+  }
+
+  // Verify task ownership
+  const task = await getTaskById(taskId);
+  if (!task) {
+    return Response.json({ error: "Task not found" }, { status: 404 });
+  }
+  if (task.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (task.sandboxId !== sandboxId) {
+    return Response.json(
+      { error: "Sandbox does not belong to this task" },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const sandbox = await connectVercelSandbox({ sandboxId });
+    const cwd = sandbox.workingDirectory;
+
+    // Run git commands in parallel to get both tracked and untracked files
+    const [trackedResult, untrackedResult] = await Promise.all([
+      sandbox.exec("git ls-files", cwd, 30000),
+      sandbox.exec("git ls-files --others --exclude-standard", cwd, 30000),
+    ]);
+
+    if (!trackedResult.success) {
+      console.error("Git ls-files failed:", trackedResult.stderr);
+      return Response.json(
+        { error: "Failed to list files. Ensure this is a git repository." },
+        { status: 400 },
+      );
+    }
+
+    // Combine tracked and untracked files
+    const trackedFiles = trackedResult.stdout.trim();
+    const untrackedFiles = untrackedResult.success
+      ? untrackedResult.stdout.trim()
+      : "";
+
+    const combinedOutput = [trackedFiles, untrackedFiles]
+      .filter(Boolean)
+      .join("\n");
+
+    const files = parseGitFiles(combinedOutput);
+
+    // Limit to 500 files for performance
+    const limitedFiles = files.slice(0, 500);
+
+    const response: FilesResponse = {
+      files: limitedFiles,
+    };
+
+    return Response.json(response);
+  } catch (error) {
+    console.error("Failed to list files:", error);
+    return Response.json(
+      { error: "Failed to connect to sandbox" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -17,6 +17,7 @@ import { useChat, type UseChatHelpers } from "@ai-sdk/react";
 import type { WebAgentUIMessage } from "@/app/types";
 import type { Task } from "@/lib/db/schema";
 import type { DiffResponse } from "@/app/api/tasks/[id]/diff/route";
+import type { FileSuggestion } from "@/app/api/tasks/[id]/files/route";
 
 export type SandboxInfo = {
   sandboxId: string;
@@ -27,6 +28,14 @@ export type SandboxInfo = {
 
 type DiffCacheState = {
   data: DiffResponse | null;
+  error: string | null;
+  isLoading: boolean;
+  /** The refreshKey value when this data was last fetched */
+  lastFetchedKey: number;
+};
+
+type FileCacheState = {
+  data: FileSuggestion[] | null;
   error: string | null;
   isLoading: boolean;
   /** The refreshKey value when this data was last fetched */
@@ -50,6 +59,14 @@ type TaskChatContextValue = {
   diffCache: DiffCacheState;
   /** Fetch diff data (uses cache if valid) */
   fetchDiff: (sandboxId: string) => Promise<void>;
+  /** Counter that increments when file list should be refreshed */
+  fileRefreshKey: number;
+  /** Trigger a file list refresh (invalidates cache) */
+  triggerFileRefresh: () => void;
+  /** Cached file list state */
+  fileCache: FileCacheState;
+  /** Fetch file list (uses cache if valid) */
+  fetchFiles: (sandboxId: string) => Promise<void>;
 };
 
 const TaskChatContext = createContext<TaskChatContextValue | undefined>(
@@ -177,6 +194,78 @@ export function TaskChatProvider({
     [task.id, diffRefreshKey],
   );
 
+  // File cache state (mirrors diff cache pattern)
+  const [fileRefreshKey, setFileRefreshKey] = useState(0);
+
+  const triggerFileRefresh = useCallback(() => {
+    setFileRefreshKey((prev) => prev + 1);
+  }, []);
+
+  const [fileCache, setFileCache] = useState<FileCacheState>({
+    data: null,
+    error: null,
+    isLoading: false,
+    lastFetchedKey: -1,
+  });
+
+  const fileFetchCounterRef = useRef(0);
+  const fileLastFetchedKeyRef = useRef<number>(-1);
+  const fileFetchingKeyRef = useRef<number | null>(null);
+
+  const fetchFiles = useCallback(
+    async (sandboxId: string) => {
+      if (
+        fileLastFetchedKeyRef.current === fileRefreshKey ||
+        fileFetchingKeyRef.current === fileRefreshKey
+      ) {
+        return;
+      }
+      fileFetchingKeyRef.current = fileRefreshKey;
+
+      const thisFetchId = ++fileFetchCounterRef.current;
+
+      setFileCache((prev) => ({
+        ...prev,
+        isLoading: true,
+        error: null,
+      }));
+
+      try {
+        const res = await fetch(
+          `/api/tasks/${task.id}/files?sandboxId=${sandboxId}`,
+        );
+
+        if (!res.ok) {
+          const errorData = (await res.json()) as { error?: string };
+          throw new Error(errorData.error ?? "Failed to fetch files");
+        }
+
+        const data = (await res.json()) as { files: FileSuggestion[] };
+
+        if (thisFetchId === fileFetchCounterRef.current) {
+          fileLastFetchedKeyRef.current = fileRefreshKey;
+          setFileCache({
+            data: data.files,
+            error: null,
+            isLoading: false,
+            lastFetchedKey: fileRefreshKey,
+          });
+        }
+      } catch (err) {
+        if (thisFetchId === fileFetchCounterRef.current) {
+          fileLastFetchedKeyRef.current = fileRefreshKey;
+          setFileCache((prev) => ({
+            ...prev,
+            error: err instanceof Error ? err.message : "Failed to fetch files",
+            isLoading: false,
+            lastFetchedKey: fileRefreshKey,
+          }));
+        }
+      }
+    },
+    [task.id, fileRefreshKey],
+  );
+
   const archiveTask = useCallback(async () => {
     const res = await fetch(`/api/tasks/${task.id}`, {
       method: "PATCH",
@@ -212,6 +301,10 @@ export function TaskChatProvider({
         triggerDiffRefresh,
         diffCache,
         fetchDiff,
+        fileRefreshKey,
+        triggerFileRefresh,
+        fileCache,
+        fetchFiles,
       }}
     >
       {children}

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -217,9 +217,10 @@ export function TaskDetailContent() {
     // Move cursor to after the inserted value + space
     const newCursorPos = mentionStart + value.length + 2; // @ + value + space
     setCursorPosition(newCursorPos);
-    // Focus input and set cursor position
+    // Focus input and set cursor position after React renders
     setTimeout(() => {
-      if (inputRef.current) {
+      // Only set cursor if input hasn't changed (user didn't type in between)
+      if (inputRef.current && inputRef.current.value === newInput) {
         inputRef.current.focus();
         inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
       }

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -32,6 +32,8 @@ import type { TaskToolUIPart } from "@open-harness/agent";
 
 import { useTaskChatContext, type SandboxInfo } from "./task-context";
 import { DiffViewer } from "./diff-viewer";
+import { useFileSuggestions } from "@/hooks/use-file-suggestions";
+import { FileSuggestionsDropdown } from "@/components/file-suggestions-dropdown";
 
 const customComponents = {
   pre: ({ children, ...props }: ComponentProps<"pre">) => {
@@ -176,6 +178,7 @@ export function TaskDetailContent() {
   const [prDialogOpen, setPrDialogOpen] = useState(false);
   const [repoDialogOpen, setRepoDialogOpen] = useState(false);
   const [showDiffPanel, setShowDiffPanel] = useState(false);
+  const [cursorPosition, setCursorPosition] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const { containerRef, isAtBottom, scrollToBottom } =
     useScrollToBottom<HTMLDivElement>();
@@ -189,6 +192,9 @@ export function TaskDetailContent() {
     hadInitialMessages,
     diffRefreshKey,
     triggerDiffRefresh,
+    fileCache,
+    fetchFiles,
+    triggerFileRefresh,
   } = useTaskChatContext();
   const {
     messages,
@@ -198,6 +204,40 @@ export function TaskDetailContent() {
     addToolApprovalResponse,
     stop,
   } = chat;
+
+  const handleFileSelect = (
+    value: string,
+    mentionStart: number,
+    cursorPos: number,
+  ) => {
+    const before = input.slice(0, mentionStart);
+    const after = input.slice(cursorPos);
+    const newInput = `${before}@${value} ${after}`;
+    setInput(newInput);
+    // Move cursor to after the inserted value + space
+    const newCursorPos = mentionStart + value.length + 2; // @ + value + space
+    setCursorPosition(newCursorPos);
+    // Focus input and set cursor position
+    setTimeout(() => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+        inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
+      }
+    }, 0);
+  };
+
+  const {
+    showSuggestions,
+    suggestions,
+    selectedIndex,
+    handleKeyDown: handleSuggestionsKeyDown,
+    mentionInfo,
+  } = useFileSuggestions({
+    inputValue: input,
+    cursorPosition,
+    files: fileCache.data,
+    onSelect: handleFileSelect,
+  });
 
   const handleKillSandbox = async () => {
     if (!sandboxInfo) return;
@@ -327,6 +367,7 @@ export function TaskDetailContent() {
       }
       // Always invalidate cache when files change
       triggerDiffRefresh();
+      triggerFileRefresh();
     }
   }, [
     currentToolStates,
@@ -334,7 +375,15 @@ export function TaskDetailContent() {
     showDiffPanel,
     sandboxInfo,
     triggerDiffRefresh,
+    triggerFileRefresh,
   ]);
+
+  // Fetch files when sandbox becomes available
+  useEffect(() => {
+    if (sandboxInfo && !fileCache.data && !fileCache.isLoading) {
+      fetchFiles(sandboxInfo.sandboxId);
+    }
+  }, [sandboxInfo, fileCache.data, fileCache.isLoading, fetchFiles]);
 
   if (error) {
     return (
@@ -640,13 +689,49 @@ export function TaskDetailContent() {
 
                 sendMessage({ text: messageText });
               }}
-              className="flex items-center gap-2 rounded-full bg-muted px-4 py-2"
+              className="relative flex items-center gap-2 rounded-full bg-muted px-4 py-2"
             >
+              {showSuggestions && (
+                <FileSuggestionsDropdown
+                  suggestions={suggestions}
+                  selectedIndex={selectedIndex}
+                  onSelect={(suggestion) => {
+                    if (mentionInfo) {
+                      handleFileSelect(
+                        suggestion.value,
+                        mentionInfo.mentionStart,
+                        cursorPosition,
+                      );
+                    }
+                  }}
+                  isLoading={fileCache.isLoading}
+                />
+              )}
               <input
                 ref={inputRef}
                 value={input}
                 placeholder="Request changes or ask a ..."
-                onChange={(e) => setInput(e.currentTarget.value)}
+                onChange={(e) => {
+                  setInput(e.currentTarget.value);
+                  setCursorPosition(e.currentTarget.selectionStart ?? 0);
+                }}
+                onKeyDown={(e) => {
+                  // Let suggestions handle keyboard events first
+                  if (handleSuggestionsKeyDown(e)) {
+                    return;
+                  }
+                  // Handle form submission
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    e.currentTarget.form?.requestSubmit();
+                  }
+                }}
+                onKeyUp={(e) => {
+                  setCursorPosition(e.currentTarget.selectionStart ?? 0);
+                }}
+                onClick={(e) => {
+                  setCursorPosition(e.currentTarget.selectionStart ?? 0);
+                }}
                 disabled={status === "streaming"}
                 className="flex-1 bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none"
               />

--- a/apps/web/components/file-suggestions-dropdown.tsx
+++ b/apps/web/components/file-suggestions-dropdown.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { FileIcon, FolderIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FileSuggestion } from "@/app/api/tasks/[id]/files/route";
+
+interface FileSuggestionsDropdownProps {
+  suggestions: FileSuggestion[];
+  selectedIndex: number;
+  onSelect: (suggestion: FileSuggestion) => void;
+  isLoading?: boolean;
+}
+
+const MAX_VISIBLE_ITEMS = 10;
+
+export function FileSuggestionsDropdown({
+  suggestions,
+  selectedIndex,
+  onSelect,
+  isLoading,
+}: FileSuggestionsDropdownProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (selectedRef.current && listRef.current) {
+      const list = listRef.current;
+      const item = selectedRef.current;
+      const listRect = list.getBoundingClientRect();
+      const itemRect = item.getBoundingClientRect();
+
+      if (itemRect.top < listRect.top) {
+        item.scrollIntoView({ block: "start" });
+      } else if (itemRect.bottom > listRect.bottom) {
+        item.scrollIntoView({ block: "end" });
+      }
+    }
+  }, [selectedIndex]);
+
+  if (isLoading) {
+    return (
+      <div className="absolute bottom-full left-0 right-0 mb-2 rounded-md border bg-popover p-2 text-sm text-muted-foreground shadow-md">
+        Loading files...
+      </div>
+    );
+  }
+
+  if (suggestions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-md border bg-popover shadow-md">
+      <div
+        ref={listRef}
+        className="max-h-[280px] overflow-y-auto py-1"
+        style={{ maxHeight: `${MAX_VISIBLE_ITEMS * 28}px` }}
+      >
+        {suggestions.map((suggestion, index) => (
+          <button
+            key={suggestion.value}
+            ref={index === selectedIndex ? selectedRef : null}
+            type="button"
+            onClick={() => onSelect(suggestion)}
+            className={cn(
+              "flex w-full items-center gap-2 px-3 py-1 text-left text-sm",
+              index === selectedIndex
+                ? "bg-accent text-accent-foreground"
+                : "hover:bg-muted",
+            )}
+          >
+            {suggestion.isDirectory ? (
+              <FolderIcon className="h-4 w-4 shrink-0 text-blue-500" />
+            ) : (
+              <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            )}
+            <span className="truncate">{suggestion.display}</span>
+          </button>
+        ))}
+      </div>
+      <div className="border-t bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground">
+        <kbd className="rounded bg-muted px-1">Tab</kbd> or{" "}
+        <kbd className="rounded bg-muted px-1">Enter</kbd> to select,{" "}
+        <kbd className="rounded bg-muted px-1">Esc</kbd> to dismiss
+      </div>
+    </div>
+  );
+}

--- a/apps/web/hooks/use-file-suggestions.ts
+++ b/apps/web/hooks/use-file-suggestions.ts
@@ -1,0 +1,112 @@
+import { useState, useMemo, useCallback, useEffect } from "react";
+import type { FileSuggestion } from "@/app/api/tasks/[id]/files/route";
+import { extractMention, filterFileSuggestions } from "@/lib/file-suggestions";
+
+interface UseFileSuggestionsOptions {
+  inputValue: string;
+  cursorPosition: number;
+  files: FileSuggestion[] | null;
+  onSelect: (value: string, mentionStart: number, cursorPos: number) => void;
+}
+
+interface UseFileSuggestionsResult {
+  showSuggestions: boolean;
+  suggestions: FileSuggestion[];
+  selectedIndex: number;
+  handleKeyDown: (e: React.KeyboardEvent) => boolean;
+  mentionInfo: { mentionStart: number; partialPath: string } | null;
+  closeSuggestions: () => void;
+}
+
+export function useFileSuggestions({
+  inputValue,
+  cursorPosition,
+  files,
+  onSelect,
+}: UseFileSuggestionsOptions): UseFileSuggestionsResult {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+
+  // Extract mention info from current input/cursor
+  const mentionInfo = useMemo(() => {
+    if (dismissed) return null;
+    return extractMention(inputValue, cursorPosition);
+  }, [inputValue, cursorPosition, dismissed]);
+
+  // Filter suggestions based on partial path
+  const suggestions = useMemo(() => {
+    if (!mentionInfo || !files) return [];
+    return filterFileSuggestions(files, mentionInfo.partialPath);
+  }, [mentionInfo, files]);
+
+  // Reset selected index when suggestions change
+  const showSuggestions = mentionInfo !== null && suggestions.length > 0;
+
+  // Reset state when mention changes
+  const partialPath = mentionInfo?.partialPath;
+  useEffect(() => {
+    setSelectedIndex(0);
+    setDismissed(false);
+  }, [partialPath]);
+
+  const closeSuggestions = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (!showSuggestions) return false;
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            prev < suggestions.length - 1 ? prev + 1 : prev,
+          );
+          return true;
+
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+          return true;
+
+        case "Tab":
+        case "Enter": {
+          const selected = suggestions[selectedIndex];
+          if (selected && mentionInfo) {
+            e.preventDefault();
+            onSelect(selected.value, mentionInfo.mentionStart, cursorPosition);
+            setDismissed(true);
+            return true;
+          }
+          return false;
+        }
+
+        case "Escape":
+          e.preventDefault();
+          setDismissed(true);
+          return true;
+
+        default:
+          return false;
+      }
+    },
+    [
+      showSuggestions,
+      suggestions,
+      selectedIndex,
+      mentionInfo,
+      cursorPosition,
+      onSelect,
+    ],
+  );
+
+  return {
+    showSuggestions,
+    suggestions,
+    selectedIndex,
+    handleKeyDown,
+    mentionInfo,
+    closeSuggestions,
+  };
+}

--- a/apps/web/lib/file-suggestions.ts
+++ b/apps/web/lib/file-suggestions.ts
@@ -12,6 +12,7 @@ export function extractMention(
   let atIndex = -1;
   for (let i = cursorPosition - 1; i >= 0; i--) {
     const char = text[i];
+    if (char === undefined) break;
     // Stop at whitespace - no mention
     if (char === " " || char === "\t" || char === "\n") {
       break;

--- a/apps/web/lib/file-suggestions.ts
+++ b/apps/web/lib/file-suggestions.ts
@@ -1,0 +1,68 @@
+import type { FileSuggestion } from "@/app/api/tasks/[id]/files/route";
+
+/**
+ * Extract the @ mention from input text at the cursor position
+ * Returns the partial path after @ or null if not in a mention
+ */
+export function extractMention(
+  text: string,
+  cursorPosition: number,
+): { mentionStart: number; partialPath: string } | null {
+  // Find the @ symbol before cursor
+  let atIndex = -1;
+  for (let i = cursorPosition - 1; i >= 0; i--) {
+    const char = text[i];
+    // Stop at whitespace - no mention
+    if (char === " " || char === "\t" || char === "\n") {
+      break;
+    }
+    if (char === "@") {
+      atIndex = i;
+      break;
+    }
+  }
+
+  if (atIndex === -1) {
+    return null;
+  }
+
+  const partialPath = text.slice(atIndex + 1, cursorPosition);
+  return { mentionStart: atIndex, partialPath };
+}
+
+/**
+ * Filter file suggestions based on a partial path
+ * Returns max results for performance
+ */
+export function filterFileSuggestions(
+  files: FileSuggestion[],
+  partialPath: string,
+  maxResults: number = 50,
+): FileSuggestion[] {
+  const query = partialPath.toLowerCase();
+
+  if (!query) {
+    // Show top-level items when no query
+    const results: FileSuggestion[] = [];
+    for (const f of files) {
+      if (
+        !f.value.includes("/") ||
+        (f.isDirectory && !f.value.slice(0, -1).includes("/"))
+      ) {
+        results.push(f);
+        if (results.length >= maxResults) break;
+      }
+    }
+    return results;
+  }
+
+  // Filter files that match the query
+  const results: FileSuggestion[] = [];
+  for (const f of files) {
+    if (f.value.toLowerCase().includes(query)) {
+      results.push(f);
+      if (results.length >= maxResults) break;
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
Implements file autocomplete in task chat input using @ mentions, enabling users to reference repository files.

- Add `/api/tasks/[id]/files` endpoint that lists tracked and untracked git files with directory support
- Add file suggestion hook and dropdown component for @ mention autocomplete with keyboard navigation (arrow keys, Tab, Enter, Esc)
- Integrate file suggestions into task chat input with cursor position tracking and mention extraction
- Cache file list in task context and refresh when sandbox files change