### PR TITLE
Allow path-glob approval rules to match outside working directory

### DIFF
--- a/packages/agent/tools/glob.ts
+++ b/packages/agent/tools/glob.ts
@@ -115,6 +115,8 @@ const globInputSchema = z.object({
 
 /**
  * Check if a path matches any path-glob approval rules for glob operations.
+ * Glob approval rules apply to paths OUTSIDE the working directory, so we need
+ * to allow matching outside the base directory.
  */
 function pathMatchesApprovalRule(
   searchPath: string,
@@ -127,7 +129,13 @@ function pathMatchesApprovalRule(
 
   for (const rule of approvalRules) {
     if (rule.type === "path-glob" && rule.tool === "glob") {
-      if (pathMatchesGlob(absolutePath, rule.glob, workingDirectory)) {
+      // Glob rules apply to paths outside the working directory,
+      // so we must allow matching outside the base
+      if (
+        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
+          allowOutsideBase: true,
+        })
+      ) {
         return true;
       }
     }

--- a/packages/agent/tools/grep.ts
+++ b/packages/agent/tools/grep.ts
@@ -106,6 +106,8 @@ const grepInputSchema = z.object({
 
 /**
  * Check if a path matches any path-glob approval rules for grep operations.
+ * Grep approval rules apply to paths OUTSIDE the working directory, so we need
+ * to allow matching outside the base directory.
  */
 function pathMatchesApprovalRule(
   searchPath: string,
@@ -118,7 +120,13 @@ function pathMatchesApprovalRule(
 
   for (const rule of approvalRules) {
     if (rule.type === "path-glob" && rule.tool === "grep") {
-      if (pathMatchesGlob(absolutePath, rule.glob, workingDirectory)) {
+      // Grep rules apply to paths outside the working directory,
+      // so we must allow matching outside the base
+      if (
+        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
+          allowOutsideBase: true,
+        })
+      ) {
         return true;
       }
     }

--- a/packages/agent/tools/read.ts
+++ b/packages/agent/tools/read.ts
@@ -2,7 +2,13 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import * as fs from "fs";
-import { isPathWithinDirectory, getSandbox, getApprovalContext } from "./utils";
+import {
+  isPathWithinDirectory,
+  getSandbox,
+  getApprovalContext,
+  pathMatchesGlob,
+} from "./utils";
+import type { ApprovalRule } from "../types";
 
 const readInputSchema = z.object({
   filePath: z
@@ -52,6 +58,36 @@ function resolveFilePath(filePath: string, workingDirectory: string): string {
   return absolutePath;
 }
 
+/**
+ * Check if a file path matches any path-glob approval rules for read operations.
+ * Read approval rules apply to paths OUTSIDE the working directory, so we need
+ * to allow matching outside the base directory.
+ */
+function pathMatchesApprovalRule(
+  filePath: string,
+  workingDirectory: string,
+  approvalRules: ApprovalRule[],
+): boolean {
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(workingDirectory, filePath);
+
+  for (const rule of approvalRules) {
+    if (rule.type === "path-glob" && rule.tool === "read") {
+      // Read rules apply to paths outside the working directory,
+      // so we must allow matching outside the base
+      if (
+        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
+          allowOutsideBase: true,
+        })
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export const readFileTool = () =>
   tool({
     needsApproval: (args, { experimental_context }) => {
@@ -65,7 +101,17 @@ export const readFileTool = () =>
       if (ctx.autoApprove === "all") {
         return false;
       }
-      // Outside working directory - always requires approval
+      // Check if path matches any saved approval rules
+      if (
+        pathMatchesApprovalRule(
+          args.filePath,
+          ctx.workingDirectory,
+          ctx.approvalRules,
+        )
+      ) {
+        return false;
+      }
+      // Outside working directory - requires approval
       return true;
     },
     description: `Read a file from the filesystem.

--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -122,19 +122,25 @@ export function getApprovalContext(
  * @param filePath - The absolute file path to check
  * @param glob - The glob pattern to match against
  * @param baseDir - The base directory for relative glob patterns
+ * @param options - Optional settings
+ * @param options.allowOutsideBase - If true, allow matching paths outside baseDir (for read approval rules)
  * @returns true if the file path matches the glob pattern
  */
 export function pathMatchesGlob(
   filePath: string,
   glob: string,
   baseDir: string,
+  options?: { allowOutsideBase?: boolean },
 ): boolean {
   const resolvedPath = path.resolve(filePath);
   const resolvedBase = path.resolve(baseDir);
 
-  // Ensure the path is within the base directory
-  if (!isPathWithinDirectory(resolvedPath, resolvedBase)) {
-    return false;
+  // By default, ensure the path is within the base directory
+  // This can be skipped for read approval rules which apply to paths outside the working directory
+  if (!options?.allowOutsideBase) {
+    if (!isPathWithinDirectory(resolvedPath, resolvedBase)) {
+      return false;
+    }
   }
 
   // Get the relative path from the base directory

--- a/packages/agent/tools/write.ts
+++ b/packages/agent/tools/write.ts
@@ -59,6 +59,8 @@ function isOutsideWorkingDirectory(
 
 /**
  * Check if a file path matches any path-glob approval rules for a specific tool.
+ * Write/edit approval rules can apply to paths outside the working directory,
+ * so we allow matching outside the base directory.
  */
 function pathMatchesApprovalRule(
   filePath: string,
@@ -72,7 +74,13 @@ function pathMatchesApprovalRule(
 
   for (const rule of approvalRules) {
     if (rule.type === "path-glob" && rule.tool === toolName) {
-      if (pathMatchesGlob(absolutePath, rule.glob, workingDirectory)) {
+      // Rules can apply to paths outside the working directory,
+      // so we must allow matching outside the base
+      if (
+        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
+          allowOutsideBase: true,
+        })
+      ) {
         return true;
       }
     }
@@ -84,19 +92,11 @@ export const writeFileTool = (options?: WriteToolOptions) =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "write");
-      // Always need approval if outside working directory (even in background mode)
-      if (isOutsideWorkingDirectory(args.filePath, ctx.workingDirectory)) {
-        return true;
-      }
-      // In background mode, auto-approve all operations within working directory
-      if (ctx.mode === "background") {
-        return false;
-      }
-      // Auto-approve edits when autoApprove is "edits" or "all"
-      if (ctx.autoApprove === "edits" || ctx.autoApprove === "all") {
-        return false;
-      }
-      // Check if path matches any saved approval rules
+      const isOutside = isOutsideWorkingDirectory(
+        args.filePath,
+        ctx.workingDirectory,
+      );
+      // Check if path matches any saved approval rules (works for both inside and outside paths)
       if (
         pathMatchesApprovalRule(
           args.filePath,
@@ -105,6 +105,18 @@ export const writeFileTool = (options?: WriteToolOptions) =>
           ctx.approvalRules,
         )
       ) {
+        return false;
+      }
+      // If outside working directory and no approval rule matched, require approval
+      if (isOutside) {
+        return true;
+      }
+      // In background mode, auto-approve all operations within working directory
+      if (ctx.mode === "background") {
+        return false;
+      }
+      // Auto-approve edits when autoApprove is "edits" or "all"
+      if (ctx.autoApprove === "edits" || ctx.autoApprove === "all") {
         return false;
       }
       // Otherwise use the configured approval setting
@@ -175,19 +187,11 @@ export const editFileTool = (options?: EditToolOptions) =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "edit");
-      // Always need approval if outside working directory (even in background mode)
-      if (isOutsideWorkingDirectory(args.filePath, ctx.workingDirectory)) {
-        return true;
-      }
-      // In background mode, auto-approve all operations within working directory
-      if (ctx.mode === "background") {
-        return false;
-      }
-      // Auto-approve edits when autoApprove is "edits" or "all"
-      if (ctx.autoApprove === "edits" || ctx.autoApprove === "all") {
-        return false;
-      }
-      // Check if path matches any saved approval rules
+      const isOutside = isOutsideWorkingDirectory(
+        args.filePath,
+        ctx.workingDirectory,
+      );
+      // Check if path matches any saved approval rules (works for both inside and outside paths)
       if (
         pathMatchesApprovalRule(
           args.filePath,
@@ -196,6 +200,18 @@ export const editFileTool = (options?: EditToolOptions) =>
           ctx.approvalRules,
         )
       ) {
+        return false;
+      }
+      // If outside working directory and no approval rule matched, require approval
+      if (isOutside) {
+        return true;
+      }
+      // In background mode, auto-approve all operations within working directory
+      if (ctx.mode === "background") {
+        return false;
+      }
+      // Auto-approve edits when autoApprove is "edits" or "all"
+      if (ctx.autoApprove === "edits" || ctx.autoApprove === "all") {
         return false;
       }
       // Otherwise use the configured approval setting

--- a/packages/agent/types.ts
+++ b/packages/agent/types.ts
@@ -41,8 +41,8 @@ export interface AgentContext {
  * Approval rules for auto-approving tool operations within a session.
  * Rules are matched against tool arguments to skip manual approval.
  *
- * Note: Rules only apply to paths within the working directory.
- * Outside-cwd operations always require explicit approval regardless of rules.
+ * Path-glob rules can match paths both inside and outside the working directory.
+ * This allows users to grant persistent approval for specific external paths.
  */
 export const approvalRuleSchema = z.discriminatedUnion("type", [
   z.object({


### PR DESCRIPTION
Enable approval rules to apply to files outside the working directory by adding `allowOutsideBase` option to `pathMatchesGlob()` function.

- Added `allowOutsideBase` optional parameter to `pathMatchesGlob()` to skip base directory validation when needed
- Updated glob, grep, and write/edit tools to pass `allowOutsideBase: true` when checking approval rules, since these rules should apply to paths both inside and outside the working directory
- Implemented `pathMatchesApprovalRule()` function in read tool to consistently handle approval rule matching across all file operation tools
- Refactored write and edit tool approval logic to check approval rules before requiring manual approval for outside-directory operations