### PR TITLE
Migrate data fetching to SWR and simplify diff/files state management

### DIFF
--- a/apps/web/app/tasks/[id]/diff-viewer.tsx
+++ b/apps/web/app/tasks/[id]/diff-viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { ChevronDown, ChevronRight, X, FileText, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -8,7 +8,6 @@ import type { DiffFile } from "@/app/api/tasks/[id]/diff/route";
 import { useTaskChatContext } from "./task-context";
 
 type DiffViewerProps = {
-  refreshKey: number;
   onClose: () => void;
 };
 
@@ -223,21 +222,13 @@ function FileEntry({
   );
 }
 
-export function DiffViewer({ refreshKey, onClose }: DiffViewerProps) {
-  const { diffCache, fetchDiff, diffRefreshKey, sandboxInfo } =
+export function DiffViewer({ onClose }: DiffViewerProps) {
+  const { diff, diffLoading, diffError, diffCachedAt, sandboxInfo } =
     useTaskChatContext();
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
 
-  const { data, error, isLoading, cachedAt } = diffCache;
-
   // Show stale indicator if sandbox is offline (even if data came from a live fetch earlier)
-  const showStaleIndicator = !sandboxInfo && data !== null;
-
-  // Fetch diff on mount and when refreshKey changes
-  // The fetchDiff function will skip if cache is still valid
-  useEffect(() => {
-    fetchDiff();
-  }, [fetchDiff, refreshKey, diffRefreshKey]);
+  const showStaleIndicator = !sandboxInfo && diff !== null;
 
   const toggleFile = (path: string) => {
     setExpandedFiles((prev) => {
@@ -252,8 +243,8 @@ export function DiffViewer({ refreshKey, onClose }: DiffViewerProps) {
   };
 
   const expandAll = () => {
-    if (data) {
-      setExpandedFiles(new Set(data.files.map((f) => f.path)));
+    if (diff) {
+      setExpandedFiles(new Set(diff.files.map((f) => f.path)));
     }
   };
 
@@ -267,19 +258,19 @@ export function DiffViewer({ refreshKey, onClose }: DiffViewerProps) {
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <div className="flex items-center gap-3">
           <h2 className="font-medium text-foreground">Changes</h2>
-          {data && data.summary.totalFiles > 0 && (
+          {diff && diff.summary.totalFiles > 0 && (
             <div className="flex items-center gap-2 text-xs">
               <span className="text-green-500">
-                +{data.summary.totalAdditions}
+                +{diff.summary.totalAdditions}
               </span>
               <span className="text-red-400">
-                -{data.summary.totalDeletions}
+                -{diff.summary.totalDeletions}
               </span>
             </div>
           )}
         </div>
         <div className="flex items-center gap-1">
-          {data && data.files.length > 0 && (
+          {diff && diff.files.length > 0 && (
             <>
               <Button
                 variant="ghost"
@@ -311,7 +302,7 @@ export function DiffViewer({ refreshKey, onClose }: DiffViewerProps) {
       </div>
 
       {/* Staleness indicator */}
-      {showStaleIndicator && <StaleBanner cachedAt={cachedAt} />}
+      {showStaleIndicator && <StaleBanner cachedAt={diffCachedAt} />}
 
       {/* Content */}
       <div
@@ -320,27 +311,27 @@ export function DiffViewer({ refreshKey, onClose }: DiffViewerProps) {
           showStaleIndicator && "opacity-90",
         )}
       >
-        {isLoading && (
+        {diffLoading && (
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
         )}
 
-        {error && (
+        {diffError && (
           <div className="px-4 py-8 text-center">
-            <p className="text-sm text-red-400">{error}</p>
+            <p className="text-sm text-red-400">{diffError}</p>
           </div>
         )}
 
-        {!isLoading && !error && data && data.files.length === 0 && (
+        {!diffLoading && !diffError && diff && diff.files.length === 0 && (
           <div className="px-4 py-8 text-center">
             <p className="text-sm text-muted-foreground">No changes detected</p>
           </div>
         )}
 
-        {!isLoading && !error && data && data.files.length > 0 && (
+        {!diffLoading && !diffError && diff && diff.files.length > 0 && (
           <div>
-            {data.files.map((file) => (
+            {diff.files.map((file) => (
               <FileEntry
                 key={file.path}
                 file={file}
@@ -353,9 +344,9 @@ export function DiffViewer({ refreshKey, onClose }: DiffViewerProps) {
       </div>
 
       {/* Footer with file count */}
-      {data && data.files.length > 0 && (
+      {diff && diff.files.length > 0 && (
         <div className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
-          {data.summary.totalFiles} file{data.summary.totalFiles !== 1 && "s"}{" "}
+          {diff.summary.totalFiles} file{diff.summary.totalFiles !== 1 && "s"}{" "}
           changed
         </div>
       )}

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useState,
   useCallback,
-  useRef,
   type ReactNode,
 } from "react";
 import {
@@ -18,9 +17,10 @@ import type { WebAgentUIMessage } from "@/app/types";
 import type { Task } from "@/lib/db/schema";
 import type { SandboxState } from "@open-harness/sandbox";
 import type { DiffResponse } from "@/app/api/tasks/[id]/diff/route";
-import type { CachedDiffResponse } from "@/app/api/tasks/[id]/diff/cached/route";
 import type { FileSuggestion } from "@/app/api/tasks/[id]/files/route";
 import type { ReconnectResponse } from "@/app/api/sandbox/reconnect/route";
+import { useTaskDiff } from "@/hooks/use-task-diff";
+import { useTaskFiles } from "@/hooks/use-task-files";
 
 export type SandboxInfo = {
   createdAt: number;
@@ -35,26 +35,6 @@ export type ReconnectionStatus =
   | "failed"
   | "no_sandbox";
 
-type DiffCacheState = {
-  data: DiffResponse | null;
-  error: string | null;
-  isLoading: boolean;
-  /** The refreshKey value when this data was last fetched */
-  lastFetchedKey: number;
-  /** Whether this is stale cached data (sandbox offline) */
-  isStale: boolean;
-  /** When the cached data was saved (for stale data display) */
-  cachedAt: Date | null;
-};
-
-type FileCacheState = {
-  data: FileSuggestion[] | null;
-  error: string | null;
-  isLoading: boolean;
-  /** The refreshKey value when this data was last fetched */
-  lastFetchedKey: number;
-};
-
 type TaskChatContextValue = {
   task: Task;
   chat: UseChatHelpers<WebAgentUIMessage>;
@@ -65,22 +45,26 @@ type TaskChatContextValue = {
   updateTaskTitle: (title: string) => Promise<void>;
   /** Whether the task had persisted messages when it was loaded */
   hadInitialMessages: boolean;
-  /** Counter that increments when diff should be refreshed */
-  diffRefreshKey: number;
-  /** Trigger a diff refresh (invalidates cache) */
-  triggerDiffRefresh: () => void;
-  /** Cached diff state */
-  diffCache: DiffCacheState;
-  /** Fetch diff data (uses cache if valid, falls back to cached if offline) */
-  fetchDiff: () => Promise<void>;
-  /** Counter that increments when file list should be refreshed */
-  fileRefreshKey: number;
-  /** Trigger a file list refresh (invalidates cache) */
-  triggerFileRefresh: () => void;
-  /** Cached file list state */
-  fileCache: FileCacheState;
-  /** Fetch file list (uses cache if valid) */
-  fetchFiles: () => Promise<void>;
+  /** Diff data (from live sandbox or cache) */
+  diff: DiffResponse | null;
+  /** Whether diff is loading */
+  diffLoading: boolean;
+  /** Diff error message */
+  diffError: string | null;
+  /** Whether diff data is stale (from cache) */
+  diffIsStale: boolean;
+  /** When the cached diff was saved */
+  diffCachedAt: Date | null;
+  /** Trigger a diff refresh */
+  refreshDiff: () => Promise<void>;
+  /** File suggestions from sandbox */
+  files: FileSuggestion[] | null;
+  /** Whether files are loading */
+  filesLoading: boolean;
+  /** Files error message */
+  filesError: string | null;
+  /** Trigger a files refresh */
+  refreshFiles: () => Promise<void>;
   /** Update task snapshot info after saving */
   updateTaskSnapshot: (snapshotUrl: string, snapshotCreatedAt: Date) => void;
   /** Update sandbox type in task state */
@@ -133,7 +117,6 @@ export function TaskChatProvider({
 
   const clearSandboxInfo = useCallback(() => {
     setSandboxInfoState(null);
-    // Clear sandboxState to indicate no active sandbox
     setTask((prev) => ({ ...prev, sandboxState: null }));
   }, []);
 
@@ -155,19 +138,15 @@ export function TaskChatProvider({
       const data = (await response.json()) as ReconnectResponse;
 
       if (data.status === "connected") {
-        // Sandbox is still alive - set info for UI
-        // (actual sandbox connection happens server-side via task.sandboxState)
         setSandboxInfoState({
           createdAt: Date.now(),
-          timeout: 300_000, // 5 minutes default for UI display
+          timeout: 300_000,
         });
         setReconnectionStatus("connected");
       } else if (data.status === "no_sandbox") {
-        // No sandbox state exists
         setTask((prev) => ({ ...prev, sandboxState: null }));
         setReconnectionStatus("no_sandbox");
       } else {
-        // expired or not_found - server has already cleared sandbox state
         setTask((prev) => ({ ...prev, sandboxState: null }));
         setReconnectionStatus("failed");
       }
@@ -188,7 +167,6 @@ export function TaskChatProvider({
     (type: "just-bash" | "vercel" | "hybrid") => {
       setTask((prev) => {
         if (!prev.sandboxState) {
-          // Create minimal sandboxState with just the type
           return {
             ...prev,
             sandboxState: { type } as SandboxState,
@@ -206,245 +184,35 @@ export function TaskChatProvider({
     [],
   );
 
-  const [diffRefreshKey, setDiffRefreshKey] = useState(0);
+  // Use SWR hooks for diff and files
+  const sandboxConnected = sandboxInfo !== null;
 
-  const triggerDiffRefresh = useCallback(() => {
-    setDiffRefreshKey((prev) => prev + 1);
-  }, []);
-
-  // Initialize diff cache with task's cached diff if available (no layout shift)
-  // Note: cachedDiff is stored as jsonb and cast to DiffResponse without runtime validation.
-  // This is safe as long as the schema is only written by our own diff route.
-  const [diffCache, setDiffCache] = useState<DiffCacheState>(() => {
-    if (initialTask.cachedDiff) {
-      return {
-        data: initialTask.cachedDiff as DiffResponse,
-        error: null,
-        isLoading: false,
-        lastFetchedKey: 0,
-        isStale: true,
-        cachedAt: initialTask.cachedDiffUpdatedAt ?? null,
-      };
-    }
-    return {
-      data: null,
-      error: null,
-      isLoading: false,
-      lastFetchedKey: -1, // -1 means never fetched
-      isStale: false,
-      cachedAt: null,
-    };
+  const {
+    diff,
+    isLoading: diffLoading,
+    error: diffError,
+    isStale: diffIsStale,
+    cachedAt: diffCachedAt,
+    refresh: refreshDiffSWR,
+  } = useTaskDiff(task.id, sandboxConnected, {
+    initialData: initialTask.cachedDiff as DiffResponse | null,
+    initialCachedAt: initialTask.cachedDiffUpdatedAt ?? null,
   });
 
-  // Track the current fetch to prevent duplicates and handle race conditions
-  const fetchCounterRef = useRef(0);
-  // Initialize to 0 if we have cached data (matches lastFetchedKey in state)
-  const lastFetchedKeyRef = useRef<number>(initialTask.cachedDiff ? 0 : -1);
-  const fetchingKeyRef = useRef<number | null>(null);
+  const {
+    files,
+    isLoading: filesLoading,
+    error: filesError,
+    refresh: refreshFilesSWR,
+  } = useTaskFiles(task.id, sandboxConnected);
 
-  const fetchDiff = useCallback(async () => {
-    // Skip if we already have data for this key or are already fetching it
-    if (
-      lastFetchedKeyRef.current === diffRefreshKey ||
-      fetchingKeyRef.current === diffRefreshKey
-    ) {
-      return;
-    }
-    fetchingKeyRef.current = diffRefreshKey;
+  const refreshDiff = useCallback(async () => {
+    await refreshDiffSWR();
+  }, [refreshDiffSWR]);
 
-    // Increment counter and capture this fetch's ID
-    const thisFetchId = ++fetchCounterRef.current;
-
-    setDiffCache((prev) => ({
-      ...prev,
-      isLoading: true,
-      error: null,
-    }));
-
-    // If no sandbox connected, go directly to cached endpoint
-    if (!sandboxInfo) {
-      try {
-        const cachedRes = await fetch(`/api/tasks/${task.id}/diff/cached`);
-        if (cachedRes.ok) {
-          const cachedData = (await cachedRes.json()) as CachedDiffResponse;
-          if (thisFetchId === fetchCounterRef.current) {
-            lastFetchedKeyRef.current = diffRefreshKey;
-            setDiffCache({
-              data: cachedData.data,
-              error: null,
-              isLoading: false,
-              lastFetchedKey: diffRefreshKey,
-              isStale: true,
-              cachedAt: new Date(cachedData.cachedAt),
-            });
-          }
-          return;
-        }
-      } catch {
-        // Ignore cached fetch errors
-      }
-
-      if (thisFetchId === fetchCounterRef.current) {
-        lastFetchedKeyRef.current = diffRefreshKey;
-        setDiffCache((prev) => ({
-          ...prev,
-          error: "No sandbox available and no cached diff",
-          isLoading: false,
-          lastFetchedKey: diffRefreshKey,
-          isStale: false,
-          cachedAt: null,
-        }));
-      }
-      return;
-    }
-
-    try {
-      const res = await fetch(`/api/tasks/${task.id}/diff`);
-
-      if (!res.ok) {
-        const errorData = (await res.json()) as { error?: string };
-        throw new Error(errorData.error ?? "Failed to fetch diff");
-      }
-
-      const data = (await res.json()) as DiffResponse;
-
-      // Only update if this is still the latest fetch
-      if (thisFetchId === fetchCounterRef.current) {
-        lastFetchedKeyRef.current = diffRefreshKey;
-        setDiffCache({
-          data,
-          error: null,
-          isLoading: false,
-          lastFetchedKey: diffRefreshKey,
-          isStale: false,
-          cachedAt: null,
-        });
-        // Update local task state so cachedDiff is available when sandbox shuts down
-        setTask((prev) => ({
-          ...prev,
-          cachedDiff: data,
-          cachedDiffUpdatedAt: new Date(),
-        }));
-      }
-      // If not the latest fetch, don't update - the newer fetch will handle it
-    } catch (err) {
-      // Try to load cached diff as fallback
-      try {
-        const cachedRes = await fetch(`/api/tasks/${task.id}/diff/cached`);
-        if (cachedRes.ok) {
-          const cachedData = (await cachedRes.json()) as CachedDiffResponse;
-          if (thisFetchId === fetchCounterRef.current) {
-            lastFetchedKeyRef.current = diffRefreshKey;
-            setDiffCache({
-              data: cachedData.data,
-              error: null,
-              isLoading: false,
-              lastFetchedKey: diffRefreshKey,
-              isStale: true,
-              cachedAt: new Date(cachedData.cachedAt),
-            });
-          }
-          return;
-        }
-      } catch {
-        // Ignore cached fetch errors
-      }
-
-      // No cached data available - show original error
-      if (thisFetchId === fetchCounterRef.current) {
-        lastFetchedKeyRef.current = diffRefreshKey;
-        setDiffCache((prev) => ({
-          ...prev,
-          error: err instanceof Error ? err.message : "Failed to fetch diff",
-          isLoading: false,
-          lastFetchedKey: diffRefreshKey,
-          isStale: false,
-          cachedAt: null,
-        }));
-      }
-    }
-  }, [task.id, diffRefreshKey, sandboxInfo]);
-
-  // File cache state (mirrors diff cache pattern)
-  const [fileRefreshKey, setFileRefreshKey] = useState(0);
-
-  const triggerFileRefresh = useCallback(() => {
-    setFileRefreshKey((prev) => prev + 1);
-  }, []);
-
-  const [fileCache, setFileCache] = useState<FileCacheState>({
-    data: null,
-    error: null,
-    isLoading: false,
-    lastFetchedKey: -1,
-  });
-
-  const fileFetchCounterRef = useRef(0);
-  const fileLastFetchedKeyRef = useRef<number>(-1);
-  const fileFetchingKeyRef = useRef<number | null>(null);
-
-  const fetchFiles = useCallback(async () => {
-    if (
-      fileLastFetchedKeyRef.current === fileRefreshKey ||
-      fileFetchingKeyRef.current === fileRefreshKey
-    ) {
-      return;
-    }
-    fileFetchingKeyRef.current = fileRefreshKey;
-
-    const thisFetchId = ++fileFetchCounterRef.current;
-
-    setFileCache((prev) => ({
-      ...prev,
-      isLoading: true,
-      error: null,
-    }));
-
-    // If no sandbox connected, skip
-    if (!sandboxInfo) {
-      if (thisFetchId === fileFetchCounterRef.current) {
-        fileLastFetchedKeyRef.current = fileRefreshKey;
-        setFileCache((prev) => ({
-          ...prev,
-          error: "No sandbox available",
-          isLoading: false,
-          lastFetchedKey: fileRefreshKey,
-        }));
-      }
-      return;
-    }
-
-    try {
-      const res = await fetch(`/api/tasks/${task.id}/files`);
-
-      if (!res.ok) {
-        const errorData = (await res.json()) as { error?: string };
-        throw new Error(errorData.error ?? "Failed to fetch files");
-      }
-
-      const data = (await res.json()) as { files: FileSuggestion[] };
-
-      if (thisFetchId === fileFetchCounterRef.current) {
-        fileLastFetchedKeyRef.current = fileRefreshKey;
-        setFileCache({
-          data: data.files,
-          error: null,
-          isLoading: false,
-          lastFetchedKey: fileRefreshKey,
-        });
-      }
-    } catch (err) {
-      if (thisFetchId === fileFetchCounterRef.current) {
-        fileLastFetchedKeyRef.current = fileRefreshKey;
-        setFileCache((prev) => ({
-          ...prev,
-          error: err instanceof Error ? err.message : "Failed to fetch files",
-          isLoading: false,
-          lastFetchedKey: fileRefreshKey,
-        }));
-      }
-    }
-  }, [task.id, fileRefreshKey, sandboxInfo]);
+  const refreshFiles = useCallback(async () => {
+    await refreshFilesSWR();
+  }, [refreshFilesSWR]);
 
   const archiveTask = useCallback(async () => {
     const res = await fetch(`/api/tasks/${task.id}`, {
@@ -485,7 +253,6 @@ export function TaskChatProvider({
     [task.id],
   );
 
-  // Track whether we started with persisted messages (for initial message logic)
   const hadInitialMessages = initialMessages.length > 0;
 
   return (
@@ -499,14 +266,16 @@ export function TaskChatProvider({
         archiveTask,
         updateTaskTitle,
         hadInitialMessages,
-        diffRefreshKey,
-        triggerDiffRefresh,
-        diffCache,
-        fetchDiff,
-        fileRefreshKey,
-        triggerFileRefresh,
-        fileCache,
-        fetchFiles,
+        diff,
+        diffLoading,
+        diffError,
+        diffIsStale,
+        diffCachedAt,
+        refreshDiff,
+        files,
+        filesLoading,
+        filesError,
+        refreshFiles,
         updateTaskSnapshot,
         setSandboxType,
         reconnectionStatus,

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useState,
   useCallback,
+  useEffect,
   type ReactNode,
 } from "react";
 import {
@@ -207,6 +208,18 @@ export function TaskChatProvider({
     error: filesError,
     refresh: refreshFilesSWR,
   } = useTaskFiles(task.id, sandboxConnected);
+
+  // Update local task state when fresh diff data is received from the live sandbox.
+  // This ensures cachedDiff is available when the sandbox disconnects.
+  useEffect(() => {
+    if (diff && !diffIsStale) {
+      setTask((prev) => ({
+        ...prev,
+        cachedDiff: diff,
+        cachedDiffUpdatedAt: new Date(),
+      }));
+    }
+  }, [diff, diffIsStale]);
 
   const refreshDiff = useCallback(async () => {
     await refreshDiffSWR();

--- a/apps/web/app/tasks/[id]/task-context.tsx
+++ b/apps/web/app/tasks/[id]/task-context.tsx
@@ -187,6 +187,8 @@ export function TaskChatProvider({
   // Use SWR hooks for diff and files
   const sandboxConnected = sandboxInfo !== null;
 
+  // Note: cachedDiff is stored as jsonb and cast to DiffResponse without runtime validation.
+  // This is safe as long as the schema is only written by our own diff route.
   const {
     diff,
     isLoading: diffLoading,

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -1013,7 +1013,9 @@ export function TaskDetailContent() {
         hasAutoOpenedDiffRef.current = true;
         setShowDiffPanel(true);
       }
-      // Refresh diff and files when files change
+      // Refresh diff and files when files change.
+      // These are fire-and-forget calls - SWR handles request deduplication
+      // and cleanup internally, so no await needed.
       refreshDiff();
       refreshFiles();
     }

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -599,13 +599,11 @@ export function TaskDetailContent() {
     archiveTask,
     updateTaskTitle,
     hadInitialMessages,
-    diffRefreshKey,
-    triggerDiffRefresh,
-    diffCache,
-    fetchDiff,
-    fileCache,
-    fetchFiles,
-    triggerFileRefresh,
+    diff,
+    refreshDiff,
+    files,
+    filesLoading,
+    refreshFiles,
     updateTaskSnapshot,
     setSandboxType,
     reconnectionStatus,
@@ -652,7 +650,7 @@ export function TaskDetailContent() {
   } = useFileSuggestions({
     inputValue: input,
     cursorPosition,
-    files: fileCache.data,
+    files,
     onSelect: handleFileSelect,
   });
 
@@ -1015,9 +1013,9 @@ export function TaskDetailContent() {
         hasAutoOpenedDiffRef.current = true;
         setShowDiffPanel(true);
       }
-      // Always invalidate cache when files change
-      triggerDiffRefresh();
-      triggerFileRefresh();
+      // Refresh diff and files when files change
+      refreshDiff();
+      refreshFiles();
     }
   }, [
     currentToolStates,
@@ -1025,30 +1023,12 @@ export function TaskDetailContent() {
     showDiffPanel,
     sandboxInfo,
     task.sandboxState?.type,
-    triggerDiffRefresh,
-    triggerFileRefresh,
+    refreshDiff,
+    refreshFiles,
   ]);
 
-  // Fetch files when sandbox becomes available
-  useEffect(() => {
-    if (sandboxInfo && !fileCache.data && !fileCache.isLoading) {
-      fetchFiles();
-    }
-  }, [sandboxInfo, fileCache.data, fileCache.isLoading, fetchFiles]);
-
-  // Fetch diff proactively (from sandbox or cached) to show stats in header
-  useEffect(() => {
-    // Fetch on mount (for cached data) or when sandbox/diffRefreshKey changes
-    if (!diffCache.isLoading && diffCache.lastFetchedKey !== diffRefreshKey) {
-      fetchDiff();
-    }
-  }, [
-    sandboxInfo,
-    diffRefreshKey,
-    diffCache.isLoading,
-    diffCache.lastFetchedKey,
-    fetchDiff,
-  ]);
+  // Note: SWR handles automatic fetching when sandbox becomes available
+  // and caching/deduplication of requests
 
   // Get token usage from the most recent assistant message (current context usage)
   const tokenUsage = useMemo(() => {
@@ -1221,19 +1201,19 @@ export function TaskDetailContent() {
                 variant="ghost"
                 size="sm"
                 onClick={() => setShowDiffPanel(!showDiffPanel)}
-                disabled={!diffCache.data && !task.cachedDiff}
+                disabled={!diff && !task.cachedDiff}
               >
                 <GitCompare className="mr-2 h-4 w-4" />
                 Diff
-                {diffCache.data &&
-                  (diffCache.data.summary.totalAdditions > 0 ||
-                    diffCache.data.summary.totalDeletions > 0) && (
+                {diff &&
+                  (diff.summary.totalAdditions > 0 ||
+                    diff.summary.totalDeletions > 0) && (
                     <span className="ml-2 text-xs">
                       <span className="text-green-500">
-                        +{diffCache.data.summary.totalAdditions}
+                        +{diff.summary.totalAdditions}
                       </span>{" "}
                       <span className="text-red-400">
-                        -{diffCache.data.summary.totalDeletions}
+                        -{diff.summary.totalDeletions}
                       </span>
                     </span>
                   )}
@@ -1494,7 +1474,7 @@ export function TaskDetailContent() {
                       );
                     }
                   }}
-                  isLoading={fileCache.isLoading}
+                  isLoading={filesLoading}
                 />
               )}
               <form
@@ -1701,10 +1681,7 @@ export function TaskDetailContent() {
 
       {/* Diff Viewer Panel */}
       {showDiffPanel && (sandboxInfo || Boolean(task.cachedDiff)) && (
-        <DiffViewer
-          refreshKey={diffRefreshKey}
-          onClose={() => setShowDiffPanel(false)}
-        />
+        <DiffViewer onClose={() => setShowDiffPanel(false)} />
       )}
     </div>
   );

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -1014,10 +1014,10 @@ export function TaskDetailContent() {
         setShowDiffPanel(true);
       }
       // Refresh diff and files when files change.
-      // These are fire-and-forget calls - SWR handles request deduplication
-      // and cleanup internally, so no await needed.
-      refreshDiff();
-      refreshFiles();
+      // Fire-and-forget with error handling - SWR updates error state internally,
+      // but we catch here to prevent unhandled rejection warnings.
+      refreshDiff().catch(() => {});
+      refreshFiles().catch(() => {});
     }
   }, [
     currentToolStates,

--- a/apps/web/components/branch-selector-compact.tsx
+++ b/apps/web/components/branch-selector-compact.tsx
@@ -42,7 +42,11 @@ export function BranchSelectorCompact({
 }: BranchSelectorCompactProps) {
   const [open, setOpen] = useState(false);
 
-  // Track whether we've auto-selected for this owner/repo combo
+  // Track which owner/repo combo we've auto-selected for.
+  // This prevents re-triggering auto-selection when switching between repos,
+  // but intentionally does NOT reset when returning to a previously visited repo.
+  // This means if a user manually clears their selection and switches back,
+  // auto-selection won't re-trigger - treating it as an intentional user action.
   const autoSelectedKeyRef = useRef<string | null>(null);
 
   // Conditional fetch based on owner and repo

--- a/apps/web/components/branch-selector-compact.tsx
+++ b/apps/web/components/branch-selector-compact.tsx
@@ -58,6 +58,9 @@ export function BranchSelectorCompact({
 
   // Auto-select default branch when data loads (only once per owner/repo combo)
   useEffect(() => {
+    // Guard against undefined owner/repo to prevent matching "undefined/undefined"
+    if (!owner || !repo) return;
+
     const key = `${owner}/${repo}`;
     if (
       data?.defaultBranch &&

--- a/apps/web/components/branch-selector-compact.tsx
+++ b/apps/web/components/branch-selector-compact.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import useSWR from "swr";
 import { GitBranch, ChevronDown, CheckIcon, PlusIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { fetcher } from "@/lib/swr";
 import {
   Popover,
   PopoverContent,
@@ -39,50 +41,34 @@ export function BranchSelectorCompact({
   onChange,
 }: BranchSelectorCompactProps) {
   const [open, setOpen] = useState(false);
-  const [branches, setBranches] = useState<string[]>([]);
-  const [defaultBranch, setDefaultBranch] = useState("main");
-  const [loading, setLoading] = useState(false);
 
-  // Use refs to avoid dependency issues in useEffect
-  const valueRef = useRef(value);
-  const isNewBranchRef = useRef(isNewBranch);
-  const onChangeRef = useRef(onChange);
-  valueRef.current = value;
-  isNewBranchRef.current = isNewBranch;
-  onChangeRef.current = onChange;
+  // Track whether we've auto-selected for this owner/repo combo
+  const autoSelectedKeyRef = useRef<string | null>(null);
 
+  // Conditional fetch based on owner and repo
+  const { data, isLoading } = useSWR<BranchesResponse>(
+    owner && repo
+      ? `/api/github/branches?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`
+      : null,
+    fetcher,
+  );
+
+  const branches = data?.branches ?? [];
+  const defaultBranch = data?.defaultBranch ?? "main";
+
+  // Auto-select default branch when data loads (only once per owner/repo combo)
   useEffect(() => {
-    if (!owner || !repo) {
-      setBranches([]);
-      return;
+    const key = `${owner}/${repo}`;
+    if (
+      data?.defaultBranch &&
+      !value &&
+      !isNewBranch &&
+      autoSelectedKeyRef.current !== key
+    ) {
+      autoSelectedKeyRef.current = key;
+      onChange(data.defaultBranch, false);
     }
-
-    const fetchBranches = async () => {
-      setLoading(true);
-      try {
-        const response = await fetch(
-          `/api/github/branches?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`,
-        );
-        if (!response.ok) {
-          throw new Error("Failed to fetch branches");
-        }
-        const data = (await response.json()) as BranchesResponse;
-        setBranches(data.branches);
-        setDefaultBranch(data.defaultBranch);
-        // Auto-select default branch if no value is set and not creating new branch
-        if (!valueRef.current && !isNewBranchRef.current) {
-          onChangeRef.current(data.defaultBranch, false);
-        }
-      } catch (err) {
-        console.error("Failed to fetch branches:", err);
-        setBranches([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchBranches();
-  }, [owner, repo]);
+  }, [data, value, isNewBranch, onChange, owner, repo]);
 
   const handleSelectBranch = (branch: string) => {
     onChange(branch, false);
@@ -94,9 +80,8 @@ export function BranchSelectorCompact({
     setOpen(false);
   };
 
-  // Determine display text
   const getDisplayText = () => {
-    if (loading) return "Loading...";
+    if (isLoading) return "Loading...";
     if (isNewBranch) return "New branch (auto)";
     return value || defaultBranch || "main";
   };
@@ -118,7 +103,7 @@ export function BranchSelectorCompact({
           <CommandInput placeholder="Search branches..." />
           <CommandList>
             <CommandEmpty>
-              {loading ? "Loading..." : "No branches found."}
+              {isLoading ? "Loading..." : "No branches found."}
             </CommandEmpty>
             <CommandGroup>
               {branches.map((branch) => (

--- a/apps/web/components/model-selector-compact.tsx
+++ b/apps/web/components/model-selector-compact.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import useSWR from "swr";
 import { ChevronDown, CheckIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { fetcher } from "@/lib/swr";
 import {
   Popover,
   PopoverContent,
@@ -27,34 +29,18 @@ interface ModelSelectorCompactProps {
   onChange: (modelId: string) => void;
 }
 
+interface ModelsResponse {
+  models: AvailableModel[];
+}
+
 export function ModelSelectorCompact({
   value,
   onChange,
 }: ModelSelectorCompactProps) {
   const [open, setOpen] = useState(false);
-  const [models, setModels] = useState<AvailableModel[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data, isLoading } = useSWR<ModelsResponse>("/api/models", fetcher);
 
-  useEffect(() => {
-    const fetchModels = async () => {
-      setLoading(true);
-      try {
-        const response = await fetch("/api/models");
-        if (!response.ok) {
-          throw new Error("Failed to fetch models");
-        }
-        const data = (await response.json()) as { models: AvailableModel[] };
-        setModels(data.models);
-      } catch (err) {
-        console.error("Failed to fetch models:", err);
-        setModels([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchModels();
-  }, []);
+  const models = data?.models ?? [];
 
   const handleSelect = (modelId: string) => {
     onChange(modelId);
@@ -62,7 +48,7 @@ export function ModelSelectorCompact({
   };
 
   const selectedModel = models.find((m) => m.id === value);
-  const displayText = loading
+  const displayText = isLoading
     ? "Loading..."
     : selectedModel
       ? getModelDisplayName(selectedModel)
@@ -84,7 +70,7 @@ export function ModelSelectorCompact({
           <CommandInput placeholder="Search models..." />
           <CommandList>
             <CommandEmpty>
-              {loading ? "Loading..." : "No models found."}
+              {isLoading ? "Loading..." : "No models found."}
             </CommandEmpty>
             <CommandGroup>
               {models.map((model) => (

--- a/apps/web/components/repo-selector-compact.tsx
+++ b/apps/web/components/repo-selector-compact.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import useSWR from "swr";
 import {
   Folder,
@@ -74,18 +74,13 @@ export function RepoSelectorCompact({
   const [open, setOpen] = useState(false);
   const [currentOwner, setCurrentOwner] = useState(selectedOwner);
 
+  // Track whether we've auto-selected an owner
+  const hasAutoSelectedRef = useRef(false);
+
   // Fetch owners (user + orgs)
   const { data: owners = [], isLoading: ownersLoading } = useSWR<Owner[]>(
     "github-owners",
     fetchOwners,
-    {
-      onSuccess: (data) => {
-        // Auto-select first owner if none selected
-        if (!currentOwner && data[0]) {
-          setCurrentOwner(data[0].login);
-        }
-      },
-    },
   );
 
   // Fetch repos for current owner (conditional fetch)
@@ -93,6 +88,14 @@ export function RepoSelectorCompact({
     currentOwner ? `/api/github/repos?owner=${currentOwner}` : null,
     fetcher,
   );
+
+  // Auto-select first owner when data loads (only once)
+  useEffect(() => {
+    if (owners[0] && !currentOwner && !hasAutoSelectedRef.current) {
+      hasAutoSelectedRef.current = true;
+      setCurrentOwner(owners[0].login);
+    }
+  }, [owners, currentOwner]);
 
   // Sync currentOwner with selectedOwner prop
   useEffect(() => {

--- a/apps/web/components/repo-selector-compact.tsx
+++ b/apps/web/components/repo-selector-compact.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
+import useSWR from "swr";
 import {
   Folder,
   ChevronDown,
@@ -9,6 +10,7 @@ import {
   Loader2Icon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { fetcher } from "@/lib/swr";
 import {
   Popover,
   PopoverContent,
@@ -43,77 +45,61 @@ interface RepoSelectorCompactProps {
   onSelect: (owner: string, repo: string) => void;
 }
 
+async function fetchOwners(): Promise<Owner[]> {
+  const [userRes, orgsRes] = await Promise.all([
+    fetch("/api/github/user"),
+    fetch("/api/github/orgs"),
+  ]);
+
+  if (!userRes.ok) return [];
+
+  const user = (await userRes.json()) as Owner;
+  const orgs = orgsRes.ok ? ((await orgsRes.json()) as Owner[]) : [];
+
+  return [
+    {
+      login: user.login,
+      name: user.name || user.login,
+      avatar_url: user.avatar_url,
+    },
+    ...orgs,
+  ];
+}
+
 export function RepoSelectorCompact({
   selectedOwner,
   selectedRepo,
   onSelect,
 }: RepoSelectorCompactProps) {
   const [open, setOpen] = useState(false);
-  const [owners, setOwners] = useState<Owner[]>([]);
-  const [repos, setRepos] = useState<Repo[]>([]);
   const [currentOwner, setCurrentOwner] = useState(selectedOwner);
-  const [ownersLoading, setOwnersLoading] = useState(true);
-  const [reposLoading, setReposLoading] = useState(false);
 
-  // Use ref to track if we've already set a default owner
-  const hasSetDefaultOwner = useRef(false);
-
-  useEffect(() => {
-    const loadOwners = async () => {
-      setOwnersLoading(true);
-      try {
-        const [userRes, orgsRes] = await Promise.all([
-          fetch("/api/github/user"),
-          fetch("/api/github/orgs"),
-        ]);
-
-        if (!userRes.ok) return;
-
-        const user = (await userRes.json()) as Owner;
-        const orgs = orgsRes.ok ? ((await orgsRes.json()) as Owner[]) : [];
-
-        const allOwners = [
-          {
-            login: user.login,
-            name: user.name || user.login,
-            avatar_url: user.avatar_url,
-          },
-          ...orgs,
-        ];
-        setOwners(allOwners);
-        if (!hasSetDefaultOwner.current && allOwners[0]) {
-          hasSetDefaultOwner.current = true;
-          setCurrentOwner(allOwners[0].login);
+  // Fetch owners (user + orgs)
+  const { data: owners = [], isLoading: ownersLoading } = useSWR<Owner[]>(
+    "github-owners",
+    fetchOwners,
+    {
+      onSuccess: (data) => {
+        // Auto-select first owner if none selected
+        if (!currentOwner && data[0]) {
+          setCurrentOwner(data[0].login);
         }
-      } catch (err) {
-        console.error("Failed to load owners:", err);
-      } finally {
-        setOwnersLoading(false);
-      }
-    };
+      },
+    },
+  );
 
-    loadOwners();
-  }, []);
+  // Fetch repos for current owner (conditional fetch)
+  const { data: repos = [], isLoading: reposLoading } = useSWR<Repo[]>(
+    currentOwner ? `/api/github/repos?owner=${currentOwner}` : null,
+    fetcher,
+  );
 
+  // Sync currentOwner with selectedOwner prop
   useEffect(() => {
-    if (!currentOwner) return;
-
-    const loadRepos = async () => {
-      setReposLoading(true);
-      setRepos([]);
-      try {
-        const res = await fetch(`/api/github/repos?owner=${currentOwner}`);
-        const data = (await res.json()) as Repo[];
-        setRepos(data);
-      } catch (error) {
-        console.error("Failed to load repos:", error);
-      } finally {
-        setReposLoading(false);
-      }
-    };
-
-    loadRepos();
-  }, [currentOwner]);
+    if (selectedOwner && selectedOwner !== currentOwner) {
+      setCurrentOwner(selectedOwner);
+    }
+  }, [selectedOwner, currentOwner]);
 
   const handleRepoSelect = (repo: Repo) => {
     onSelect(currentOwner, repo.name);

--- a/apps/web/hooks/use-session.ts
+++ b/apps/web/hooks/use-session.ts
@@ -1,32 +1,22 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
 import type { SessionUserInfo } from "@/lib/session/types";
 
 export function useSession() {
-  const [session, setSession] = useState<SessionUserInfo | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { data, isLoading } = useSWR<SessionUserInfo>(
+    "/api/auth/info",
+    fetcher,
+    {
+      revalidateOnFocus: true,
+      fallbackData: { user: undefined },
+    },
+  );
 
-  useEffect(() => {
-    const fetchSession = async () => {
-      try {
-        const res = await fetch("/api/auth/info");
-        const data = (await res.json()) as SessionUserInfo;
-        setSession(data);
-      } catch (error) {
-        console.error("Failed to fetch session:", error);
-        setSession({ user: undefined });
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchSession();
-
-    const handleFocus = () => fetchSession();
-    window.addEventListener("focus", handleFocus);
-    return () => window.removeEventListener("focus", handleFocus);
-  }, []);
-
-  return { session, loading, isAuthenticated: !!session?.user };
+  return {
+    session: data ?? null,
+    loading: isLoading,
+    isAuthenticated: !!data?.user,
+  };
 }

--- a/apps/web/hooks/use-task-diff.ts
+++ b/apps/web/hooks/use-task-diff.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import type { DiffResponse } from "@/app/api/tasks/[id]/diff/route";
+import type { CachedDiffResponse } from "@/app/api/tasks/[id]/diff/cached/route";
+
+export interface UseTaskDiffOptions {
+  /** Initial cached diff data to show while loading */
+  initialData?: DiffResponse | null;
+  /** Initial cached timestamp */
+  initialCachedAt?: Date | null;
+}
+
+export interface UseTaskDiffReturn {
+  diff: DiffResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  /** Whether the data is from cache (sandbox offline) */
+  isStale: boolean;
+  /** When the cached data was saved */
+  cachedAt: Date | null;
+  /** Trigger a refresh */
+  refresh: () => Promise<DiffResponse | undefined>;
+}
+
+export function useTaskDiff(
+  taskId: string,
+  sandboxConnected: boolean,
+  options?: UseTaskDiffOptions,
+): UseTaskDiffReturn {
+  // Primary: fetch from live sandbox when connected
+  const {
+    data: liveData,
+    error: liveError,
+    isLoading: liveLoading,
+    mutate: mutateLive,
+  } = useSWR<DiffResponse>(
+    sandboxConnected ? `/api/tasks/${taskId}/diff` : null,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      // Don't show stale data when reconnecting - let the cached endpoint handle it
+      revalidateIfStale: true,
+    },
+  );
+
+  // Fallback: fetch cached diff when sandbox disconnected
+  const {
+    data: cachedData,
+    error: cachedError,
+    isLoading: cachedLoading,
+  } = useSWR<CachedDiffResponse>(
+    !sandboxConnected ? `/api/tasks/${taskId}/diff/cached` : null,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  // Determine which data to use
+  if (sandboxConnected) {
+    return {
+      diff: liveData ?? options?.initialData ?? null,
+      isLoading: liveLoading,
+      error: liveError?.message ?? null,
+      isStale: false,
+      cachedAt: null,
+      refresh: mutateLive,
+    };
+  }
+
+  // Sandbox disconnected - use cached data
+  if (cachedData) {
+    return {
+      diff: cachedData.data,
+      isLoading: false,
+      error: null,
+      isStale: true,
+      cachedAt: new Date(cachedData.cachedAt),
+      refresh: async () => undefined,
+    };
+  }
+
+  // Use initial data while loading cached
+  if (cachedLoading && options?.initialData) {
+    return {
+      diff: options.initialData,
+      isLoading: true,
+      error: null,
+      isStale: true,
+      cachedAt: options.initialCachedAt ?? null,
+      refresh: async () => undefined,
+    };
+  }
+
+  // No cached data available
+  return {
+    diff: options?.initialData ?? null,
+    isLoading: cachedLoading,
+    error:
+      cachedError?.message ??
+      (!cachedLoading && !options?.initialData
+        ? "No sandbox available and no cached diff"
+        : null),
+    isStale: !!options?.initialData,
+    cachedAt: options?.initialCachedAt ?? null,
+    refresh: async () => undefined,
+  };
+}

--- a/apps/web/hooks/use-task-files.ts
+++ b/apps/web/hooks/use-task-files.ts
@@ -27,11 +27,13 @@ export function useTaskFiles(
     },
   );
 
+  // When sandbox is disconnected, return null state without an error.
+  // This distinguishes "no sandbox to fetch from" from "fetch failed".
   if (!sandboxConnected) {
     return {
       files: null,
       isLoading: false,
-      error: "No sandbox available",
+      error: null,
       refresh: async () => undefined,
     };
   }

--- a/apps/web/hooks/use-task-files.ts
+++ b/apps/web/hooks/use-task-files.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import type {
+  FileSuggestion,
+  FilesResponse,
+} from "@/app/api/tasks/[id]/files/route";
+
+export interface UseTaskFilesReturn {
+  files: FileSuggestion[] | null;
+  isLoading: boolean;
+  error: string | null;
+  /** Trigger a refresh */
+  refresh: () => Promise<FilesResponse | undefined>;
+}
+
+export function useTaskFiles(
+  taskId: string,
+  sandboxConnected: boolean,
+): UseTaskFilesReturn {
+  const { data, error, isLoading, mutate } = useSWR<FilesResponse>(
+    sandboxConnected ? `/api/tasks/${taskId}/files` : null,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  if (!sandboxConnected) {
+    return {
+      files: null,
+      isLoading: false,
+      error: "No sandbox available",
+      refresh: async () => undefined,
+    };
+  }
+
+  return {
+    files: data?.files ?? null,
+    isLoading,
+    error: error?.message ?? null,
+    refresh: mutate,
+  };
+}

--- a/apps/web/hooks/use-tasks.ts
+++ b/apps/web/hooks/use-tasks.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
 import type { Task } from "@/lib/db/schema";
 
 interface CreateTaskInput {
@@ -14,31 +15,19 @@ interface CreateTaskInput {
   modelId?: string;
 }
 
+interface TasksResponse {
+  tasks: Task[];
+}
+
 export function useTasks() {
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data, error, isLoading, mutate } = useSWR<TasksResponse>(
+    "/api/tasks",
+    fetcher,
+  );
 
-  const fetchTasks = useCallback(async () => {
-    try {
-      const res = await fetch("/api/tasks");
-      if (!res.ok) {
-        throw new Error("Failed to fetch tasks");
-      }
-      const data = (await res.json()) as { tasks: Task[] };
-      setTasks(data.tasks);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to fetch tasks");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const tasks = data?.tasks ?? [];
 
-  useEffect(() => {
-    fetchTasks();
-  }, [fetchTasks]);
-
-  const createTask = useCallback(async (input: CreateTaskInput) => {
+  const createTask = async (input: CreateTaskInput) => {
     const res = await fetch("/api/tasks", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -46,16 +35,17 @@ export function useTasks() {
     });
 
     if (!res.ok) {
-      const data = (await res.json()) as { error?: string };
-      throw new Error(data.error ?? "Failed to create task");
+      const errorData = (await res.json()) as { error?: string };
+      throw new Error(errorData.error ?? "Failed to create task");
     }
 
-    const data = (await res.json()) as { task: Task };
-    setTasks((prev) => [data.task, ...prev]);
-    return data.task;
-  }, []);
+    const responseData = (await res.json()) as { task: Task };
+    // Optimistically update the cache
+    mutate({ tasks: [responseData.task, ...tasks] }, false);
+    return responseData.task;
+  };
 
-  const archiveTask = useCallback(async (taskId: string) => {
+  const archiveTask = async (taskId: string) => {
     const res = await fetch(`/api/tasks/${taskId}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -63,21 +53,25 @@ export function useTasks() {
     });
 
     if (!res.ok) {
-      const data = (await res.json()) as { error?: string };
-      throw new Error(data.error ?? "Failed to archive task");
+      const errorData = (await res.json()) as { error?: string };
+      throw new Error(errorData.error ?? "Failed to archive task");
     }
 
-    const data = (await res.json()) as { task: Task };
-    setTasks((prev) => prev.map((t) => (t.id === taskId ? data.task : t)));
-    return data.task;
-  }, []);
+    const responseData = (await res.json()) as { task: Task };
+    // Optimistically update the cache
+    mutate(
+      { tasks: tasks.map((t) => (t.id === taskId ? responseData.task : t)) },
+      false,
+    );
+    return responseData.task;
+  };
 
   return {
     tasks,
-    loading,
-    error,
+    loading: isLoading,
+    error: error?.message ?? null,
     createTask,
     archiveTask,
-    refreshTasks: fetchTasks,
+    refreshTasks: mutate,
   };
 }

--- a/apps/web/hooks/use-tasks.ts
+++ b/apps/web/hooks/use-tasks.ts
@@ -40,8 +40,13 @@ export function useTasks() {
     }
 
     const responseData = (await res.json()) as { task: Task };
-    // Optimistically update the cache
-    mutate({ tasks: [responseData.task, ...tasks] }, false);
+    // Optimistically update the cache using functional form to avoid stale closure
+    mutate(
+      (current) => ({
+        tasks: [responseData.task, ...(current?.tasks ?? [])],
+      }),
+      { revalidate: false },
+    );
     return responseData.task;
   };
 
@@ -58,10 +63,14 @@ export function useTasks() {
     }
 
     const responseData = (await res.json()) as { task: Task };
-    // Optimistically update the cache
+    // Optimistically update the cache using functional form to avoid stale closure
     mutate(
-      { tasks: tasks.map((t) => (t.id === taskId ? responseData.task : t)) },
-      false,
+      (current) => ({
+        tasks: (current?.tasks ?? []).map((t) =>
+          t.id === taskId ? responseData.task : t,
+        ),
+      }),
+      { revalidate: false },
     );
     return responseData.task;
   };

--- a/apps/web/lib/swr.ts
+++ b/apps/web/lib/swr.ts
@@ -1,0 +1,23 @@
+import type { SWRConfiguration } from "swr";
+
+export const fetcher = async <T>(url: string): Promise<T> => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const error = new Error("Fetch failed");
+    try {
+      const data = (await res.json()) as { error?: string };
+      error.message = data.error ?? res.statusText;
+    } catch {
+      error.message = res.statusText;
+    }
+    throw error;
+  }
+  return res.json() as Promise<T>;
+};
+
+export const swrConfig: SWRConfiguration = {
+  fetcher,
+  revalidateOnFocus: true,
+  dedupingInterval: 2000,
+  errorRetryCount: 3,
+};

--- a/apps/web/lib/swr.ts
+++ b/apps/web/lib/swr.ts
@@ -1,5 +1,7 @@
-import type { SWRConfiguration } from "swr";
-
+/**
+ * Default fetcher for SWR hooks.
+ * Parses JSON responses and extracts error messages from failed requests.
+ */
 export const fetcher = async <T>(url: string): Promise<T> => {
   const res = await fetch(url);
   if (!res.ok) {
@@ -15,9 +17,10 @@ export const fetcher = async <T>(url: string): Promise<T> => {
   return res.json() as Promise<T>;
 };
 
-export const swrConfig: SWRConfiguration = {
-  fetcher,
-  revalidateOnFocus: true,
-  dedupingInterval: 2000,
-  errorRetryCount: 3,
-};
+/**
+ * SWR revalidateOnFocus guidelines:
+ *
+ * - Session/auth data: revalidateOnFocus: true (detect login state changes)
+ * - GitHub data (branches, repos, models): default (true) - relatively static, cheap to refetch
+ * - Task diff/files: revalidateOnFocus: false - requires sandbox connection, avoid unnecessary errors
+ */

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "react-hook-form": "^7.70.0",
     "server-only": "^0.0.1",
     "streamdown": "^1.6.11",
+    "swr": "^2.3.8",
     "tailwind-merge": "^3.4.0",
     "zod": "catalog:"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "react-hook-form": "^7.70.0",
         "server-only": "^0.0.1",
         "streamdown": "^1.6.11",
+        "swr": "^2.3.8",
         "tailwind-merge": "^3.4.0",
         "zod": "catalog:",
       },


### PR DESCRIPTION
This refactor replaces manual useState/useEffect patterns with SWR hooks across multiple components for automatic caching, deduplication, and simplified state handling.

- **Task diff/files**: Extracted manual fetch logic into `useTaskDiff` and `useTaskFiles` hooks using SWR; removed refreshKey pattern and complex cache state objects
- **Context simplification**: Replaced `diffCache`, `fetchDiff`, `triggerDiffRefresh` with simple `diff`, `diffLoading`, `diffError`, `refreshDiff` properties; SWR handles background updates and stale data automatically
- **Component cleanup**: Removed prop drilling of `refreshKey` to DiffViewer; deleted manual fetch effects in TaskDetailContent since SWR manages fetching on connection changes
- **Selectors and hooks**: Migrated BranchSelectorCompact, ModelSelectorCompact, RepoSelectorCompact, useSession, and useTasks to SWR for consistent patterns and less boilerplate