### PR TITLE
Add sandbox reconnection on page refresh with metadata tracking

### DIFF
--- a/apps/web/app/api/sandbox/reconnect/route.ts
+++ b/apps/web/app/api/sandbox/reconnect/route.ts
@@ -1,0 +1,98 @@
+import { Sandbox as VercelSandboxSDK } from "@vercel/sandbox";
+import { getServerSession } from "@/lib/session/get-server-session";
+import { getTaskById, updateTask } from "@/lib/db/tasks";
+
+export type ReconnectStatus =
+  | "connected"
+  | "expired"
+  | "not_found"
+  | "no_sandbox";
+
+export type ReconnectResponse =
+  | {
+      status: "connected";
+      sandboxId: string;
+      createdAt: number;
+      timeout: number;
+      remainingTimeout: number;
+    }
+  | {
+      status: "expired" | "not_found" | "no_sandbox";
+      hasSnapshot: boolean;
+    };
+
+export async function GET(req: Request): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const taskId = url.searchParams.get("taskId");
+
+  if (!taskId) {
+    return Response.json({ error: "Missing taskId" }, { status: 400 });
+  }
+
+  const task = await getTaskById(taskId);
+  if (!task) {
+    return Response.json({ error: "Task not found" }, { status: 404 });
+  }
+  if (task.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // No sandbox to reconnect to
+  if (!task.sandboxId || !task.sandboxCreatedAt || !task.sandboxTimeout) {
+    return Response.json({
+      status: "no_sandbox",
+      hasSnapshot: !!task.snapshotUrl,
+    } satisfies ReconnectResponse);
+  }
+
+  // Check if sandbox might still be valid (with 10s buffer)
+  const expiresAt = task.sandboxCreatedAt.getTime() + task.sandboxTimeout;
+  const now = Date.now();
+  const remainingTimeout = expiresAt - now;
+
+  if (remainingTimeout < 10_000) {
+    // Clear stale sandbox metadata
+    await updateTask(taskId, {
+      sandboxId: null,
+      sandboxCreatedAt: null,
+      sandboxTimeout: null,
+    });
+
+    return Response.json({
+      status: "expired",
+      hasSnapshot: !!task.snapshotUrl,
+    } satisfies ReconnectResponse);
+  }
+
+  // Attempt to reconnect
+  try {
+    await VercelSandboxSDK.get({ sandboxId: task.sandboxId });
+
+    // Success - sandbox exists and is accessible
+    return Response.json({
+      status: "connected",
+      sandboxId: task.sandboxId,
+      createdAt: task.sandboxCreatedAt.getTime(),
+      timeout: task.sandboxTimeout,
+      remainingTimeout,
+    } satisfies ReconnectResponse);
+  } catch {
+    // Sandbox no longer exists (was stopped or timed out on Vercel side)
+    // Clear sandbox info from task
+    await updateTask(taskId, {
+      sandboxId: null,
+      sandboxCreatedAt: null,
+      sandboxTimeout: null,
+    });
+
+    return Response.json({
+      status: "not_found",
+      hasSnapshot: !!task.snapshotUrl,
+    } satisfies ReconnectResponse);
+  }
+}

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -41,8 +41,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  let taskSandboxId = providedSandboxId;
-
+  // Validate task ownership and sandbox association
   if (taskId) {
     const task = await getTaskById(taskId);
     if (!task) {
@@ -51,15 +50,8 @@ export async function POST(req: Request) {
     if (task.userId !== session.user.id) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }
-    if (task.sandboxId) {
-      if (providedSandboxId && task.sandboxId !== providedSandboxId) {
-        return Response.json(
-          { error: "Sandbox does not belong to this task" },
-          { status: 403 },
-        );
-      }
-      taskSandboxId = task.sandboxId;
-    } else if (providedSandboxId) {
+    // Validate provided sandboxId matches task's sandbox (if any)
+    if (providedSandboxId && task.sandboxId !== providedSandboxId) {
       return Response.json(
         { error: "Sandbox does not belong to this task" },
         { status: 403 },
@@ -101,10 +93,15 @@ export async function POST(req: Request) {
 
   const sandbox = await connectVercelSandbox(sandboxOptions);
 
-  // Update task with sandboxId if this is a new sandbox
+  // Update task with sandbox metadata
   // This handles both first-time creation and sandbox recreation after expiry/restore
-  if (taskId && sandbox.id !== taskSandboxId) {
-    await updateTask(taskId, { sandboxId: sandbox.id });
+  const sandboxCreatedAt = new Date();
+  if (taskId) {
+    await updateTask(taskId, {
+      sandboxId: sandbox.id,
+      sandboxCreatedAt,
+      sandboxTimeout: DEFAULT_TIMEOUT,
+    });
   }
 
   return Response.json({
@@ -162,8 +159,12 @@ export async function DELETE(req: Request) {
   const sandbox = await connectVercelSandbox({ sandboxId });
   await sandbox.stop();
 
-  // Clear sandboxId from task so future sandbox creation doesn't fail validation
-  await updateTask(taskId, { sandboxId: null });
+  // Clear sandbox metadata from task so future sandbox creation doesn't fail validation
+  await updateTask(taskId, {
+    sandboxId: null,
+    sandboxCreatedAt: null,
+    sandboxTimeout: null,
+  });
 
   return Response.json({ success: true });
 }

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -145,6 +145,13 @@ export function TaskChatProvider({
       const response = await fetch(
         `/api/sandbox/reconnect?taskId=${task.id}`,
       );
+
+      if (!response.ok) {
+        console.error("Reconnection request failed:", response.status);
+        setReconnectionStatus("failed");
+        return;
+      }
+
       const data = (await response.json()) as ReconnectResponse;
 
       if (data.status === "connected") {
@@ -156,9 +163,15 @@ export function TaskChatProvider({
         });
         setReconnectionStatus("connected");
       } else if (data.status === "no_sandbox") {
+        // Clear stale sandboxId from local state
+        sandboxIdRef.current = null;
+        setTask((prev) => ({ ...prev, sandboxId: null }));
         setReconnectionStatus("no_sandbox");
       } else {
-        // expired or not_found
+        // expired or not_found - server has already cleared sandbox metadata
+        // Clear stale sandboxId from local state to prevent 403 errors on next sandbox creation
+        sandboxIdRef.current = null;
+        setTask((prev) => ({ ...prev, sandboxId: null }));
         setReconnectionStatus("failed");
       }
     } catch (error) {

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -18,6 +18,7 @@ import type { WebAgentUIMessage } from "@/app/types";
 import type { Task } from "@/lib/db/schema";
 import type { DiffResponse } from "@/app/api/tasks/[id]/diff/route";
 import type { FileSuggestion } from "@/app/api/tasks/[id]/files/route";
+import type { ReconnectResponse } from "@/app/api/sandbox/reconnect/route";
 
 export type SandboxInfo = {
   sandboxId: string;
@@ -25,6 +26,13 @@ export type SandboxInfo = {
   timeout: number;
   currentBranch?: string;
 };
+
+export type ReconnectionStatus =
+  | "idle"
+  | "checking"
+  | "connected"
+  | "failed"
+  | "no_sandbox";
 
 type DiffCacheState = {
   data: DiffResponse | null;
@@ -69,6 +77,10 @@ type TaskChatContextValue = {
   fetchFiles: (sandboxId: string) => Promise<void>;
   /** Update task snapshot info after saving */
   updateTaskSnapshot: (snapshotUrl: string, snapshotCreatedAt: Date) => void;
+  /** Current status of sandbox reconnection attempt */
+  reconnectionStatus: ReconnectionStatus;
+  /** Attempt to reconnect to an existing sandbox */
+  attemptReconnection: () => Promise<void>;
 };
 
 const TaskChatContext = createContext<TaskChatContextValue | undefined>(
@@ -122,6 +134,38 @@ export function TaskChatProvider({
     // Keep task.sandboxId in sync so it doesn't become stale
     setTask((prev) => ({ ...prev, sandboxId: null }));
   }, []);
+
+  const [reconnectionStatus, setReconnectionStatus] =
+    useState<ReconnectionStatus>("idle");
+
+  const attemptReconnection = useCallback(async () => {
+    setReconnectionStatus("checking");
+
+    try {
+      const response = await fetch(
+        `/api/sandbox/reconnect?taskId=${task.id}`,
+      );
+      const data = (await response.json()) as ReconnectResponse;
+
+      if (data.status === "connected") {
+        sandboxIdRef.current = data.sandboxId;
+        setSandboxInfoState({
+          sandboxId: data.sandboxId,
+          createdAt: data.createdAt,
+          timeout: data.timeout,
+        });
+        setReconnectionStatus("connected");
+      } else if (data.status === "no_sandbox") {
+        setReconnectionStatus("no_sandbox");
+      } else {
+        // expired or not_found
+        setReconnectionStatus("failed");
+      }
+    } catch (error) {
+      console.error("Failed to reconnect to sandbox:", error);
+      setReconnectionStatus("failed");
+    }
+  }, [task.id]);
 
   const updateTaskSnapshot = useCallback(
     (snapshotUrl: string, snapshotCreatedAt: Date) => {
@@ -319,6 +363,8 @@ export function TaskChatProvider({
         fileCache,
         fetchFiles,
         updateTaskSnapshot,
+        reconnectionStatus,
+        attemptReconnection,
       }}
     >
       {children}

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -192,12 +192,21 @@ function SandboxStatus({
     );
   }
 
-  // No sandbox was ever created for this task
+  // No sandbox was ever created for this task (or it was cleared)
   if (reconnectionStatus === "no_sandbox") {
     return (
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <span className="h-2 w-2 rounded-full bg-gray-400" />
         <span>No active sandbox</span>
+        {hasSnapshot && (
+          <button
+            type="button"
+            onClick={onRestore}
+            className="flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-primary hover:bg-primary/20"
+          >
+            <span>Restore snapshot</span>
+          </button>
+        )}
       </div>
     );
   }

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -36,7 +36,11 @@ import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
 import type { WebAgentUIToolPart, WebAgentUIMessagePart } from "@/app/types";
 import type { TaskToolUIPart } from "@open-harness/agent";
 
-import { useTaskChatContext, type SandboxInfo } from "./task-context";
+import {
+  useTaskChatContext,
+  type SandboxInfo,
+  type ReconnectionStatus,
+} from "./task-context";
 import { DiffViewer } from "./diff-viewer";
 import { useFileSuggestions } from "@/hooks/use-file-suggestions";
 import { FileSuggestionsDropdown } from "@/components/file-suggestions-dropdown";
@@ -107,6 +111,8 @@ function formatTimeRemaining(ms: number): string {
 function SandboxStatus({
   sandboxInfo,
   isCreating,
+  isReconnecting,
+  reconnectionStatus,
   isSavingSnapshot,
   isRestoring,
   hasSnapshot,
@@ -117,6 +123,8 @@ function SandboxStatus({
 }: {
   sandboxInfo: SandboxInfo | null;
   isCreating: boolean;
+  isReconnecting: boolean;
+  reconnectionStatus: ReconnectionStatus;
   isSavingSnapshot: boolean;
   isRestoring: boolean;
   hasSnapshot: boolean;
@@ -152,6 +160,44 @@ function SandboxStatus({
         <span>
           {isRestoring ? "Restoring snapshot..." : "Creating sandbox..."}
         </span>
+      </div>
+    );
+  }
+
+  if (isReconnecting) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
+        <span>Reconnecting to sandbox...</span>
+      </div>
+    );
+  }
+
+  // Reconnection failed - show appropriate state
+  if (reconnectionStatus === "failed") {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="h-2 w-2 rounded-full bg-amber-500" />
+        <span>Sandbox expired</span>
+        {hasSnapshot && (
+          <button
+            type="button"
+            onClick={onRestore}
+            className="flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-primary hover:bg-primary/20"
+          >
+            <span>Restore snapshot</span>
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // No sandbox was ever created for this task
+  if (reconnectionStatus === "no_sandbox") {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="h-2 w-2 rounded-full bg-gray-400" />
+        <span>No active sandbox</span>
       </div>
     );
   }
@@ -314,6 +360,8 @@ export function TaskDetailContent() {
     fetchFiles,
     triggerFileRefresh,
     updateTaskSnapshot,
+    reconnectionStatus,
+    attemptReconnection,
   } = useTaskChatContext();
   const {
     messages,
@@ -515,6 +563,32 @@ export function TaskDetailContent() {
     }
   }, [status]);
 
+  // Attempt to reconnect to existing sandbox on page refresh
+  useEffect(() => {
+    // Only attempt reconnection if:
+    // 1. We have initial messages (returning to an existing conversation)
+    // 2. Task has a sandboxId (sandbox was created before)
+    // 3. No current sandboxInfo (haven't reconnected yet)
+    // 4. Not already creating a sandbox
+    // 5. Reconnection status is idle (haven't tried yet)
+    if (
+      hadInitialMessages &&
+      task.sandboxId &&
+      !sandboxInfo &&
+      !isCreatingSandbox &&
+      reconnectionStatus === "idle"
+    ) {
+      attemptReconnection();
+    }
+  }, [
+    hadInitialMessages,
+    task.sandboxId,
+    sandboxInfo,
+    isCreatingSandbox,
+    reconnectionStatus,
+    attemptReconnection,
+  ]);
+
   // Auto-send initial message when task loads and no messages exist
   // Use hadInitialMessages to prevent race condition on remount
   const hasSentInitialMessage = useRef(hadInitialMessages);
@@ -561,6 +635,7 @@ export function TaskDetailContent() {
     task.cloneUrl,
     task.branch,
     task.isNewBranch,
+    task.prNumber,
     task.sandboxId,
     task.title,
   ]);
@@ -933,6 +1008,8 @@ export function TaskDetailContent() {
               <SandboxStatus
                 sandboxInfo={sandboxInfo}
                 isCreating={isCreatingSandbox}
+                isReconnecting={reconnectionStatus === "checking"}
+                reconnectionStatus={reconnectionStatus}
                 isSavingSnapshot={isSavingSnapshot}
                 isRestoring={isRestoringSnapshot}
                 hasSnapshot={!!task.snapshotUrl}

--- a/apps/web/lib/db/migrations/0004_ambitious_king_bedlam.sql
+++ b/apps/web/lib/db/migrations/0004_ambitious_king_bedlam.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "tasks" ADD COLUMN "sandbox_created_at" timestamp;--> statement-breakpoint
+ALTER TABLE "tasks" ADD COLUMN "sandbox_timeout" integer;

--- a/apps/web/lib/db/migrations/meta/0004_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,470 @@
+{
+  "id": "a6149c21-4f1e-4c22-8618-17478c55986d",
+  "prevId": "3a3787f3-0643-4b9d-9c8a-451aeb0bf25d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_provider_idx": {
+          "name": "accounts_user_id_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_messages": {
+      "name": "task_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_messages_task_id_tasks_id_fk": {
+          "name": "task_messages_task_id_tasks_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new_branch": {
+          "name": "is_new_branch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_created_at": {
+          "name": "sandbox_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_timeout": {
+          "name": "sandbox_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines_added": {
+          "name": "lines_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lines_removed": {
+          "name": "lines_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_url": {
+          "name": "snapshot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_size_bytes": {
+          "name": "snapshot_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_provider_external_id_idx": {
+          "name": "users_provider_external_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1768251380500,
       "tag": "0003_serious_george_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1768326697711,
+      "tag": "0004_ambitious_king_bedlam",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -84,6 +84,8 @@ export const tasks = pgTable("tasks", {
   isNewBranch: boolean("is_new_branch").default(false).notNull(),
   // Sandbox info
   sandboxId: text("sandbox_id"),
+  sandboxCreatedAt: timestamp("sandbox_created_at"),
+  sandboxTimeout: integer("sandbox_timeout"),
   // Git stats (for display in task list)
   linesAdded: integer("lines_added").default(0),
   linesRemoved: integer("lines_removed").default(0),


### PR DESCRIPTION
Enables users to reconnect to existing sandboxes when returning to a task, with graceful fallback to snapshot restoration.

- Create `/api/sandbox/reconnect` endpoint to validate and reconnect to existing sandboxes, with status tracking (connected/expired/not_found/no_sandbox)
- Store `sandboxCreatedAt` and `sandboxTimeout` in database to determine sandbox expiration (with 10s buffer) and clear stale metadata
- Add `reconnectionStatus` state to task context with `attemptReconnection()` hook called on page refresh when task has prior sandbox
- Update sandbox status UI to show reconnection states and offer snapshot restoration when sandbox expires