### PR TITLE
Add Vercel env token configuration to worktree setup

### DIFF
--- a/.worktree-setup
+++ b/.worktree-setup
@@ -3,3 +3,7 @@
 bun install
 cp "$GWT_MAIN_PATH/apps/cli/.env" apps/cli/.env
 cp "$GWT_MAIN_PATH/apps/web/.env" apps/web/.env
+
+vc env pull "$GWT_MAIN_PATH/.env.local" --cwd "$GWT_MAIN_PATH"
+grep "^VERCEL_OIDC_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/cli/.env
+grep "^VERCEL_OIDC_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/web/.env

--- a/.worktree-setup
+++ b/.worktree-setup
@@ -7,3 +7,4 @@ cp "$GWT_MAIN_PATH/apps/web/.env" apps/web/.env
 vc env pull "$GWT_MAIN_PATH/.env.local" --cwd "$GWT_MAIN_PATH"
 grep "^VERCEL_OIDC_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/cli/.env
 grep "^VERCEL_OIDC_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/web/.env
+grep "^BLOB_READ_WRITE_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/web/.env


### PR DESCRIPTION
Updates the worktree setup script to automatically pull and configure required environment tokens.

- Pulls Vercel environment variables from main path using `vc env pull`
- Extracts VERCEL_OIDC_TOKEN and appends it to both cli and web app environments
- Extracts BLOB_READ_WRITE_TOKEN and appends it to web app environment
- Ensures all necessary credentials are available when setting up git worktrees