### PR TITLE
Add streaming mode prop to Streamdown component

### DIFF
--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -1055,6 +1055,9 @@ export function TaskDetailContent() {
                           ) : (
                             <div className="max-w-[80%]">
                               <Streamdown
+                                mode={
+                                  isMessageStreaming ? "streaming" : "static"
+                                }
                                 isAnimating={isMessageStreaming}
                                 shikiTheme={shikiThemes}
                                 components={customComponents}


### PR DESCRIPTION
- Pass `mode` prop to Streamdown component to distinguish between streaming and static content states
- Uses `isMessageStreaming` boolean to dynamically set mode to 'streaming' or 'static'
- Improves component behavior by explicitly indicating when content is being streamed vs. static