### PR TITLE
Standardize sandbox type identifiers with SandboxType enum

### DIFF
--- a/packages/sandbox/index.ts
+++ b/packages/sandbox/index.ts
@@ -1,22 +1,23 @@
 export type {
-  Sandbox,
-  SandboxStats,
   ExecResult,
+  RestoreOptions,
+  Sandbox,
   SandboxHook,
   SandboxHooks,
+  SandboxStats,
+  SandboxType,
   SnapshotOptions,
   SnapshotResult,
-  RestoreOptions,
 } from "./interface";
-export { LocalSandbox, createLocalSandbox } from "./local";
 export {
-  VercelSandbox,
+  createJustBashSandbox,
+  JustBashSandbox,
+  type JustBashSandboxConfig,
+} from "./just-bash";
+export { createLocalSandbox, LocalSandbox } from "./local";
+export {
   connectVercelSandbox,
+  VercelSandbox,
   type VercelSandboxConfig,
   type VercelSandboxConnectConfig,
 } from "./vercel";
-export {
-  JustBashSandbox,
-  createJustBashSandbox,
-  type JustBashSandboxConfig,
-} from "./just-bash";

--- a/packages/sandbox/interface.ts
+++ b/packages/sandbox/interface.ts
@@ -1,6 +1,14 @@
 import type { Dirent } from "fs";
 
 /**
+ * The type of sandbox environment.
+ * - "local": Local filesystem sandbox using Node.js fs/child_process
+ * - "in-memory": In-memory sandbox using just-bash (no real filesystem)
+ * - "cloud": Remote cloud sandbox (e.g., Vercel Sandbox)
+ */
+export type SandboxType = "local" | "in-memory" | "cloud";
+
+/**
  * Options for creating a snapshot of the sandbox filesystem.
  */
 export interface SnapshotOptions {
@@ -133,7 +141,7 @@ export interface Sandbox {
    * Identifier for the sandbox implementation type.
    * Used to conditionally adjust agent behavior (e.g., disable git instructions).
    */
-  readonly type?: string;
+  readonly type: SandboxType;
 
   /**
    * The working directory for this sandbox.

--- a/packages/sandbox/just-bash.ts
+++ b/packages/sandbox/just-bash.ts
@@ -1,10 +1,10 @@
-import { Bash, OverlayFs } from "just-bash";
 import type { Dirent } from "fs";
+import { Bash, OverlayFs } from "just-bash";
 import type {
-  Sandbox,
-  SandboxStats,
   ExecResult,
+  Sandbox,
   SandboxHooks,
+  SandboxStats,
 } from "./interface";
 
 const MAX_OUTPUT_LENGTH = 50_000;
@@ -65,7 +65,7 @@ export interface JustBashSandboxConfig {
  * - Full lifecycle hook support
  */
 export class JustBashSandbox implements Sandbox {
-  readonly type = "just-bash";
+  readonly type = "in-memory" as const;
   readonly workingDirectory: string;
   readonly env?: Record<string, string>;
   readonly hooks?: SandboxHooks;

--- a/packages/sandbox/local.ts
+++ b/packages/sandbox/local.ts
@@ -1,7 +1,7 @@
-import * as fs from "fs/promises";
 import { spawn } from "child_process";
 import type { Dirent } from "fs";
-import type { Sandbox, SandboxStats, ExecResult } from "./interface";
+import * as fs from "fs/promises";
+import type { ExecResult, Sandbox, SandboxStats } from "./interface";
 
 const MAX_OUTPUT_LENGTH = 50_000;
 
@@ -13,7 +13,7 @@ const MAX_OUTPUT_LENGTH = 50_000;
  * Use VercelSandbox for hooks support.
  */
 export class LocalSandbox implements Sandbox {
-  readonly type = "local";
+  readonly type = "local" as const;
   readonly workingDirectory: string;
   readonly env?: Record<string, string>;
   readonly environmentDetails = `- Full shell access with all standard CLI tools

--- a/packages/sandbox/vercel.ts
+++ b/packages/sandbox/vercel.ts
@@ -1,13 +1,13 @@
 import { Sandbox as VercelSandboxSDK } from "@vercel/sandbox";
 import type { Dirent } from "fs";
 import type {
-  Sandbox,
-  SandboxStats,
   ExecResult,
+  RestoreOptions,
+  Sandbox,
   SandboxHooks,
+  SandboxStats,
   SnapshotOptions,
   SnapshotResult,
-  RestoreOptions,
 } from "./interface";
 
 const MAX_OUTPUT_LENGTH = 50_000;
@@ -80,7 +80,7 @@ export interface VercelSandboxConfig {
  * Runs code in isolated Firecracker MicroVMs.
  */
 export class VercelSandbox implements Sandbox {
-  readonly type = "vercel";
+  readonly type = "cloud" as const;
   /**
    * Unique identifier for this sandbox.
    * Use this to reconnect to an existing sandbox via `connectVercelSandbox({ sandboxId })`.


### PR DESCRIPTION
Introduces a new `SandboxType` union type to standardize sandbox implementation identifiers across the codebase.

- Added `SandboxType = "local" | "in-memory" | "cloud"` enum to replace ad-hoc string values
- Updated `Sandbox.type` property from optional `string?` to required `SandboxType`
- Changed sandbox implementations to use typed constants: LocalSandbox → "local", JustBashSandbox → "in-memory", VercelSandbox → "cloud"
- Alphabetized imports and exports throughout for consistency