### PR TITLE
Reorder sandbox options and make environmentDetails dynamic

### DIFF
--- a/apps/web/components/sandbox-selector-compact.tsx
+++ b/apps/web/components/sandbox-selector-compact.tsx
@@ -26,11 +26,6 @@ interface SandboxOption {
 
 const SANDBOX_OPTIONS: SandboxOption[] = [
   {
-    id: "hybrid",
-    name: "Hybrid",
-    description: "Starts in-memory, hands off to cloud",
-  },
-  {
     id: "vercel",
     name: "Vercel",
     description: "Full cloud sandbox",
@@ -39,6 +34,11 @@ const SANDBOX_OPTIONS: SandboxOption[] = [
     id: "just-bash",
     name: "Just Bash",
     description: "In-memory bash-only sandbox",
+  },
+  {
+    id: "hybrid",
+    name: "Hybrid",
+    description: "Starts in-memory, hands off to cloud",
   },
 ];
 

--- a/packages/sandbox/hybrid/sandbox.ts
+++ b/packages/sandbox/hybrid/sandbox.ts
@@ -78,7 +78,6 @@ export interface HybridSandboxConfig {
  */
 export class HybridSandbox implements Sandbox {
   readonly type = "hybrid" as const;
-  readonly environmentDetails: string | undefined;
   readonly expiresAt: number | undefined;
   readonly timeout: number | undefined;
 
@@ -92,9 +91,22 @@ export class HybridSandbox implements Sandbox {
     this.justBash = config.justBash;
     this._pendingOperations = config.pendingOperations ?? [];
     this.onVercelRequired = config.onVercelRequired;
-    this.environmentDetails = this.justBash.environmentDetails;
     this.expiresAt = this.justBash.expiresAt;
     this.timeout = this.justBash.timeout;
+  }
+
+  /**
+   * Environment details - dynamically returns the correct details based on state.
+   * After handoff to Vercel, returns Vercel's environment details (with Git available).
+   * Before/during handoff, returns JustBash's environment details (no Git).
+   */
+  get environmentDetails(): string | undefined {
+    // After handoff complete, use Vercel's environment details
+    if (this.state === "vercel" && this.vercel) {
+      return this.vercel.environmentDetails;
+    }
+    // Before or during handoff, use JustBash's environment details
+    return this.justBash?.environmentDetails;
   }
 
   /**


### PR DESCRIPTION
This PR makes two related changes to improve sandbox behavior:

- **Reordered sandbox options**: Moved the Hybrid option to the end of the list in the UI, keeping Vercel and Just Bash as the primary choices
- **Made environmentDetails dynamic**: Converted `environmentDetails` from a static property to a getter that returns the correct environment details based on sandbox state—Vercel's details (with Git) after handoff, or JustBash's details (without Git) before/during handoff

This ensures users see the appropriate environment capabilities as the sandbox transitions between in-memory and cloud execution.