### PR TITLE
Remove .js extensions from all imports across monorepo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,10 +84,9 @@ The `task` tool delegates to specialized subagents:
 - **Constants**: UPPER_SNAKE_CASE for true constants (e.g., `TIMEOUT_MS`, `SAFE_COMMAND_PREFIXES`)
 
 ### Imports
-- **Do NOT use `.js` extensions** in packages consumed by the web app (e.g., `import { foo } from "./utils"` not `"./utils.js"`)
+- **Do NOT use `.js` extensions** in imports (e.g., `import { foo } from "./utils"` not `"./utils.js"`)
   - The `.js` extension causes module resolution issues with Next.js/Turbopack
-  - This applies to: `packages/sandbox`, `packages/agent`, `packages/shared`, `apps/web`
-  - Exception: `apps/cli` and `packages/tui` can use `.js` extensions (CLI-only)
+  - This applies to all packages and apps in the monorepo
 - Prefer named exports over default exports
 - Group imports: external packages first, then internal packages, then relative imports
 - Use type imports when importing only types: `import type { Foo } from "./types"`

--- a/TODO-BEFORE-RELEASE.md
+++ b/TODO-BEFORE-RELEASE.md
@@ -83,7 +83,7 @@ To work through these todos, follow this pattern:
 
 ## Technical Debt
 
-- [ ] Align import extensions across packages - `packages/shared` uses `.js` extensions which cause issues with Next.js/Turbopack
+- [x] Align import extensions across packages - `packages/shared` uses `.js` extensions which cause issues with Next.js/Turbopack
 
 ---
 

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -2,14 +2,14 @@
 
 import { defaultModelLabel } from "@open-harness/agent";
 import { createTUI } from "@open-harness/tui";
-import { loadAgentsMd } from "./agents-md.js";
-import { onCleanup, cleanup } from "./cleanup-handler.js";
+import { loadAgentsMd } from "./agents-md";
+import { onCleanup, cleanup } from "./cleanup-handler";
 import {
   createSandbox,
   parseSandboxType,
   type SandboxType,
-} from "./sandbox-factory.js";
-import { showSpinner } from "./spinner.js";
+} from "./sandbox-factory";
+import { showSpinner } from "./spinner";
 
 function printHelp() {
   console.log("Deep Agent CLI");

--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -169,7 +169,6 @@ export function pathMatchesGlob(
   }
 }
 
-
 export type ToolNeedsApprovalFunction<INPUT> = (
   input: INPUT,
   options: {
@@ -192,4 +191,3 @@ export type ToolNeedsApprovalFunction<INPUT> = (
     experimental_context?: unknown;
   },
 ) => boolean | PromiseLike<boolean>;
-

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -3,14 +3,14 @@ export {
   ReasoningProvider,
   useReasoningContext,
   type ThinkingState,
-} from "./hooks/reasoning-context.js";
+} from "./hooks/reasoning-context";
 
 export {
   ExpandedViewProvider,
   useExpandedView,
-} from "./hooks/expanded-view-context.js";
+} from "./hooks/expanded-view-context";
 
-export { TodoViewProvider, useTodoView } from "./hooks/todo-view-context.js";
+export { TodoViewProvider, useTodoView } from "./hooks/todo-view-context";
 
 // Lib - Paste blocks
 export {
@@ -23,7 +23,7 @@ export {
   expandPasteTokens,
   countLines,
   formatPastePlaceholder,
-} from "./lib/paste-blocks.js";
+} from "./lib/paste-blocks";
 
 // Lib - Diff utilities
 export {
@@ -37,7 +37,7 @@ export {
   createEditDiffLines,
   getLanguageFromPath,
   createNewFileCodeLines,
-} from "./lib/diff.js";
+} from "./lib/diff";
 
 // Lib - Tool state utilities
 export {
@@ -47,4 +47,4 @@ export {
   getStatusColor,
   getStatusLabel,
   toRelativePath,
-} from "./lib/tool-state.js";
+} from "./lib/tool-state";

--- a/packages/shared/lib/paste-blocks.test.ts
+++ b/packages/shared/lib/paste-blocks.test.ts
@@ -6,7 +6,7 @@ import {
   extractPasteTokens,
   formatPastePlaceholder,
   type PasteBlock,
-} from "./paste-blocks.js";
+} from "./paste-blocks";
 
 test("countLines handles newline variants", () => {
   expect(countLines("a\nb\nc")).toBe(3);

--- a/packages/tui/app.tsx
+++ b/packages/tui/app.tsx
@@ -7,23 +7,23 @@ import {
   useExpandedView,
   useTodoView,
 } from "@open-harness/shared";
-import { renderMarkdown } from "./lib/markdown.js";
-import { useChatContext } from "./chat-context.js";
-import { ToolCall, getToolApprovalInfo } from "./components/tool-call.js";
-import { ApprovalPanel } from "./components/approval-panel.js";
-import { TaskGroupView } from "./components/task-group-view.js";
-import { StatusBar, StandaloneTodoList } from "./components/status-bar.js";
-import { InputBox } from "./components/input-box.js";
-import { Header } from "./components/header.js";
+import { renderMarkdown } from "./lib/markdown";
+import { useChatContext } from "./chat-context";
+import { ToolCall, getToolApprovalInfo } from "./components/tool-call";
+import { ApprovalPanel } from "./components/approval-panel";
+import { TaskGroupView } from "./components/task-group-view";
+import { StatusBar, StandaloneTodoList } from "./components/status-bar";
+import { InputBox } from "./components/input-box";
+import { Header } from "./components/header";
 import { defaultModelLabel } from "@open-harness/agent";
-import { pasteCollapseLineThreshold } from "./config.js";
-import { extractTodosFromLastAssistantMessage } from "./utils/extract-todos.js";
+import { pasteCollapseLineThreshold } from "./config";
+import { extractTodosFromLastAssistantMessage } from "./utils/extract-todos";
 import type {
   TUIOptions,
   TUIAgentUIMessagePart,
   TUIAgentUIMessage,
   TUIAgentUIToolPart,
-} from "./types.js";
+} from "./types";
 import type { TaskToolUIPart } from "@open-harness/agent";
 
 type AppProps = {

--- a/packages/tui/chat-context.tsx
+++ b/packages/tui/chat-context.tsx
@@ -12,14 +12,14 @@ import {
   lastAssistantMessageIsCompleteWithApprovalResponses,
 } from "ai";
 import { Chat } from "@ai-sdk/react";
-import { createAgentTransport } from "./transport.js";
-import { tuiAgent } from "./config.js";
+import { createAgentTransport } from "./transport";
+import { tuiAgent } from "./config";
 import type {
   TUIAgentCallOptions,
   TUIAgentUIMessage,
   AutoAcceptMode,
   ApprovalRule,
-} from "./types.js";
+} from "./types";
 import { getContextLimit } from "@open-harness/agent";
 
 type ChatState = {

--- a/packages/tui/components/approval-buttons.tsx
+++ b/packages/tui/components/approval-buttons.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import { useChat } from "@ai-sdk/react";
-import { useChatContext } from "../chat-context.js";
+import { useChatContext } from "../chat-context";
 
 export function ApprovalButtons({ approvalId }: { approvalId: string }) {
   const { chat } = useChatContext();

--- a/packages/tui/components/approval-panel.tsx
+++ b/packages/tui/components/approval-panel.tsx
@@ -8,10 +8,10 @@ import {
   type CodeLine,
   type DiffLine,
 } from "@open-harness/shared";
-import { useChatContext } from "../chat-context.js";
-import type { TUIAgentUIToolPart, ApprovalRule } from "../types.js";
-import { inferApprovalRule } from "../lib/approval.js";
-import { cliHighlighter } from "../lib/highlighter.js";
+import { useChatContext } from "../chat-context";
+import type { TUIAgentUIToolPart, ApprovalRule } from "../types";
+import { inferApprovalRule } from "../lib/approval";
+import { cliHighlighter } from "../lib/highlighter";
 
 export type ApprovalPanelProps = {
   approvalId: string;

--- a/packages/tui/components/index.ts
+++ b/packages/tui/components/index.ts
@@ -1,21 +1,21 @@
 // Main tool call component
-export { ToolCall } from "./tool-call.js";
+export { ToolCall } from "./tool-call";
 
 // Individual tool renderers (for custom overrides)
-export * from "./tool-renderers/index.js";
+export * from "./tool-renderers/index";
 
 // Other components
-export { TextOutput } from "./text-output.js";
-export { StatusBar, StandaloneTodoList } from "./status-bar.js";
-export { InputBox } from "./input-box.js";
-export { DiffView, parseEditOutput } from "./diff-view.js";
-export { Header } from "./header.js";
-export { ApprovalPanel } from "./approval-panel.js";
-export { ApprovalButtons } from "./approval-buttons.js";
+export { TextOutput } from "./text-output";
+export { StatusBar, StandaloneTodoList } from "./status-bar";
+export { InputBox } from "./input-box";
+export { DiffView, parseEditOutput } from "./diff-view";
+export { Header } from "./header";
+export { ApprovalPanel } from "./approval-panel";
+export { ApprovalButtons } from "./approval-buttons";
 
 // Re-exports from tool-call for backwards compatibility
 export {
   getToolApprovalInfo,
   inferApprovalRule,
   type ToolApprovalInfo,
-} from "./tool-call.js";
+} from "./tool-call";

--- a/packages/tui/components/input-box.tsx
+++ b/packages/tui/components/input-box.tsx
@@ -8,9 +8,9 @@ import React, {
 } from "react";
 import { Box, Text, useInput } from "ink";
 import type { FileUIPart } from "ai";
-import { TextInput } from "./text-input.js";
-import { Suggestions, type Suggestion } from "./suggestions.js";
-import { getFileSuggestions, extractMention } from "../lib/file-suggestions.js";
+import { TextInput } from "./text-input";
+import { Suggestions, type Suggestion } from "./suggestions";
+import { getFileSuggestions, extractMention } from "../lib/file-suggestions";
 import {
   countLines,
   createPasteToken,
@@ -25,13 +25,13 @@ import {
   imageToDataUrl,
   isImagePath,
   loadImageFromPath,
-} from "../lib/image-clipboard.js";
+} from "../lib/image-clipboard";
 import {
   formatImagePlaceholder,
   imageBlockToFilePart,
   type ImageBlock,
-} from "../lib/image-blocks.js";
-import type { AutoAcceptMode } from "../types.js";
+} from "../lib/image-blocks";
+import type { AutoAcceptMode } from "../types";
 
 type InputBoxProps = {
   onSubmit: (value: string, files?: FileUIPart[]) => void;

--- a/packages/tui/components/task-group-view.tsx
+++ b/packages/tui/components/task-group-view.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Box, Text } from "ink";
 import { getToolName, isToolUIPart } from "ai";
-import type { TaskToolUIPart } from "../../agent/tools/task.js";
+import type { TaskToolUIPart } from "../../agent/tools/task";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 

--- a/packages/tui/components/tool-call.tsx
+++ b/packages/tui/components/tool-call.tsx
@@ -5,18 +5,18 @@
  * It extracts the render state and delegates to the appropriate renderer.
  */
 import React from "react";
-import type { TUIAgentUIToolPart } from "../types.js";
-import { renderToolPart, extractRenderState } from "../lib/render-tool.js";
+import type { TUIAgentUIToolPart } from "../types";
+import { renderToolPart, extractRenderState } from "../lib/render-tool";
 
 // Re-export approval utilities for backwards compatibility
-export { getToolApprovalInfo, inferApprovalRule } from "../lib/approval.js";
-export type { ToolApprovalInfo } from "../lib/approval.js";
+export { getToolApprovalInfo, inferApprovalRule } from "../lib/approval";
+export type { ToolApprovalInfo } from "../lib/approval";
 
 // Re-export shared components for backwards compatibility
-export { ToolSpinner, SubagentToolCall } from "./tool-renderers/index.js";
+export { ToolSpinner, SubagentToolCall } from "./tool-renderers/index";
 
 // Re-export ApprovalButtons (keeping it here for now as it's tightly coupled to chat context)
-export { ApprovalButtons } from "./approval-buttons.js";
+export { ApprovalButtons } from "./approval-buttons";
 
 export type ToolCallProps = {
   part: TUIAgentUIToolPart;

--- a/packages/tui/components/tool-renderers/bash-renderer.tsx
+++ b/packages/tui/components/tool-renderers/bash-renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
-import type { ToolRendererProps } from "../../lib/render-tool.js";
-import { ToolSpinner, getDotColor } from "./shared.js";
+import type { ToolRendererProps } from "../../lib/render-tool";
+import { ToolSpinner, getDotColor } from "./shared";
 
 export function BashRenderer({ part, state }: ToolRendererProps<"tool-bash">) {
   const command = String(part.input?.command ?? "");

--- a/packages/tui/components/tool-renderers/default-renderer.tsx
+++ b/packages/tui/components/tool-renderers/default-renderer.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Text } from "ink";
 import { getToolName } from "ai";
-import type { TUIAgentUIToolPart } from "../../types.js";
-import type { ToolRenderState } from "../../lib/render-tool.js";
-import { ToolLayout } from "./shared.js";
+import type { TUIAgentUIToolPart } from "../../types";
+import type { ToolRenderState } from "../../lib/render-tool";
+import { ToolLayout } from "./shared";
 
 /**
  * Default renderer for unknown tool types.

--- a/packages/tui/components/tool-renderers/edit-renderer.tsx
+++ b/packages/tui/components/tool-renderers/edit-renderer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { createEditDiffLines } from "@open-harness/shared";
-import type { ToolRendererProps } from "../../lib/render-tool.js";
-import { FileChangeLayout, toRelativePath } from "./shared.js";
-import { useChatContext } from "../../chat-context.js";
+import type { ToolRendererProps } from "../../lib/render-tool";
+import { FileChangeLayout, toRelativePath } from "./shared";
+import { useChatContext } from "../../chat-context";
 
 export function EditRenderer({ part, state }: ToolRendererProps<"tool-edit">) {
   const { state: chatState } = useChatContext();

--- a/packages/tui/components/tool-renderers/glob-renderer.tsx
+++ b/packages/tui/components/tool-renderers/glob-renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "ink";
-import type { ToolRendererProps } from "../../lib/render-tool.js";
-import { ToolLayout } from "./shared.js";
+import type { ToolRendererProps } from "../../lib/render-tool";
+import { ToolLayout } from "./shared";
 
 export function GlobRenderer({ part, state }: ToolRendererProps<"tool-glob">) {
   const pattern = part.input?.pattern ?? "...";

--- a/packages/tui/components/tool-renderers/grep-renderer.tsx
+++ b/packages/tui/components/tool-renderers/grep-renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "ink";
-import type { ToolRendererProps } from "../../lib/render-tool.js";
-import { ToolLayout } from "./shared.js";
+import type { ToolRendererProps } from "../../lib/render-tool";
+import { ToolLayout } from "./shared";
 
 export function GrepRenderer({ part, state }: ToolRendererProps<"tool-grep">) {
   const pattern = part.input?.pattern ?? "...";

--- a/packages/tui/components/tool-renderers/index.ts
+++ b/packages/tui/components/tool-renderers/index.ts
@@ -6,15 +6,15 @@
  */
 
 // Individual renderers
-export { ReadRenderer } from "./read-renderer.js";
-export { WriteRenderer } from "./write-renderer.js";
-export { EditRenderer } from "./edit-renderer.js";
-export { GlobRenderer } from "./glob-renderer.js";
-export { GrepRenderer } from "./grep-renderer.js";
-export { BashRenderer } from "./bash-renderer.js";
-export { TodoRenderer } from "./todo-renderer.js";
-export { TaskRenderer, SubagentToolCall } from "./task-renderer.js";
-export { DefaultRenderer } from "./default-renderer.js";
+export { ReadRenderer } from "./read-renderer";
+export { WriteRenderer } from "./write-renderer";
+export { EditRenderer } from "./edit-renderer";
+export { GlobRenderer } from "./glob-renderer";
+export { GrepRenderer } from "./grep-renderer";
+export { BashRenderer } from "./bash-renderer";
+export { TodoRenderer } from "./todo-renderer";
+export { TaskRenderer, SubagentToolCall } from "./task-renderer";
+export { DefaultRenderer } from "./default-renderer";
 
 // Shared components
 export {
@@ -23,4 +23,4 @@ export {
   FileChangeLayout,
   getDotColor,
   toRelativePath,
-} from "./shared.js";
+} from "./shared";

--- a/packages/tui/components/tool-renderers/read-renderer.tsx
+++ b/packages/tui/components/tool-renderers/read-renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "ink";
-import type { ToolRendererProps } from "../../lib/render-tool.js";
-import { ToolLayout, toRelativePath } from "./shared.js";
+import type { ToolRendererProps } from "../../lib/render-tool";
+import { ToolLayout, toRelativePath } from "./shared";
 
 export function ReadRenderer({ part, state }: ToolRendererProps<"tool-read">) {
   const cwd = process.cwd();

--- a/packages/tui/components/tool-renderers/shared.tsx
+++ b/packages/tui/components/tool-renderers/shared.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect, type ReactNode } from "react";
 import { Box, Text } from "ink";
 import type { DiffLine, CodeLine } from "@open-harness/shared";
-import type { ToolRenderState } from "../../lib/render-tool.js";
+import type { ToolRenderState } from "../../lib/render-tool";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 

--- a/packages/tui/components/tool-renderers/task-renderer.tsx
+++ b/packages/tui/components/tool-renderers/task-renderer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { getToolName, isTextUIPart, isToolUIPart } from "ai";
-import type { ToolRendererProps } from "../../lib/render-tool.js";
-import { ToolSpinner } from "./shared.js";
+import type { ToolRendererProps } from "../../lib/render-tool";
+import { ToolSpinner } from "./shared";
 
 /**
  * Simplified tool call renderer for subagent tool parts.

--- a/packages/tui/components/tool-renderers/todo-renderer.tsx
+++ b/packages/tui/components/tool-renderers/todo-renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
-import type { ToolRendererProps } from "../../lib/render-tool.js";
-import { ToolLayout } from "./shared.js";
+import type { ToolRendererProps } from "../../lib/render-tool";
+import { ToolLayout } from "./shared";
 
 function getTodoIcon(status: string) {
   switch (status) {

--- a/packages/tui/components/tool-renderers/write-renderer.tsx
+++ b/packages/tui/components/tool-renderers/write-renderer.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from "react";
 import { createNewFileCodeLines } from "@open-harness/shared";
-import type { ToolRendererProps } from "../../lib/render-tool.js";
-import { NewFileLayout, toRelativePath } from "./shared.js";
-import { useChatContext } from "../../chat-context.js";
-import { cliHighlighter } from "../../lib/highlighter.js";
+import type { ToolRendererProps } from "../../lib/render-tool";
+import { NewFileLayout, toRelativePath } from "./shared";
+import { useChatContext } from "../../chat-context";
+import { cliHighlighter } from "../../lib/highlighter";
 
 export function WriteRenderer({
   part,

--- a/packages/tui/config.ts
+++ b/packages/tui/config.ts
@@ -1,7 +1,7 @@
 import { deepAgent } from "@open-harness/agent";
 import type { AgentMode } from "@open-harness/agent";
 import type { Sandbox } from "@open-harness/sandbox";
-import type { TUIAgentCallOptions } from "./types.js";
+import type { TUIAgentCallOptions } from "./types";
 
 // Configure your agent here - this is the single source of truth for the TUI
 export const tuiAgent = deepAgent;

--- a/packages/tui/index.tsx
+++ b/packages/tui/index.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import { render } from "ink";
-import { App } from "./app.js";
-import { ChatProvider } from "./chat-context.js";
+import { App } from "./app";
+import { ChatProvider } from "./chat-context";
 import {
   ReasoningProvider,
   ExpandedViewProvider,
   TodoViewProvider,
 } from "@open-harness/shared";
 import { defaultModelLabel } from "@open-harness/agent";
-import { createDefaultAgentOptions } from "./config.js";
-import type { TUIOptions } from "./types.js";
+import { createDefaultAgentOptions } from "./config";
+import type { TUIOptions } from "./types";
 
-export type { TUIOptions, AutoAcceptMode } from "./types.js";
-export { useChatContext, ChatProvider } from "./chat-context.js";
-export { tuiAgent, createDefaultAgentOptions } from "./config.js";
+export type { TUIOptions, AutoAcceptMode } from "./types";
+export { useChatContext, ChatProvider } from "./chat-context";
+export { tuiAgent, createDefaultAgentOptions } from "./config";
 
 /**
  * Create a Claude Code-style TUI.
@@ -103,10 +103,10 @@ export function renderTUI(options: TUIOptions) {
 }
 
 // Re-export components for custom TUI composition
-export * from "./components/index.js";
+export * from "./components/index";
 
 // Re-export render-tool types and utilities
-export * from "./lib/render-tool.js";
+export * from "./lib/render-tool";
 
 // Re-export transport for custom usage
-export { createAgentTransport } from "./transport.js";
+export { createAgentTransport } from "./transport";

--- a/packages/tui/lib/approval.ts
+++ b/packages/tui/lib/approval.ts
@@ -4,7 +4,7 @@
  */
 import * as path from "path";
 import { getToolName } from "ai";
-import type { TUIAgentUIToolPart, ApprovalRule } from "../types.js";
+import type { TUIAgentUIToolPart, ApprovalRule } from "../types";
 
 export type ToolApprovalInfo = {
   toolType: string;

--- a/packages/tui/lib/file-suggestions.ts
+++ b/packages/tui/lib/file-suggestions.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import type { Suggestion } from "../components/suggestions.js";
+import type { Suggestion } from "../components/suggestions";
 
 // Cache for all files to avoid repeated filesystem scans
 let cachedFiles: Suggestion[] | null = null;

--- a/packages/tui/lib/image-blocks.ts
+++ b/packages/tui/lib/image-blocks.ts
@@ -1,5 +1,5 @@
 import type { FileUIPart } from "ai";
-import type { ImageMediaType } from "./image-clipboard.js";
+import type { ImageMediaType } from "./image-clipboard";
 
 export type ImageBlock = {
   id: number;

--- a/packages/tui/lib/render-tool.tsx
+++ b/packages/tui/lib/render-tool.tsx
@@ -6,22 +6,22 @@
  * tool types are handled.
  */
 import React from "react";
-import type { TUIAgentUIToolPart } from "../types.js";
+import type { TUIAgentUIToolPart } from "../types";
 import {
   extractRenderState,
   type ToolRenderState,
 } from "@open-harness/shared/lib/tool-state";
 
 // Import all renderers
-import { ReadRenderer } from "../components/tool-renderers/read-renderer.js";
-import { WriteRenderer } from "../components/tool-renderers/write-renderer.js";
-import { EditRenderer } from "../components/tool-renderers/edit-renderer.js";
-import { GlobRenderer } from "../components/tool-renderers/glob-renderer.js";
-import { GrepRenderer } from "../components/tool-renderers/grep-renderer.js";
-import { BashRenderer } from "../components/tool-renderers/bash-renderer.js";
-import { TodoRenderer } from "../components/tool-renderers/todo-renderer.js";
-import { TaskRenderer } from "../components/tool-renderers/task-renderer.js";
-import { DefaultRenderer } from "../components/tool-renderers/default-renderer.js";
+import { ReadRenderer } from "../components/tool-renderers/read-renderer";
+import { WriteRenderer } from "../components/tool-renderers/write-renderer";
+import { EditRenderer } from "../components/tool-renderers/edit-renderer";
+import { GlobRenderer } from "../components/tool-renderers/glob-renderer";
+import { GrepRenderer } from "../components/tool-renderers/grep-renderer";
+import { BashRenderer } from "../components/tool-renderers/bash-renderer";
+import { TodoRenderer } from "../components/tool-renderers/todo-renderer";
+import { TaskRenderer } from "../components/tool-renderers/task-renderer";
+import { DefaultRenderer } from "../components/tool-renderers/default-renderer";
 
 /**
  * All possible tool part types derived from the agent.

--- a/packages/tui/types.ts
+++ b/packages/tui/types.ts
@@ -6,7 +6,7 @@ import type {
   ToolUIPart,
 } from "ai";
 import type { Sandbox } from "@open-harness/sandbox";
-import type { tuiAgent } from "./config.js";
+import type { tuiAgent } from "./config";
 
 export type TUIAgent = typeof tuiAgent;
 export type TUIAgentCallOptions = Parameters<

--- a/packages/tui/utils/extract-todos.ts
+++ b/packages/tui/utils/extract-todos.ts
@@ -1,6 +1,6 @@
 import { isToolUIPart } from "ai";
-import type { TodoItem } from "../../agent/types.js";
-import type { TUIAgentUIMessage, TUIAgentUIToolPart } from "../types.js";
+import type { TodoItem } from "../../agent/types";
+import type { TUIAgentUIMessage, TUIAgentUIToolPart } from "../types";
 
 function isTodoWritePart(
   part: TUIAgentUIToolPart,


### PR DESCRIPTION
This PR aligns import practices across the entire monorepo by removing `.js` file extensions from all relative imports.

- **Removed `.js` extensions** from all import statements in `packages/` and `apps/` to ensure consistency with Next.js/Turbopack module resolution
- **Updated AGENTS.md** to clarify that the no-extension rule applies to all packages and apps monorepo-wide (previously had an exception for CLI/TUI)
- **Marked technical debt item as complete** in TODO-BEFORE-RELEASE.md
- **Cleaned up trailing whitespace** in packages/agent/tools/utils.ts