### PR TITLE
Refactor agent options to require explicit sandbox and mode

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -136,8 +136,8 @@ async function main() {
         version: "0.1.0",
       },
       agentOptions: {
-        workingDirectory: sandbox.workingDirectory,
         sandbox,
+        mode: "interactive",
         ...(agentsMd?.content && {
           customInstructions: agentsMd.content,
         }),

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -103,10 +103,10 @@ export async function POST(req: Request) {
   const result = await deepAgent.stream({
     messages: modelMessages,
     options: {
-      workingDirectory: sandbox.workingDirectory,
       sandbox,
+      mode: "interactive",
       // TODO: consider enabling approvals for non-cloud-sandbox environments
-      autoApprove: "all",
+      approvals: { autoApprove: "all" },
     },
     abortSignal: req.signal,
   });

--- a/docs/deep-agent-model-call-options-plan.md
+++ b/docs/deep-agent-model-call-options-plan.md
@@ -1,0 +1,113 @@
+# Deep Agent Model Call Options Plan
+
+## Problem Statement
+
+The deep agent currently hardcodes its model selection and exports a `deepAgentModelId`
+string for UI display. This couples application concerns (model choice and UI display)
+to the agent package. We want model ownership to live in the application layer (similar
+to sandbox ownership), while still allowing per-call model overrides through agent
+call options.
+
+## Goals
+
+- Let applications own the chosen model and pass it into the agent call options.
+- Support `model?: LanguageModel` in deep agent call options, aligned with AI SDK types
+  (string model ID or `LanguageModelV3`).
+- Apply provider-specific cache-control to tools and messages based on the selected
+  model for each call.
+- Keep subagent models fixed in the agent package (no model override for subagents).
+- Remove the need for `deepAgentModelId` export from the agent package.
+
+## Non-goals
+
+- Adding model selection UI or automatic model routing logic.
+- Changing subagent models or exposing subagent model selection as a call option.
+- Introducing new model normalization utilities (no gateway resolver changes).
+
+## Proposed Approach
+
+1. **Deep agent call options include `model?: LanguageModel`.**
+   The model is optional; if not provided, use the agent's default model.
+
+2. **Use the per-call model in `prepareCall`.**
+   `prepareCall` has access to both `options` and `settings`, so we can pick the
+   effective model as `options.model ?? settings.model` and return it.
+
+3. **Apply cache-control per call for tools and messages.**
+   Use `addCacheControl({ tools, model })` in `prepareCall` so tools are configured
+   according to the selected model, not just the agent default. For messages, use the
+   model provided to `prepareStep` (already available on the first argument).
+
+4. **App owns model selection and UI display.**
+   Applications pass a model string (or `LanguageModel` object) into agent options and
+   use that same value for UI display and context-limit calculations.
+
+## Detailed Plan
+
+### 1. Deep agent call options and prepareCall
+
+- File: `packages/agent/deep-agent.ts`
+  - Extend `callOptionsSchema` with:
+    ```ts
+    model: z.custom<LanguageModel>().optional(),
+    ```
+  - In `prepareCall`, compute:
+    ```ts
+    const callModel = options.model ?? model;
+    ```
+  - Return `model: callModel` and `tools: addCacheControl({ tools, model: callModel })`
+    so the per-call model drives tool cache-control.
+  - Keep `prepareStep` using the `model` passed in the first argument for message
+    cache-control (this already supports per-call model selection).
+
+### 2. Remove agent export of model ID
+
+- File: `packages/agent/index.ts`
+  - Stop exporting `deepAgentModelId`.
+  - Update any internal references to rely on app-level config instead.
+
+### 3. TUI: model ownership and display
+
+- Files: `packages/tui/config.ts`, `packages/tui/index.tsx`,
+  `packages/tui/chat-context.tsx`, `packages/tui/types.ts`
+  - Update the TUI config to hold an application-owned model identifier
+    (string or `LanguageModel`), and pass that value to:
+    - Header display (model label).
+    - Context-limit calculation via `getContextLimit`.
+  - Ensure `agentOptions` include `model` when creating default options.
+
+### 4. CLI: pass model from application config
+
+- File: `apps/cli/index.ts`
+  - Use the app-owned model configuration to populate both:
+    - `agentOptions.model`
+    - header `model` display
+  - This keeps the CLI model choice local to the CLI app.
+
+### 5. Web app: optional UI model display
+
+- Files: `apps/web/app/config.ts` and the relevant chat provider(s)
+  - If the web UI shows a model label or uses `getContextLimit`, pass the model from
+    a local config (similar to the CLI approach).
+  - If there is no model display, only pass `agentOptions.model` for agent calls.
+
+### 6. Subagents remain fixed
+
+- Files: `packages/agent/subagents/explorer.ts`,
+  `packages/agent/subagents/executor.ts`, `packages/agent/tools/task.ts`
+  - No changes to subagent call options.
+  - Document that subagents are pinned to their current model (haiku).
+
+## Compatibility Notes
+
+- `model` is optional in call options, so existing calls remain valid.
+- Removing `deepAgentModelId` is a breaking change for any consumers that import it;
+  update those consumers to use their own model config.
+- When passing `LanguageModel` objects (not strings), UI display should use a string
+  label owned by the app (e.g., store a `modelLabel` alongside the model).
+
+## Validation
+
+- Typecheck to ensure `DeepAgentCallOptions` includes `model?: LanguageModel`.
+- Run `turbo typecheck --filter=@open-harness/agent` and `--filter=@open-harness/tui`.
+- Manually confirm header model display and context limit are sourced from app config.

--- a/packages/agent/deep-agent.ts
+++ b/packages/agent/deep-agent.ts
@@ -14,18 +14,21 @@ import { buildSystemPrompt } from "./system-prompt";
 import type { TodoItem, AgentMode, ApprovalRule } from "./types";
 import { approvalRuleSchema } from "./types";
 import { addCacheControl, compactContext } from "./context-management";
-import { createLocalSandbox, type Sandbox } from "@open-harness/sandbox";
+import type { Sandbox } from "@open-harness/sandbox";
 
 const agentModeSchema = z.enum(["interactive", "background"]);
 const autoApproveSchema = z.enum(["off", "edits", "all"]);
 
-const callOptionsSchema = z.object({
-  workingDirectory: z.string(),
-  mode: agentModeSchema.optional(),
-  customInstructions: z.string().optional(),
-  sandbox: z.custom<Sandbox>().optional(),
+const approvalsSchema = z.object({
   autoApprove: autoApproveSchema.optional(),
-  approvalRules: z.array(approvalRuleSchema).optional(),
+  rules: z.array(approvalRuleSchema).optional(),
+});
+
+const callOptionsSchema = z.object({
+  sandbox: z.custom<Sandbox>(),
+  mode: agentModeSchema,
+  customInstructions: z.string().optional(),
+  approvals: approvalsSchema.optional(),
 });
 
 export type DeepAgentCallOptions = z.infer<typeof callOptionsSchema>;
@@ -59,15 +62,14 @@ export const deepAgent = new ToolLoopAgent({
     }),
   }),
   prepareCall: ({ options, model, ...settings }) => {
-    const workingDirectory = options?.workingDirectory ?? process.cwd();
-    const mode: AgentMode = options?.mode ?? "interactive";
-    const autoApprove = options?.autoApprove ?? "off";
-    const approvalRules: ApprovalRule[] = options?.approvalRules ?? [];
-
-    const customInstructions = options?.customInstructions;
-
-    // Use provided sandbox, or create a local sandbox with the working directory
-    const sandbox = options?.sandbox ?? createLocalSandbox(workingDirectory);
+    if (!options) {
+      throw new Error("Deep agent requires call options with sandbox and mode.");
+    }
+    const mode: AgentMode = options.mode;
+    const autoApprove = options.approvals?.autoApprove ?? "off";
+    const approvalRules: ApprovalRule[] = options.approvals?.rules ?? [];
+    const customInstructions = options.customInstructions;
+    const sandbox = options.sandbox;
 
     const instructions = buildSystemPrompt({
       cwd: sandbox.workingDirectory,

--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -131,12 +131,8 @@ export const bashTool = (options?: ToolOptions) =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "bash");
-      // Auto-approve all bash commands when autoApprove is "all"
-      // In subagents, the user grants permission at the top level for all changes,
-      // so we bypass directory boundary checks here.
-      // TODO: This is specifically for working with monorepos and calling within
-      // nested files, but we should probably revert this change.
-      if (ctx.autoApprove === "all") {
+      // Check if command matches any saved approval rules
+      if (commandMatchesApprovalRule(args.command, ctx.approvalRules)) {
         return false;
       }
       // Need approval if cwd is outside working directory (even in background mode)
@@ -147,8 +143,8 @@ export const bashTool = (options?: ToolOptions) =>
       if (ctx.mode === "background") {
         return false;
       }
-      // Check if command matches any saved approval rules
-      if (commandMatchesApprovalRule(args.command, ctx.approvalRules)) {
+      // Auto-approve bash commands within working directory in interactive mode
+      if (ctx.mode === "interactive" && ctx.autoApprove === "all") {
         return false;
       }
       // Check command safety

--- a/packages/agent/tools/glob.ts
+++ b/packages/agent/tools/glob.ts
@@ -158,10 +158,6 @@ export const globTool = () =>
       if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
         return false;
       }
-      // Auto-approve when autoApprove is "all"
-      if (ctx.autoApprove === "all") {
-        return false;
-      }
       // Outside working directory - check if a rule matches
       if (
         pathMatchesApprovalRule(

--- a/packages/agent/tools/grep.ts
+++ b/packages/agent/tools/grep.ts
@@ -145,10 +145,6 @@ export const grepTool = () =>
       if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
         return false;
       }
-      // Auto-approve when autoApprove is "all"
-      if (ctx.autoApprove === "all") {
-        return false;
-      }
       // Outside working directory - check if a rule matches
       if (
         pathMatchesApprovalRule(

--- a/packages/agent/tools/read.ts
+++ b/packages/agent/tools/read.ts
@@ -97,10 +97,6 @@ export const readFileTool = () =>
       if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
         return false;
       }
-      // Auto-approve when autoApprove is "all"
-      if (ctx.autoApprove === "all") {
-        return false;
-      }
       // Check if path matches any saved approval rules
       if (
         pathMatchesApprovalRule(

--- a/packages/tui/config.ts
+++ b/packages/tui/config.ts
@@ -1,5 +1,7 @@
 import { deepAgent, deepAgentModelId } from "@open-harness/agent";
-import type { TUIAgentCallOptions } from "./types";
+import type { AgentMode } from "@open-harness/agent";
+import type { Sandbox } from "@open-harness/sandbox";
+import type { TUIAgentCallOptions } from "./types.js";
 
 // Configure your agent here - this is the single source of truth for the TUI
 export const tuiAgent = deepAgent;
@@ -8,9 +10,11 @@ export const pasteCollapseLineThreshold = 5;
 
 // Default agent options factory
 export function createDefaultAgentOptions(
-  workingDirectory: string,
+  sandbox: Sandbox,
+  mode: AgentMode = "interactive",
 ): TUIAgentCallOptions {
   return {
-    workingDirectory,
+    sandbox,
+    mode,
   };
 }

--- a/packages/tui/index.tsx
+++ b/packages/tui/index.tsx
@@ -28,25 +28,36 @@ export {
  * import { createTUI } from './tui';
  *
  * // Interactive mode
- * await createTUI({ workingDirectory: process.cwd() });
+ * await createTUI({
+ *   sandbox,
+ *   workingDirectory: sandbox.workingDirectory,
+ * });
  *
  * // One-shot mode with initial prompt
  * await createTUI({
+ *   sandbox,
  *   initialPrompt: "Explain this codebase",
- *   workingDirectory: process.cwd(),
+ *   workingDirectory: sandbox.workingDirectory,
  * });
  * ```
  */
 export async function createTUI(options: TUIOptions): Promise<void> {
+  if (!options.agentOptions && !options.sandbox) {
+    throw new Error("createTUI requires agentOptions or a sandbox.");
+  }
+
   const agentOptions =
     options.agentOptions ??
-    createDefaultAgentOptions(options.workingDirectory ?? process.cwd());
+    createDefaultAgentOptions(options.sandbox!);
+
+  const workingDirectory =
+    options.workingDirectory ?? options.sandbox?.workingDirectory;
 
   const { waitUntilExit } = render(
     <ChatProvider
       agentOptions={agentOptions}
       model={options.header?.model ?? tuiAgentModelId}
-      workingDirectory={options.workingDirectory}
+      workingDirectory={workingDirectory}
       initialAutoAcceptMode={options.initialAutoAcceptMode}
     >
       <ReasoningProvider>
@@ -67,15 +78,22 @@ export async function createTUI(options: TUIOptions): Promise<void> {
  * Useful for programmatic control.
  */
 export function renderTUI(options: TUIOptions) {
+  if (!options.agentOptions && !options.sandbox) {
+    throw new Error("renderTUI requires agentOptions or a sandbox.");
+  }
+
   const agentOptions =
     options.agentOptions ??
-    createDefaultAgentOptions(options.workingDirectory ?? process.cwd());
+    createDefaultAgentOptions(options.sandbox!);
+
+  const workingDirectory =
+    options.workingDirectory ?? options.sandbox?.workingDirectory;
 
   return render(
     <ChatProvider
       agentOptions={agentOptions}
       model={options.header?.model ?? tuiAgentModelId}
-      workingDirectory={options.workingDirectory}
+      workingDirectory={workingDirectory}
       initialAutoAcceptMode={options.initialAutoAcceptMode}
     >
       <ReasoningProvider>

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@open-harness/agent": "workspace:*",
+    "@open-harness/sandbox": "workspace:*",
     "@open-harness/shared": "workspace:*",
     "cli-highlight": "^2.1.11",
     "ink": "^6.6.0",

--- a/packages/tui/transport.ts
+++ b/packages/tui/transport.ts
@@ -44,12 +44,21 @@ export function createAgentTransport({
       });
 
       // Get current settings at request time
-      const autoApprove = getAutoApprove?.() ?? "off";
-      const approvalRules = getApprovalRules?.() ?? [];
+      const autoApprove = getAutoApprove
+        ? getAutoApprove()
+        : agentOptions.approvals?.autoApprove ?? "off";
+      const approvalRules = getApprovalRules
+        ? getApprovalRules()
+        : agentOptions.approvals?.rules ?? [];
+      const approvals = {
+        ...agentOptions.approvals,
+        autoApprove,
+        rules: approvalRules,
+      };
 
       const result = await agent.stream({
         messages: prunedMessages,
-        options: { ...agentOptions, autoApprove, approvalRules },
+        options: { ...agentOptions, approvals },
         abortSignal: abortSignal ?? undefined,
         experimental_transform: smoothStream(),
       });

--- a/packages/tui/types.ts
+++ b/packages/tui/types.ts
@@ -5,7 +5,8 @@ import type {
   LanguageModelUsage,
   ToolUIPart,
 } from "ai";
-import type { tuiAgent } from "./config";
+import type { Sandbox } from "@open-harness/sandbox";
+import type { tuiAgent } from "./config.js";
 
 export type TUIAgent = typeof tuiAgent;
 export type TUIAgentCallOptions = Parameters<
@@ -37,8 +38,10 @@ export type { ApprovalRule } from "@open-harness/agent";
 export type TUIOptions = {
   /** Initial prompt to run (for one-shot mode) */
   initialPrompt?: string;
-  /** Working directory for the agent */
+  /** Working directory for display/approval context */
   workingDirectory?: string;
+  /** Sandbox to use when agentOptions are not provided */
+  sandbox?: Sandbox;
   /** Custom agent options (defaults provided if not specified) */
   agentOptions?: TUIAgentCallOptions;
   /** Header configuration */


### PR DESCRIPTION
This change refactors the deep agent and TUI to require explicit sandbox and mode configuration, removing implicit defaults and improving clarity.

- **Deep agent**: Made `sandbox` and `mode` required call options; removed implicit local sandbox creation and default mode
- **Approvals restructuring**: Consolidated `autoApprove` and `approvalRules` into a nested `approvals` object for cleaner API
- **Tool approval logic**: Reordered bash tool checks to properly respect mode before auto-approving; removed unnecessary auto-approve checks from glob/grep/read tools
- **TUI updates**: Changed `createDefaultAgentOptions` and `createTUI` to accept `Sandbox` instead of working directory string; sandbox is now required or must be passed via `agentOptions`
- **Documentation**: Added comprehensive plan document outlining model ownership transition and future call options structure