### PR TITLE
Add VERCEL_OIDC_TOKEN setup to worktree initialization

### DIFF
--- a/.worktree-setup
+++ b/.worktree-setup
@@ -3,3 +3,7 @@
 bun install
 cp "$GWT_MAIN_PATH/apps/cli/.env" apps/cli/.env
 cp "$GWT_MAIN_PATH/apps/web/.env" apps/web/.env
+
+vc env pull "$GWT_MAIN_PATH/.env.local" --cwd "$GWT_MAIN_PATH"
+grep "^VERCEL_OIDC_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/cli/.env
+grep "^VERCEL_OIDC_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/web/.env


### PR DESCRIPTION
Updates the worktree setup script to automatically configure Vercel OIDC token authentication.

- Pulls environment variables from the main worktree using `vc env pull`
- Extracts and appends `VERCEL_OIDC_TOKEN` to both CLI and web app `.env` files
- Enables seamless authentication setup for new worktree instances