### PR TITLE
Add offline diff caching and viewing support

### DIFF
--- a/apps/web/app/api/tasks/[id]/diff/cached/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/cached/route.ts
@@ -1,0 +1,46 @@
+import { getTaskById } from "@/lib/db/tasks";
+import { getServerSession } from "@/lib/session/get-server-session";
+import type { DiffResponse } from "../route";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export type CachedDiffResponse = {
+  data: DiffResponse;
+  cachedAt: string;
+  isStale: true;
+};
+
+export async function GET(_req: Request, context: RouteContext) {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { id: taskId } = await context.params;
+
+  const task = await getTaskById(taskId);
+  if (!task) {
+    return Response.json({ error: "Task not found" }, { status: 404 });
+  }
+  if (task.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!task.cachedDiff) {
+    return Response.json(
+      { error: "No cached diff available" },
+      { status: 404 },
+    );
+  }
+
+  const response: CachedDiffResponse = {
+    data: task.cachedDiff as DiffResponse,
+    cachedAt:
+      task.cachedDiffUpdatedAt?.toISOString() ?? new Date().toISOString(),
+    isStale: true,
+  };
+
+  return Response.json(response);
+}

--- a/apps/web/app/api/tasks/[id]/diff/cached/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/cached/route.ts
@@ -35,6 +35,8 @@ export async function GET(_req: Request, context: RouteContext) {
     );
   }
 
+  // Note: cachedDiff is stored as jsonb and cast to DiffResponse without runtime validation.
+  // This is safe as long as the schema is only written by our own diff route.
   const response: CachedDiffResponse = {
     data: task.cachedDiff as DiffResponse,
     cachedAt:

--- a/apps/web/app/api/tasks/[id]/diff/route.ts
+++ b/apps/web/app/api/tasks/[id]/diff/route.ts
@@ -1,5 +1,5 @@
 import { connectVercelSandbox } from "@open-harness/sandbox";
-import { getTaskById } from "@/lib/db/tasks";
+import { getTaskById, updateTask } from "@/lib/db/tasks";
 import { getServerSession } from "@/lib/session/get-server-session";
 import type { NextRequest } from "next/server";
 
@@ -302,6 +302,14 @@ ${diffLines}`;
         totalDeletions,
       },
     };
+
+    // Cache diff for offline viewing (fire-and-forget)
+    updateTask(taskId, {
+      cachedDiff: response,
+      cachedDiffUpdatedAt: new Date(),
+      linesAdded: response.summary.totalAdditions,
+      linesRemoved: response.summary.totalDeletions,
+    }).catch((err) => console.error("Failed to cache diff:", err));
 
     return Response.json(response);
   } catch (error) {

--- a/apps/web/app/tasks/[id]/diff-viewer.tsx
+++ b/apps/web/app/tasks/[id]/diff-viewer.tsx
@@ -232,7 +232,7 @@ export function DiffViewer({
   const { diffCache, fetchDiff, diffRefreshKey } = useTaskChatContext();
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
 
-  const { data, error, isLoading, isStale: _isStale, cachedAt } = diffCache;
+  const { data, error, isLoading, cachedAt } = diffCache;
 
   // Show stale indicator if sandbox is offline (even if data came from a live fetch earlier)
   const showStaleIndicator = !sandboxId && data !== null;

--- a/apps/web/app/tasks/[id]/diff-viewer.tsx
+++ b/apps/web/app/tasks/[id]/diff-viewer.tsx
@@ -8,7 +8,7 @@ import type { DiffFile } from "@/app/api/tasks/[id]/diff/route";
 import { useTaskChatContext } from "./task-context";
 
 type DiffViewerProps = {
-  sandboxId: string;
+  sandboxId?: string;
   refreshKey: number;
   onClose: () => void;
 };
@@ -67,6 +67,32 @@ function parseDiffContent(diff: string): ParsedDiffLine[] {
   }
 
   return lines;
+}
+
+function formatTimestamp(date: Date) {
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function StaleBanner({ cachedAt }: { cachedAt: Date | null }) {
+  return (
+    <div className="flex items-center gap-2 border-b border-border bg-amber-950/30 px-4 py-2 text-xs text-amber-400">
+      <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" />
+      <span>
+        Viewing cached changes - sandbox is offline
+        {cachedAt && (
+          <span className="text-amber-400/70">
+            {" "}
+            (saved {formatTimestamp(cachedAt)})
+          </span>
+        )}
+      </span>
+    </div>
+  );
 }
 
 function StatusBadge({ status }: { status: DiffFile["status"] }) {
@@ -206,7 +232,10 @@ export function DiffViewer({
   const { diffCache, fetchDiff, diffRefreshKey } = useTaskChatContext();
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
 
-  const { data, error, isLoading } = diffCache;
+  const { data, error, isLoading, isStale: _isStale, cachedAt } = diffCache;
+
+  // Show stale indicator if sandbox is offline (even if data came from a live fetch earlier)
+  const showStaleIndicator = !sandboxId && data !== null;
 
   // Fetch diff on mount and when refreshKey changes
   // The fetchDiff function will skip if cache is still valid
@@ -285,8 +314,16 @@ export function DiffViewer({
         </div>
       </div>
 
+      {/* Staleness indicator */}
+      {showStaleIndicator && <StaleBanner cachedAt={cachedAt} />}
+
       {/* Content */}
-      <div className="flex-1 overflow-y-auto">
+      <div
+        className={cn(
+          "flex-1 overflow-y-auto",
+          showStaleIndicator && "opacity-90",
+        )}
+      >
         {isLoading && (
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -196,18 +196,32 @@ export function TaskChatProvider({
     setDiffRefreshKey((prev) => prev + 1);
   }, []);
 
-  const [diffCache, setDiffCache] = useState<DiffCacheState>({
-    data: null,
-    error: null,
-    isLoading: false,
-    lastFetchedKey: -1, // -1 means never fetched
-    isStale: false,
-    cachedAt: null,
+  // Initialize diff cache with task's cached diff if available (no layout shift)
+  const [diffCache, setDiffCache] = useState<DiffCacheState>(() => {
+    if (initialTask.cachedDiff) {
+      return {
+        data: initialTask.cachedDiff as DiffResponse,
+        error: null,
+        isLoading: false,
+        lastFetchedKey: 0,
+        isStale: true,
+        cachedAt: initialTask.cachedDiffUpdatedAt ?? null,
+      };
+    }
+    return {
+      data: null,
+      error: null,
+      isLoading: false,
+      lastFetchedKey: -1, // -1 means never fetched
+      isStale: false,
+      cachedAt: null,
+    };
   });
 
   // Track the current fetch to prevent duplicates and handle race conditions
   const fetchCounterRef = useRef(0);
-  const lastFetchedKeyRef = useRef<number>(-1);
+  // Initialize to 0 if we have cached data (matches lastFetchedKey in state)
+  const lastFetchedKeyRef = useRef<number>(initialTask.cachedDiff ? 0 : -1);
   const fetchingKeyRef = useRef<number | null>(null);
 
   const fetchDiff = useCallback(

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -197,6 +197,8 @@ export function TaskChatProvider({
   }, []);
 
   // Initialize diff cache with task's cached diff if available (no layout shift)
+  // Note: cachedDiff is stored as jsonb and cast to DiffResponse without runtime validation.
+  // This is safe as long as the schema is only written by our own diff route.
   const [diffCache, setDiffCache] = useState<DiffCacheState>(() => {
     if (initialTask.cachedDiff) {
       return {

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -17,6 +17,7 @@ import { useChat, type UseChatHelpers } from "@ai-sdk/react";
 import type { WebAgentUIMessage } from "@/app/types";
 import type { Task } from "@/lib/db/schema";
 import type { DiffResponse } from "@/app/api/tasks/[id]/diff/route";
+import type { CachedDiffResponse } from "@/app/api/tasks/[id]/diff/cached/route";
 import type { FileSuggestion } from "@/app/api/tasks/[id]/files/route";
 import type { ReconnectResponse } from "@/app/api/sandbox/reconnect/route";
 
@@ -40,6 +41,10 @@ type DiffCacheState = {
   isLoading: boolean;
   /** The refreshKey value when this data was last fetched */
   lastFetchedKey: number;
+  /** Whether this is stale cached data (sandbox offline) */
+  isStale: boolean;
+  /** When the cached data was saved (for stale data display) */
+  cachedAt: Date | null;
 };
 
 type FileCacheState = {
@@ -65,8 +70,8 @@ type TaskChatContextValue = {
   triggerDiffRefresh: () => void;
   /** Cached diff state */
   diffCache: DiffCacheState;
-  /** Fetch diff data (uses cache if valid) */
-  fetchDiff: (sandboxId: string) => Promise<void>;
+  /** Fetch diff data (uses cache if valid, falls back to cached if offline) */
+  fetchDiff: (sandboxId?: string) => Promise<void>;
   /** Counter that increments when file list should be refreshed */
   fileRefreshKey: number;
   /** Trigger a file list refresh (invalidates cache) */
@@ -142,9 +147,7 @@ export function TaskChatProvider({
     setReconnectionStatus("checking");
 
     try {
-      const response = await fetch(
-        `/api/sandbox/reconnect?taskId=${task.id}`,
-      );
+      const response = await fetch(`/api/sandbox/reconnect?taskId=${task.id}`);
 
       if (!response.ok) {
         console.error("Reconnection request failed:", response.status);
@@ -198,6 +201,8 @@ export function TaskChatProvider({
     error: null,
     isLoading: false,
     lastFetchedKey: -1, // -1 means never fetched
+    isStale: false,
+    cachedAt: null,
   });
 
   // Track the current fetch to prevent duplicates and handle race conditions
@@ -206,7 +211,7 @@ export function TaskChatProvider({
   const fetchingKeyRef = useRef<number | null>(null);
 
   const fetchDiff = useCallback(
-    async (sandboxId: string) => {
+    async (sandboxId?: string) => {
       // Skip if we already have data for this key or are already fetching it
       if (
         lastFetchedKeyRef.current === diffRefreshKey ||
@@ -224,6 +229,43 @@ export function TaskChatProvider({
         isLoading: true,
         error: null,
       }));
+
+      // If no sandboxId, go directly to cached endpoint
+      if (!sandboxId) {
+        try {
+          const cachedRes = await fetch(`/api/tasks/${task.id}/diff/cached`);
+          if (cachedRes.ok) {
+            const cachedData = (await cachedRes.json()) as CachedDiffResponse;
+            if (thisFetchId === fetchCounterRef.current) {
+              lastFetchedKeyRef.current = diffRefreshKey;
+              setDiffCache({
+                data: cachedData.data,
+                error: null,
+                isLoading: false,
+                lastFetchedKey: diffRefreshKey,
+                isStale: true,
+                cachedAt: new Date(cachedData.cachedAt),
+              });
+            }
+            return;
+          }
+        } catch {
+          // Ignore cached fetch errors
+        }
+
+        if (thisFetchId === fetchCounterRef.current) {
+          lastFetchedKeyRef.current = diffRefreshKey;
+          setDiffCache((prev) => ({
+            ...prev,
+            error: "No sandbox available and no cached diff",
+            isLoading: false,
+            lastFetchedKey: diffRefreshKey,
+            isStale: false,
+            cachedAt: null,
+          }));
+        }
+        return;
+      }
 
       try {
         const res = await fetch(
@@ -245,11 +287,41 @@ export function TaskChatProvider({
             error: null,
             isLoading: false,
             lastFetchedKey: diffRefreshKey,
+            isStale: false,
+            cachedAt: null,
           });
+          // Update local task state so cachedDiff is available when sandbox shuts down
+          setTask((prev) => ({
+            ...prev,
+            cachedDiff: data,
+            cachedDiffUpdatedAt: new Date(),
+          }));
         }
         // If not the latest fetch, don't update - the newer fetch will handle it
       } catch (err) {
-        // Only update if this is still the latest fetch
+        // Try to load cached diff as fallback
+        try {
+          const cachedRes = await fetch(`/api/tasks/${task.id}/diff/cached`);
+          if (cachedRes.ok) {
+            const cachedData = (await cachedRes.json()) as CachedDiffResponse;
+            if (thisFetchId === fetchCounterRef.current) {
+              lastFetchedKeyRef.current = diffRefreshKey;
+              setDiffCache({
+                data: cachedData.data,
+                error: null,
+                isLoading: false,
+                lastFetchedKey: diffRefreshKey,
+                isStale: true,
+                cachedAt: new Date(cachedData.cachedAt),
+              });
+            }
+            return;
+          }
+        } catch {
+          // Ignore cached fetch errors
+        }
+
+        // No cached data available - show original error
         if (thisFetchId === fetchCounterRef.current) {
           lastFetchedKeyRef.current = diffRefreshKey;
           setDiffCache((prev) => ({
@@ -257,6 +329,8 @@ export function TaskChatProvider({
             error: err instanceof Error ? err.message : "Failed to fetch diff",
             isLoading: false,
             lastFetchedKey: diffRefreshKey,
+            isStale: false,
+            cachedAt: null,
           }));
         }
       }

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -14,7 +14,6 @@ import {
   Square,
   X,
   Archive,
-  Share2,
   GitPullRequest,
   FolderGit2,
   MoreVertical,
@@ -399,6 +398,8 @@ export function TaskDetailContent() {
     hadInitialMessages,
     diffRefreshKey,
     triggerDiffRefresh,
+    diffCache,
+    fetchDiff,
     fileCache,
     fetchFiles,
     triggerFileRefresh,
@@ -814,6 +815,20 @@ export function TaskDetailContent() {
     }
   }, [sandboxInfo, fileCache.data, fileCache.isLoading, fetchFiles]);
 
+  // Fetch diff proactively (from sandbox or cached) to show stats in header
+  useEffect(() => {
+    // Fetch on mount (for cached data) or when sandbox/diffRefreshKey changes
+    if (!diffCache.isLoading && diffCache.lastFetchedKey !== diffRefreshKey) {
+      fetchDiff(sandboxInfo?.sandboxId);
+    }
+  }, [
+    sandboxInfo?.sandboxId,
+    diffRefreshKey,
+    diffCache.isLoading,
+    diffCache.lastFetchedKey,
+    fetchDiff,
+  ]);
+
   if (error) {
     return (
       <div className="flex h-screen items-center justify-center bg-background">
@@ -880,10 +895,6 @@ export function TaskDetailContent() {
               <Archive className="mr-2 h-4 w-4" />
               Archive
             </Button>
-            <Button variant="ghost" size="sm">
-              <Share2 className="mr-2 h-4 w-4" />
-              Share
-            </Button>
             <Button
               variant="ghost"
               size="sm"
@@ -892,6 +903,18 @@ export function TaskDetailContent() {
             >
               <GitCompare className="mr-2 h-4 w-4" />
               Diff
+              {diffCache.data &&
+                (diffCache.data.summary.totalAdditions > 0 ||
+                  diffCache.data.summary.totalDeletions > 0) && (
+                  <span className="ml-2 text-xs">
+                    <span className="text-green-500">
+                      +{diffCache.data.summary.totalAdditions}
+                    </span>{" "}
+                    <span className="text-red-400">
+                      -{diffCache.data.summary.totalDeletions}
+                    </span>
+                  </span>
+                )}
             </Button>
             {task?.cloneUrl ? (
               // Task has a repo - show PR buttons

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -308,7 +308,6 @@ function SandboxInputOverlay({
   sandboxInfo,
   isCreating,
   isRestoring,
-  _timeRemaining,
   hasSnapshot,
   onRestore,
   onCreateNew,
@@ -316,7 +315,6 @@ function SandboxInputOverlay({
   sandboxInfo: SandboxInfo | null;
   isCreating: boolean;
   isRestoring: boolean;
-  _timeRemaining: number | null;
   hasSnapshot: boolean;
   onRestore: () => void;
   onCreateNew: () => void;
@@ -899,7 +897,7 @@ export function TaskDetailContent() {
               variant="ghost"
               size="sm"
               onClick={() => setShowDiffPanel(!showDiffPanel)}
-              disabled={!sandboxInfo && (!task.cachedDiff as boolean)}
+              disabled={!sandboxInfo && !task.cachedDiff}
             >
               <GitCompare className="mr-2 h-4 w-4" />
               Diff
@@ -1197,7 +1195,6 @@ export function TaskDetailContent() {
                 sandboxInfo={sandboxInfo}
                 isCreating={isCreatingSandbox}
                 isRestoring={isRestoringSnapshot}
-                _timeRemaining={sandboxTimeRemaining}
                 hasSnapshot={!!task.snapshotUrl}
                 onRestore={handleRestoreSnapshot}
                 onCreateNew={handleCreateNewSandbox}

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -40,11 +40,7 @@ import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
 import type { WebAgentUIToolPart, WebAgentUIMessagePart } from "@/app/types";
 import type { TaskToolUIPart } from "@open-harness/agent";
 
-import {
-  useTaskChatContext,
-  type SandboxInfo,
-  type ReconnectionStatus,
-} from "./task-context";
+import { useTaskChatContext, type SandboxInfo } from "./task-context";
 import { DiffViewer } from "./diff-viewer";
 import { useFileSuggestions } from "@/hooks/use-file-suggestions";
 import { FileSuggestionsDropdown } from "@/components/file-suggestions-dropdown";
@@ -313,7 +309,7 @@ function SandboxInputOverlay({
   sandboxInfo,
   isCreating,
   isRestoring,
-  timeRemaining,
+  _timeRemaining,
   hasSnapshot,
   onRestore,
   onCreateNew,
@@ -321,7 +317,7 @@ function SandboxInputOverlay({
   sandboxInfo: SandboxInfo | null;
   isCreating: boolean;
   isRestoring: boolean;
-  timeRemaining: number | null;
+  _timeRemaining: number | null;
   hasSnapshot: boolean;
   onRestore: () => void;
   onCreateNew: () => void;
@@ -471,42 +467,45 @@ export function TaskDetailContent() {
     }
   }, [sandboxInfo, task.id, clearSandboxInfo]);
 
-  const saveSnapshot = async (
-    sandboxId: string,
-  ): Promise<{
-    success: boolean;
-    downloadUrl?: string;
-    createdAt?: number;
-  }> => {
-    try {
-      const response = await fetch("/api/sandbox/snapshot", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sandboxId,
-          taskId: task.id,
-        }),
-      });
+  const saveSnapshot = useCallback(
+    async (
+      sandboxId: string,
+    ): Promise<{
+      success: boolean;
+      downloadUrl?: string;
+      createdAt?: number;
+    }> => {
+      try {
+        const response = await fetch("/api/sandbox/snapshot", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sandboxId,
+            taskId: task.id,
+          }),
+        });
 
-      if (!response.ok) {
-        const error = (await response.json()) as { error?: string };
-        console.error("Failed to save snapshot:", error.error);
+        if (!response.ok) {
+          const error = (await response.json()) as { error?: string };
+          console.error("Failed to save snapshot:", error.error);
+          return { success: false };
+        }
+        const data = (await response.json()) as {
+          downloadUrl: string;
+          createdAt: number;
+        };
+        return {
+          success: true,
+          downloadUrl: data.downloadUrl,
+          createdAt: data.createdAt,
+        };
+      } catch (err) {
+        console.error("Failed to save snapshot:", err);
         return { success: false };
       }
-      const data = (await response.json()) as {
-        downloadUrl: string;
-        createdAt: number;
-      };
-      return {
-        success: true,
-        downloadUrl: data.downloadUrl,
-        createdAt: data.createdAt,
-      };
-    } catch (err) {
-      console.error("Failed to save snapshot:", err);
-      return { success: false };
-    }
-  };
+    },
+    [task.id],
+  );
 
   const handleSaveAndKill = useCallback(async () => {
     if (!sandboxInfo || isSavingSnapshotRef.current) return;
@@ -523,7 +522,7 @@ export function TaskDetailContent() {
     }
     // Kill sandbox after saving (regardless of save success)
     await handleKillSandbox();
-  }, [sandboxInfo, updateTaskSnapshot, handleKillSandbox]);
+  }, [sandboxInfo, updateTaskSnapshot, handleKillSandbox, saveSnapshot]);
 
   const handleExtendSandbox = async () => {
     if (!sandboxInfo) return;
@@ -889,7 +888,7 @@ export function TaskDetailContent() {
               variant="ghost"
               size="sm"
               onClick={() => setShowDiffPanel(!showDiffPanel)}
-              disabled={!sandboxInfo}
+              disabled={!sandboxInfo && (!task.cachedDiff as boolean)}
             >
               <GitCompare className="mr-2 h-4 w-4" />
               Diff
@@ -1175,7 +1174,7 @@ export function TaskDetailContent() {
                 sandboxInfo={sandboxInfo}
                 isCreating={isCreatingSandbox}
                 isRestoring={isRestoringSnapshot}
-                timeRemaining={sandboxTimeRemaining}
+                _timeRemaining={sandboxTimeRemaining}
                 hasSnapshot={!!task.snapshotUrl}
                 onRestore={handleRestoreSnapshot}
                 onCreateNew={handleCreateNewSandbox}
@@ -1300,9 +1299,9 @@ export function TaskDetailContent() {
       )}
 
       {/* Diff Viewer Panel */}
-      {showDiffPanel && sandboxInfo && (
+      {showDiffPanel && (sandboxInfo || Boolean(task.cachedDiff)) && (
         <DiffViewer
-          sandboxId={sandboxInfo.sandboxId}
+          sandboxId={sandboxInfo?.sandboxId}
           refreshKey={diffRefreshKey}
           onClose={() => setShowDiffPanel(false)}
         />

--- a/apps/web/lib/db/migrations/0005_crazy_titanium_man.sql
+++ b/apps/web/lib/db/migrations/0005_crazy_titanium_man.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "tasks" ADD COLUMN "cached_diff" jsonb;--> statement-breakpoint
+ALTER TABLE "tasks" ADD COLUMN "cached_diff_updated_at" timestamp;

--- a/apps/web/lib/db/migrations/meta/0005_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0005_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "a6149c21-4f1e-4c22-8618-17478c55986d",
-  "prevId": "3a3787f3-0643-4b9d-9c8a-451aeb0bf25d",
+  "id": "454022f9-1321-4b91-99cd-67a16ee573fb",
+  "prevId": "a6149c21-4f1e-4c22-8618-17478c55986d",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -291,6 +291,18 @@
         "snapshot_size_bytes": {
           "name": "snapshot_size_bytes",
           "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_diff": {
+          "name": "cached_diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_diff_updated_at": {
+          "name": "cached_diff_updated_at",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": false
         },

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1768326697711,
       "tag": "0004_ambitious_king_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1768341978785,
+      "tag": "0005_crazy_titanium_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -98,6 +98,9 @@ export const tasks = pgTable("tasks", {
   snapshotUrl: text("snapshot_url"),
   snapshotCreatedAt: timestamp("snapshot_created_at"),
   snapshotSizeBytes: integer("snapshot_size_bytes"),
+  // Cached diff for offline viewing
+  cachedDiff: jsonb("cached_diff"),
+  cachedDiffUpdatedAt: timestamp("cached_diff_updated_at"),
   // Timestamps
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/bun.lock
+++ b/bun.lock
@@ -588,7 +588,7 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
-    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -718,7 +718,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001763", "", {}, "sha512-mh/dGtq56uN98LlNX9qdbKnzINhX0QzhiWBFEkFfsFO4QyCvL8YegrJAazCwXIeqkIob8BlZPGM3xdnY+sgmvQ=="],
 


### PR DESCRIPTION
Enables users to view cached diff data when sandbox is offline, improving resilience and UX.

- Added `cachedDiff` and `cachedDiffUpdatedAt` fields to tasks table for persistent diff storage
- Created new `/api/tasks/[id]/diff/cached` endpoint to retrieve cached diffs without active sandbox
- Modified diff endpoint to automatically cache results after fetching from sandbox
- Updated DiffViewer to accept optional sandboxId and display staleness indicator when viewing offline data
- Enhanced task context to preload cached diff on mount and fall back to cache on fetch errors
- Display diff stats badge in header even without active sandbox connection