### PR TITLE
Auto-save sandbox state before timeout deadline

### DIFF
--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -151,7 +151,8 @@ function SandboxStatus({
     hasAutoSavedRef.current = false;
   }, [sandboxInfo?.sandboxId]);
 
-  // Auto-save when timeout reached (buffer in vercel.ts gives 30s extra)
+  // Auto-save when timeout reached
+  // The TIMEOUT_BUFFER_MS in vercel.ts gives 30s extra sandbox life for this to complete
   useEffect(() => {
     if (
       timeRemaining !== null &&

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -127,6 +127,7 @@ function SandboxStatus({
 }) {
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
   const [showStopConfirm, setShowStopConfirm] = useState(false);
+  const hasAutoSavedRef = useRef(false);
 
   useEffect(() => {
     if (!sandboxInfo) {
@@ -144,6 +145,24 @@ function SandboxStatus({
     const interval = setInterval(updateTime, 1000);
     return () => clearInterval(interval);
   }, [sandboxInfo]);
+
+  // Reset auto-save flag when sandbox changes
+  useEffect(() => {
+    hasAutoSavedRef.current = false;
+  }, [sandboxInfo?.sandboxId]);
+
+  // Auto-save when timeout reached (buffer in vercel.ts gives 30s extra)
+  useEffect(() => {
+    if (
+      timeRemaining !== null &&
+      timeRemaining <= 0 &&
+      !hasAutoSavedRef.current &&
+      !isSavingSnapshot
+    ) {
+      hasAutoSavedRef.current = true;
+      onSaveAndKill();
+    }
+  }, [timeRemaining, isSavingSnapshot, onSaveAndKill]);
 
   if (isCreating || isRestoring) {
     return (

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -144,8 +144,9 @@ export class VercelSandbox implements Sandbox {
   }
 
   /**
-   * Schedule a timer to proactively call stop() before the SDK timeout.
-   * This ensures beforeStop hook has time to run.
+   * Schedule a timer to call onTimeout hook before the SDK timeout.
+   * Note: This does NOT call stop() - the client is responsible for stopping.
+   * The TIMEOUT_BUFFER_MS gives the client time to save and stop after their countdown ends.
    */
   private scheduleProactiveStop(): void {
     if (this._expiresAt === undefined) return;
@@ -157,7 +158,7 @@ export class VercelSandbox implements Sandbox {
       try {
         if (this.isStopped) return;
 
-        // Call onTimeout hook first
+        // Call onTimeout hook if configured (for CLI usage)
         if (this.hooks?.onTimeout) {
           try {
             await this.hooks.onTimeout(this);
@@ -169,11 +170,11 @@ export class VercelSandbox implements Sandbox {
           }
         }
 
-        await this.stop();
+        // Don't call stop() here - let the client handle it.
+        // The SDK timeout (with TIMEOUT_BUFFER_MS) is the safety net.
       } catch (error) {
-        // Sandbox may already be stopped by SDK
         console.warn(
-          "[VercelSandbox] Proactive stop failed (sandbox may already be stopped):",
+          "[VercelSandbox] onTimeout handler failed:",
           error instanceof Error ? error.message : error,
         );
       }


### PR DESCRIPTION
Implements auto-save functionality when sandbox countdown reaches zero to prevent data loss.

- Add `hasAutoSavedRef` to track whether auto-save has already executed for current sandbox
- Trigger `onSaveAndKill()` when `timeRemaining` hits zero, ensuring save completes within the 30s `TIMEOUT_BUFFER_MS` safety margin
- Update `scheduleProactiveStop()` to only call the `onTimeout` hook instead of directly stopping the sandbox, allowing the client to control the stop sequence
- Clarify in comments that the client is responsible for saving and stopping, with the SDK timeout as a safety net