### PR TITLE
Add provider-agnostic tools documentation and approval config refactor plan

### DIFF
--- a/docs/documentation/provider-agnostic-tools.md
+++ b/docs/documentation/provider-agnostic-tools.md
@@ -1,0 +1,290 @@
+# Provider-Agnostic Tools
+
+This document describes how tools are implemented to work with multiple AI providers (Anthropic, OpenAI, Google, etc.) while leveraging provider-specific optimizations when available.
+
+## Overview
+
+The AI SDK supports three types of tools:
+
+1. **Custom tools** - Provider-agnostic tools you define entirely yourself
+2. **Provider-defined tools** - Tools where the provider specifies the schema (e.g., Anthropic's `bash_20250124`)
+3. **Provider-executed tools** - Tools that run on the provider's servers
+
+Our implementation uses a **hybrid approach**: provider-defined tools for providers that offer them (like Anthropic's bash tool), with fallback to custom tools for other providers. This gives us the best of both worlds - optimized performance for supported providers and universal compatibility.
+
+## Architecture
+
+### Provider Detection
+
+The `getProvider()` function in `packages/agent/tools/utils.ts` detects the provider from a `LanguageModel`:
+
+```typescript
+export type Provider = "anthropic" | "openai" | "google" | "other";
+
+export function getProvider(model: LanguageModel): Provider {
+  // Handle string model IDs (e.g., "anthropic/claude-haiku-4.5")
+  if (typeof model === "string") {
+    const modelLower = model.toLowerCase();
+    if (modelLower.includes("anthropic") || modelLower.includes("claude")) {
+      return "anthropic";
+    }
+    // ... similar checks for openai, google
+    return "other";
+  }
+
+  // Handle LanguageModel objects
+  const providerStr = model.provider?.toLowerCase() ?? "";
+  const modelId = model.modelId?.toLowerCase() ?? "";
+
+  if (
+    providerStr.includes("anthropic") ||
+    modelId.includes("anthropic") ||
+    modelId.includes("claude")
+  ) {
+    return "anthropic";
+  }
+  // ... similar checks for openai, google
+  return "other";
+}
+```
+
+This function handles both:
+- String model IDs (e.g., `"anthropic:claude-haiku-4.5"`)
+- `LanguageModel` objects with `provider` and `modelId` properties
+
+### Tool Factory Pattern
+
+Tools that have provider-specific variants use a factory function that returns the appropriate implementation based on the model.
+
+**Example: Bash Tool** (`packages/agent/tools/bash/index.ts`):
+
+```typescript
+import { getProvider } from "../utils";
+import { defaultBashTool } from "./default";
+import { createAnthropicBashTool } from "./anthropic";
+
+export function bashTool(options?: BashToolOptionsWithoutModel): DefaultBashTool;
+export function bashTool(options: BashToolOptionsWithModel): DefaultBashTool | AnthropicBashTool;
+export function bashTool(options?: /* combined */): DefaultBashTool | AnthropicBashTool {
+  const { model, needsApproval } = options ?? {};
+
+  if (!model) {
+    return defaultBashTool({ needsApproval });
+  }
+
+  const provider = getProvider(model);
+  switch (provider) {
+    case "anthropic":
+      return createAnthropicBashTool({ needsApproval });
+    default:
+      return defaultBashTool({ needsApproval });
+  }
+}
+```
+
+### Provider-Specific vs Default Implementations
+
+#### Anthropic Bash Tool (`packages/agent/tools/bash/anthropic.ts`)
+
+Uses Anthropic's provider-defined tool. The model has been specifically trained to use this tool effectively:
+
+```typescript
+import { anthropic } from "@ai-sdk/anthropic";
+
+export const createAnthropicBashTool = (options?: { needsApproval?: boolean }) =>
+  anthropic.tools.bash_20250124({
+    needsApproval: (args, { experimental_context }) => {
+      // Shared approval logic
+      return shouldApproveCommand(args.command, ctx);
+    },
+    execute: async ({ command }, { experimental_context }) => {
+      // Shared execution logic via executeBashCommand()
+    },
+  });
+```
+
+#### Default Bash Tool (`packages/agent/tools/bash/default.ts`)
+
+Custom tool for all other providers:
+
+```typescript
+import { tool } from "ai";
+import { z } from "zod";
+
+const bashInputSchema = z.object({
+  command: z.string().describe("The bash command to execute"),
+  cwd: z.string().optional().describe("Working directory (absolute path)"),
+});
+
+export const defaultBashTool = (options?: { needsApproval?: boolean }) =>
+  tool({
+    description: "Execute bash commands...",
+    inputSchema: bashInputSchema,
+    needsApproval: (args, { experimental_context }) => {
+      // Same shared approval logic
+      return shouldApproveCommand(args.command, ctx);
+    },
+    execute: async (args, { experimental_context }) => {
+      // Same shared execution logic via executeBashCommand()
+    },
+  });
+```
+
+**Key differences:**
+- Anthropic tool uses provider-optimized schema (only `command` parameter)
+- Default tool includes optional `cwd` parameter for explicit control
+- Both share the same approval and execution logic
+
+### Shared Logic (`packages/agent/tools/bash/shared.ts`)
+
+Common functionality is extracted to avoid duplication:
+
+```typescript
+// Shared execution
+export async function executeBashCommand(
+  command: string,
+  sandbox: SandboxLike,
+  options?: { cwd?: string; timeout?: number }
+): Promise<BashResult> {
+  // Implementation used by both tools
+}
+
+// Shared approval
+export function shouldApproveCommand(
+  command: string,
+  ctx: CommandApprovalContext
+): boolean {
+  if (commandMatchesApprovalRule(command, ctx.approvalRules)) {
+    return false;
+  }
+  if (ctx.mode === "background") {
+    return false;
+  }
+  if (ctx.mode === "interactive" && ctx.autoApprove === "all") {
+    return false;
+  }
+  return commandNeedsApproval(command);
+}
+```
+
+## Dynamic Toolset Per Request
+
+The agent builds tools dynamically based on the model being used for each request.
+
+**In `packages/agent/deep-agent.ts`:**
+
+```typescript
+function buildToolSet(model: LanguageModel) {
+  return {
+    todo_write: todoWriteTool,
+    read: readFileTool(),
+    write: writeFileTool({ needsApproval: true }),
+    edit: editFileTool({ needsApproval: true }),
+    grep: grepTool(),
+    glob: globTool(),
+    bash: bashTool({ model, needsApproval: true }), // Provider-specific!
+    task: taskTool,
+  };
+}
+
+// In prepareCall:
+const callModel = options.model ?? model;
+const dynamicTools = buildToolSet(callModel);
+```
+
+This enables runtime tool switching when the model changes between requests.
+
+## Provider-Specific Optimizations
+
+### Cache Control
+
+Anthropic models support prompt caching. The `applyCacheControl()` function in `packages/agent/context-management/cache-control.ts` conditionally applies cache hints:
+
+```typescript
+export function applyCacheControl(
+  tools: Record<string, CoreTool>,
+  model: LanguageModel
+): Record<string, CoreTool> {
+  if (!isAnthropicModel(model)) {
+    return tools; // No-op for non-Anthropic models
+  }
+
+  // Apply cacheControl: { type: "ephemeral" } to tools
+}
+```
+
+## Adding Support for New Providers
+
+To add provider-specific tool variants:
+
+1. **Update provider detection** in `packages/agent/tools/utils.ts`:
+
+```typescript
+export function getProvider(model: LanguageModel): Provider {
+  // Add detection for new provider
+  if (modelLower.includes("newprovider") || modelLower.includes("newmodel")) {
+    return "newprovider";
+  }
+}
+```
+
+2. **Create provider-specific implementation** (if provider offers optimized tools):
+
+```typescript
+// packages/agent/tools/bash/newprovider.ts
+import { newprovider } from "@ai-sdk/newprovider";
+
+export const createNewProviderBashTool = (options) =>
+  newprovider.tools.bash({
+    needsApproval: (args, ctx) => shouldApproveCommand(args.command, getCtx(ctx)),
+    execute: (args, ctx) => executeBashCommand(args.command, getSandbox(ctx)),
+  });
+```
+
+3. **Update the factory function**:
+
+```typescript
+// packages/agent/tools/bash/index.ts
+export function bashTool(options) {
+  const provider = getProvider(model);
+  switch (provider) {
+    case "anthropic":
+      return createAnthropicBashTool({ needsApproval });
+    case "newprovider":
+      return createNewProviderBashTool({ needsApproval });
+    default:
+      return defaultBashTool({ needsApproval });
+  }
+}
+```
+
+## Tools Without Provider-Specific Variants
+
+Most tools (read, write, edit, grep, glob, task, todo) are provider-agnostic and use the standard `tool()` function from AI SDK. They work identically across all providers:
+
+```typescript
+export const readFileTool = () =>
+  tool({
+    description: "Read a file from the filesystem",
+    inputSchema: z.object({
+      path: z.string().describe("Absolute path to the file"),
+    }),
+    execute: async (args, { experimental_context }) => {
+      const sandbox = getSandbox(experimental_context, "read");
+      return sandbox.readFile(args.path);
+    },
+  });
+```
+
+Provider-specific variants are only needed when a provider offers optimized tools that the model has been trained to use.
+
+## Summary
+
+| Aspect | Implementation |
+|--------|----------------|
+| Provider detection | `getProvider()` function handles strings and objects |
+| Tool selection | Factory pattern returns appropriate implementation |
+| Shared logic | Common execution/approval in `shared.ts` |
+| Dynamic toolsets | Built per-request based on model |
+| Cache control | Applied conditionally for Anthropic only |
+| Fallback | Default custom tool for unknown providers |

--- a/docs/plans/approval-config-refactor.md
+++ b/docs/plans/approval-config-refactor.md
@@ -1,0 +1,210 @@
+# Plan: Refactor Approval Config to Discriminated Union
+
+**Status:** Incomplete / Not Implemented
+
+## Problem
+
+The current approval configuration uses three separate fields with implicit interactions:
+
+```typescript
+interface AgentContext {
+  sandbox: Sandbox;
+  mode: AgentMode;           // "interactive" | "background"
+  autoApprove: AutoApprove;  // "off" | "edits" | "all"
+  approvalRules: ApprovalRule[];
+}
+```
+
+Issues:
+- When `mode: "background"`, both `autoApprove` and `approvalRules` are redundant
+- When `autoApprove: "all"`, `approvalRules` is redundant
+- Subagents awkwardly set `autoApprove: "all"` to mean "delegated trust"
+- Approval logic is scattered with implicit precedence rules
+- Context shape doesn't match between main agent and subagents (subagents omit `mode` and `approvalRules`, relying on defaults)
+
+## Proposed Solution
+
+Use a discriminated union that makes the trust model explicit:
+
+```typescript
+type ApprovalConfig =
+  | {
+      type: "interactive";
+      autoApprove: "off" | "edits" | "all";
+      sessionRules: ApprovalRule[];
+    }
+  | { type: "background" }
+  | { type: "delegated" };
+
+interface AgentContext {
+  sandbox: Sandbox;
+  approval: ApprovalConfig;
+}
+```
+
+Benefits:
+- No redundant fields - `background` and `delegated` don't carry unused `approvalRules`
+- Self-documenting - subagents use `type: "delegated"` which explains why they auto-approve
+- Type-safe - can't accidentally set `approvalRules` on a background context
+- Simpler logic - switch statements make precedence obvious
+
+## Approval Logic
+
+The current scattered logic:
+
+```typescript
+// Current (implicit precedence)
+if (commandMatchesApprovalRule(command, ctx.approvalRules)) return false;
+if (ctx.mode === "background") return false;
+if (ctx.mode === "interactive" && ctx.autoApprove === "all") return false;
+return commandNeedsApproval(command);
+```
+
+Becomes:
+
+```typescript
+function shouldApproveCommand(command: string, approval: ApprovalConfig): boolean {
+  switch (approval.type) {
+    case "background":
+    case "delegated":
+      return false; // Full trust within sandbox
+
+    case "interactive":
+      if (commandMatchesApprovalRule(command, approval.sessionRules)) {
+        return false;
+      }
+      if (approval.autoApprove === "all") {
+        return false;
+      }
+      return commandNeedsApproval(command);
+  }
+}
+```
+
+## Files to Modify
+
+### Type definitions
+- `packages/agent/types.ts` - Define `ApprovalConfig`, update `AgentContext`
+
+### Context management
+- `packages/agent/tools/utils.ts` - Update `getApprovalContext()` return type and logic
+
+### Main agent
+- `packages/agent/deep-agent.ts` - Update schemas and context creation
+
+### Tools (update `needsApproval` logic)
+- `packages/agent/tools/bash/shared.ts` - Update `CommandApprovalContext` and `shouldApproveCommand`
+- `packages/agent/tools/write.ts` - Update write and edit tool approval
+- `packages/agent/tools/task.ts` - Update task tool approval
+- `packages/agent/tools/read.ts` - Update read tool approval
+- `packages/agent/tools/glob.ts` - Update glob tool approval
+- `packages/agent/tools/grep.ts` - Update grep tool approval
+
+### Subagents
+- `packages/agent/subagents/executor.ts` - Use `{ type: "delegated" }`
+- `packages/agent/subagents/explorer.ts` - Use `{ type: "delegated" }`
+
+## Implementation Steps
+
+### Step 1: Define new types (`types.ts`)
+
+```typescript
+export type ApprovalConfig =
+  | {
+      type: "interactive";
+      autoApprove: "off" | "edits" | "all";
+      sessionRules: ApprovalRule[];
+    }
+  | { type: "background" }
+  | { type: "delegated" };
+
+export interface AgentContext {
+  sandbox: Sandbox;
+  approval: ApprovalConfig;
+}
+```
+
+Keep `AgentMode`, `AutoApprove` exported for backward compatibility during migration.
+
+### Step 2: Update `getApprovalContext()` (`utils.ts`)
+
+Change return type and add helper functions:
+
+```typescript
+export function getApprovalConfig(
+  experimental_context: unknown,
+  toolName?: string,
+): { sandbox: Sandbox; approval: ApprovalConfig } {
+  // Extract and validate context
+  // Return normalized approval config
+}
+
+// Helper for common approval checks
+export function shouldAutoApprove(config: ApprovalConfig): boolean {
+  return config.type === "background" || config.type === "delegated";
+}
+
+export function getSessionRules(config: ApprovalConfig): ApprovalRule[] {
+  return config.type === "interactive" ? config.sessionRules : [];
+}
+```
+
+### Step 3: Update `deep-agent.ts`
+
+Update schema and context creation:
+
+```typescript
+const approvalConfigSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("interactive"),
+    autoApprove: z.enum(["off", "edits", "all"]).default("off"),
+    sessionRules: z.array(approvalRuleSchema).default([]),
+  }),
+  z.object({ type: z.literal("background") }),
+  z.object({ type: z.literal("delegated") }),
+]);
+
+// In prepareCall:
+experimental_context: { sandbox, approval: options.approval }
+```
+
+### Step 4: Update tool approval logic
+
+Replace scattered checks with clean switch statements in each tool file.
+
+### Step 5: Update subagents
+
+```typescript
+// executor.ts and explorer.ts
+experimental_context: {
+  sandbox,
+  approval: { type: "delegated" },
+}
+```
+
+## Verification
+
+1. Run typecheck: `turbo typecheck --filter=@open-harness/agent`
+2. Run lint: `turbo lint --filter=@open-harness/agent`
+3. Manual test scenarios:
+   - Interactive mode with `autoApprove: "off"` - dangerous commands should require approval
+   - Interactive mode with `autoApprove: "all"` - all commands auto-approved
+   - Background mode - all commands auto-approved
+   - Subagent (delegated) - all commands auto-approved
+   - Session rules - matching commands bypass approval
+
+## Appendix: Current Approval Usage Locations
+
+| File | Line(s) | Usage |
+|------|---------|-------|
+| `types.ts` | 22, 31, 33-38 | Type definitions |
+| `deep-agent.ts` | 26-27, 29-32, 94-97, 122 | Schema and context creation |
+| `utils.ts` | 65-68, 77-79, 89-117 | `getMode()`, `isBackgroundMode()`, `getApprovalContext()` |
+| `write.ts` | 93-127, 188-222 | `needsApproval` for write and edit tools |
+| `bash/shared.ts` | 42-55, 183-211 | `commandMatchesApprovalRule`, `shouldApproveCommand` |
+| `task.ts` | 29-62 | `subagentMatchesApprovalRule`, `needsApproval` |
+| `glob.ts` | 121-172 | `pathMatchesApprovalRule`, `needsApproval` |
+| `grep.ts` | 112-159 | `pathMatchesApprovalRule`, `needsApproval` |
+| `read.ts` | 66-112 | `pathMatchesApprovalRule`, `needsApproval` |
+| `executor.ts` | 92-96 | Context setup (sets `autoApprove: "all"`) |
+| `explorer.ts` | 103-107 | Context setup (sets `autoApprove: "all"`) |

--- a/docs/research/dynamic-provider-defined-tools.md
+++ b/docs/research/dynamic-provider-defined-tools.md
@@ -1,0 +1,209 @@
+## Types of Tools
+
+The AI SDK supports three types of tools, each with different trade-offs:
+
+### Custom Tools
+
+Custom tools are tools you define entirely yourself, including the description, input schema, and execute function. They are provider-agnostic and give you full control.
+
+```ts
+import { tool } from "ai";
+import { z } from "zod";
+
+const weatherTool = tool({
+  description: "Get the weather in a location",
+  inputSchema: z.object({
+    location: z.string().describe("The location to get the weather for"),
+  }),
+  execute: async ({ location }) => {
+    // Your implementation
+    return { temperature: 72, conditions: "sunny" };
+  },
+});
+```
+
+**When to use**: When you need full control, want provider portability, or are implementing application-specific functionality.
+
+### Provider-Defined Tools
+
+Provider-defined tools are tools where the provider specifies the tool's `inputSchema` and `description`, but you provide the `execute` function. These are sometimes called "client tools" because execution happens on your side.
+
+Examples include Anthropic's `bash` and `text_editor` tools. The model has been specifically trained to use these tools effectively, which can result in better performance for supported tasks.
+
+```ts
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateText } from "ai";
+
+const result = await generateText({
+  model: anthropic("claude-opus-4-5"),
+  tools: {
+    bash: anthropic.tools.bash_20250124({
+      execute: async ({ command }) => {
+        // Your implementation to run the command
+        return runCommand(command);
+      },
+    }),
+  },
+  prompt: "List files in the current directory",
+});
+```
+
+**When to use**: When the provider offers a tool the model is trained to use well, and you want better performance for that specific task.
+
+### Provider-Executed Tools
+
+Provider-executed tools are tools that run entirely on the provider's servers. You configure them, but the provider handles execution. These are sometimes called "server-side tools".
+
+Examples include OpenAI's web search and Anthropic's code execution. These provide out-of-the-box functionality without requiring you to set up infrastructure.
+
+```ts
+import { openai } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+const result = await generateText({
+  model: openai("gpt-5.2"),
+  tools: {
+    web_search: openai.tools.webSearch(),
+  },
+  prompt: "What happened in the news today?",
+});
+```
+
+**When to use**: When you want powerful functionality (like web search or sandboxed code execution) without managing the infrastructure yourself.
+
+---
+
+Important to note that provider-defined tools include needs approval (which includes context too!).
+
+e.g.
+
+```ts
+      bash: anthropic.tools.bash_20241022({
+        needsApproval: ({command, restart}, {experimental_context}) => true,
+        async execute({ command }, {experimental_context}) {
+          console.log('COMMAND', command);
+          return [
+            {
+              type: 'text',
+              text: `
+          ❯ ls
+          README.md     build         data          node_modules  package.json  src           tsconfig.json
+          `,
+            },
+          ];
+        },
+      }),
+```
+
+There's a needsApproval utility function in tools/utils.ts that can be used like this:
+
+```ts
+const bashInputSchema = z.object({
+  command: z.string().describe("The bash command to execute"),
+  cwd: z
+    .string()
+    .optional()
+    .describe("Working directory for the command (absolute path)"),
+});
+
+type BashInput = z.infer<typeof bashInputSchema>;
+type ApprovalFn = ToolNeedsApprovalFunction<BashInput>;
+```
+
+---
+
+## Dynamic toolset per request concept
+
+What if we could switch out specific tools for their provider-defined version, depending on whichever model is being used per request?
+
+The following code is an example of this and this works.
+
+```ts
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateText, LanguageModel, stepCountIs, tool } from "ai";
+import { run } from "../lib/run";
+import { z } from "zod";
+
+const bashDefault = tool({
+  description: "Execute bash commands",
+  inputSchema: z.object({
+    command: z.string().describe("The bash command to execute"),
+  }),
+  execute: async ({ command }) => {
+    console.log("COMMAND", command);
+    console.log("Using default bash tool execution");
+    return [
+      {
+        type: "text",
+        text: `
+          ❯ ls
+          README.md     build         data          node_modules  package.json  src           tsconfig.json
+          `,
+      },
+    ];
+  },
+});
+
+const bashAnthropic = anthropic.tools.bash_20250124({
+  async execute({ command }) {
+    console.log("COMMAND", command);
+    console.log("Using Anthropic's bash tool execution");
+    return [
+      {
+        type: "text",
+        text: `
+          ❯ ls
+          README.md     build         data          node_modules  package.json  src           tsconfig.json
+          `,
+      },
+    ];
+  },
+});
+
+type Provider = "anthropic" | "openai" | "other";
+
+function getModel(model: LanguageModel): Provider {
+  if (typeof model === "string") {
+    if (model.includes("anthropic") || model.includes("claude")) {
+      return "anthropic";
+    }
+    return "other";
+  }
+
+  if (
+    model.provider === "anthropic" ||
+    model.provider.includes("anthropic") ||
+    model.modelId.includes("anthropic") ||
+    model.modelId.includes("claude")
+  ) {
+    return "anthropic";
+  }
+
+  return "other";
+}
+
+const bashTool = (model: LanguageModel) => {
+  const provider = getModel(model);
+
+  switch (provider) {
+    case "anthropic":
+      return bashAnthropic;
+    default:
+      return bashDefault;
+  }
+};
+
+run(async () => {
+  const model = anthropic("claude-haiku-4-5");
+  const result = await generateText({
+    model,
+    tools: {
+      bash: bashTool(model),
+    },
+    prompt: "List the files in my home directory.",
+    stopWhen: stepCountIs(2),
+  });
+
+  console.log(result.text);
+});
+```

--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -6,6 +6,7 @@ import type {
   ApprovalRule,
 } from "../types";
 import type { Sandbox } from "@open-harness/sandbox";
+import type { ModelMessage } from "ai";
 
 /**
  * Check if a file path is within a given directory.
@@ -167,3 +168,28 @@ export function pathMatchesGlob(
     return false;
   }
 }
+
+
+export type ToolNeedsApprovalFunction<INPUT> = (
+  input: INPUT,
+  options: {
+    /**
+     * The ID of the tool call. You can use it e.g. when sending tool-call related information with stream data.
+     */
+    toolCallId: string;
+
+    /**
+     * Messages that were sent to the language model to initiate the response that contained the tool call.
+     * The messages **do not** include the system prompt nor the assistant response that contained the tool call.
+     */
+    messages: ModelMessage[];
+
+    /**
+     * Additional context.
+     *
+     * Experimental (can break in patch releases).
+     */
+    experimental_context?: unknown;
+  },
+) => boolean | PromiseLike<boolean>;
+


### PR DESCRIPTION
This PR introduces comprehensive documentation and planning for provider-specific tool implementations.

- **Added `provider-agnostic-tools.md`**: Detailed documentation explaining how tools work across multiple AI providers (Anthropic, OpenAI, Google) with provider-specific optimizations when available, including architecture, factory patterns, and examples
- **Added `approval-config-refactor.md`**: Planning document proposing refactoring approval configuration from three separate fields to a discriminated union type for cleaner, type-safe approval logic
- **Added `dynamic-provider-defined-tools.md`**: Research document explaining three types of tools (custom, provider-defined, provider-executed) with working examples of dynamic tool selection per request
- **Updated `tools/utils.ts`**: Added `ToolNeedsApprovalFunction` type definition to support provider-defined tool approval callbacks