### PR TITLE
Add multiline text input navigation and keybindings

### DIFF
--- a/packages/tui/components/text-input.tsx
+++ b/packages/tui/components/text-input.tsx
@@ -98,6 +98,55 @@ function findLineEnd(value: string, cursorOffset: number): number {
   return value.length; // No newline found, go to end
 }
 
+/**
+ * Calculate the cursor position when moving up one line.
+ * Returns -1 if already on the first line.
+ */
+function findPositionAbove(value: string, cursorOffset: number): number {
+  const lineStart = findLineStart(value, cursorOffset);
+
+  // If we're on the first line, return -1 to signal parent should handle
+  if (lineStart === 0) {
+    return -1;
+  }
+
+  // Column position within current line
+  const column = cursorOffset - lineStart;
+
+  // Find the start of the previous line (lineStart - 1 is the newline, go before it)
+  const prevLineEnd = lineStart - 1;
+  const prevLineStart = findLineStart(value, prevLineEnd);
+  const prevLineLength = prevLineEnd - prevLineStart;
+
+  // Move to same column on previous line, clamped to line length
+  return prevLineStart + Math.min(column, prevLineLength);
+}
+
+/**
+ * Calculate the cursor position when moving down one line.
+ * Returns -1 if already on the last line.
+ */
+function findPositionBelow(value: string, cursorOffset: number): number {
+  const lineEnd = findLineEnd(value, cursorOffset);
+
+  // If we're on the last line, return -1 to signal parent should handle
+  if (lineEnd === value.length) {
+    return -1;
+  }
+
+  // Column position within current line
+  const lineStart = findLineStart(value, cursorOffset);
+  const column = cursorOffset - lineStart;
+
+  // Next line starts after the newline
+  const nextLineStart = lineEnd + 1;
+  const nextLineEnd = findLineEnd(value, nextLineStart);
+  const nextLineLength = nextLineEnd - nextLineStart;
+
+  // Move to same column on next line, clamped to line length
+  return nextLineStart + Math.min(column, nextLineLength);
+}
+
 export function TextInput({
   value: externalValue,
   onChange,
@@ -275,6 +324,12 @@ export function TextInput({
         } else {
           result += tokenText;
         }
+      } else if (char === "\n") {
+        // For newlines, show cursor as inverse space at end of line
+        if (isCursor) {
+          result += chalk.inverse(" ");
+        }
+        result += "\n";
       } else {
         result += isCursor ? chalk.inverse(char) : char;
       }
@@ -338,14 +393,30 @@ export function TextInput({
         flushPasteBuffer();
       }
 
-      // Handle up arrow - let parent intercept if needed
+      // Handle up arrow - navigate within multiline text, or let parent handle
       if (key.upArrow) {
+        if (showCursor) {
+          const newPos = findPositionAbove(currentValue, currentCursor);
+          if (newPos !== -1) {
+            updateCursor(newPos);
+            return;
+          }
+        }
+        // On first line or cursor hidden - let parent intercept
         if (onUpArrow?.()) return;
         return; // Still block if no handler
       }
 
-      // Handle down arrow - let parent intercept if needed
+      // Handle down arrow - navigate within multiline text, or let parent handle
       if (key.downArrow) {
+        if (showCursor) {
+          const newPos = findPositionBelow(currentValue, currentCursor);
+          if (newPos !== -1) {
+            updateCursor(newPos);
+            return;
+          }
+        }
+        // On last line or cursor hidden - let parent intercept
         if (onDownArrow?.()) return;
         return; // Still block if no handler
       }

--- a/packages/tui/components/text-input.tsx
+++ b/packages/tui/components/text-input.tsx
@@ -29,7 +29,7 @@ type TextInputProps = {
 };
 
 /**
- * Find the position of the previous word boundary (for Option+Delete)
+ * Find the position of the previous word boundary (for Option+Left, Option+Delete)
  */
 function findPrevWordBoundary(value: string, cursorOffset: number): number {
   if (cursorOffset <= 0) return 0;
@@ -44,6 +44,27 @@ function findPrevWordBoundary(value: string, cursorOffset: number): number {
   // Skip the word characters
   while (pos > 0 && !/\s/.test(value[pos - 1]!)) {
     pos--;
+  }
+
+  return pos;
+}
+
+/**
+ * Find the position of the next word boundary (for Option+Right)
+ */
+function findNextWordBoundary(value: string, cursorOffset: number): number {
+  if (cursorOffset >= value.length) return value.length;
+
+  let pos = cursorOffset;
+
+  // Skip current word characters
+  while (pos < value.length && !/\s/.test(value[pos]!)) {
+    pos++;
+  }
+
+  // Skip whitespace
+  while (pos < value.length && /\s/.test(value[pos]!)) {
+    pos++;
   }
 
   return pos;
@@ -354,22 +375,23 @@ export function TextInput({
         if (showCursor) {
           // Option+Right: Move to next word boundary
           if (key.meta) {
-            let pos = currentCursor;
-            // Skip current word
-            while (
-              pos < currentValue.length &&
-              !/\s/.test(currentValue[pos]!)
-            ) {
-              pos++;
-            }
-            // Skip whitespace
-            while (pos < currentValue.length && /\s/.test(currentValue[pos]!)) {
-              pos++;
-            }
-            nextCursorOffset = pos;
+            nextCursorOffset = findNextWordBoundary(
+              currentValue,
+              currentCursor,
+            );
           } else {
             nextCursorOffset++;
           }
+        }
+      } else if (key.meta && input === "b") {
+        // Option+Left (emacs-style): Move to previous word boundary
+        if (showCursor) {
+          nextCursorOffset = findPrevWordBoundary(currentValue, currentCursor);
+        }
+      } else if (key.meta && input === "f") {
+        // Option+Right (emacs-style): Move to next word boundary
+        if (showCursor) {
+          nextCursorOffset = findNextWordBoundary(currentValue, currentCursor);
         }
       } else if (key.ctrl && input === "u") {
         // Ctrl+U: Delete entire line to the left (Cmd+Delete equivalent)

--- a/packages/tui/components/text-input.tsx
+++ b/packages/tui/components/text-input.tsx
@@ -70,6 +70,34 @@ function findNextWordBoundary(value: string, cursorOffset: number): number {
   return pos;
 }
 
+/**
+ * Find the position of the beginning of the current line (for Ctrl+A / Command+Left)
+ */
+function findLineStart(value: string, cursorOffset: number): number {
+  if (cursorOffset <= 0) return 0;
+
+  // Search backwards for a newline
+  for (let i = cursorOffset - 1; i >= 0; i--) {
+    if (value[i] === "\n") {
+      return i + 1; // Position after the newline
+    }
+  }
+  return 0; // No newline found, go to start
+}
+
+/**
+ * Find the position of the end of the current line (for Ctrl+E / Command+Right)
+ */
+function findLineEnd(value: string, cursorOffset: number): number {
+  // Search forwards for a newline
+  for (let i = cursorOffset; i < value.length; i++) {
+    if (value[i] === "\n") {
+      return i; // Position before the newline
+    }
+  }
+  return value.length; // No newline found, go to end
+}
+
 export function TextInput({
   value: externalValue,
   onChange,
@@ -392,6 +420,16 @@ export function TextInput({
         // Option+Right (emacs-style): Move to next word boundary
         if (showCursor) {
           nextCursorOffset = findNextWordBoundary(currentValue, currentCursor);
+        }
+      } else if (key.ctrl && input === "a") {
+        // Ctrl+A (Command+Left): Move to beginning of current line
+        if (showCursor) {
+          nextCursorOffset = findLineStart(currentValue, currentCursor);
+        }
+      } else if (key.ctrl && input === "e") {
+        // Ctrl+E (Command+Right): Move to end of current line
+        if (showCursor) {
+          nextCursorOffset = findLineEnd(currentValue, currentCursor);
         }
       } else if (key.ctrl && input === "u") {
         // Ctrl+U: Delete entire line to the left (Cmd+Delete equivalent)

--- a/packages/tui/components/text-input.tsx
+++ b/packages/tui/components/text-input.tsx
@@ -503,10 +503,13 @@ export function TextInput({
           nextCursorOffset = findLineEnd(currentValue, currentCursor);
         }
       } else if (key.ctrl && input === "u") {
-        // Ctrl+U: Delete entire line to the left (Cmd+Delete equivalent)
-        if (currentCursor > 0) {
-          nextValue = currentValue.slice(currentCursor);
-          nextCursorOffset = 0;
+        // Ctrl+U: Delete to beginning of current line (Cmd+Delete equivalent)
+        const lineStart = findLineStart(currentValue, currentCursor);
+        if (currentCursor > lineStart) {
+          nextValue =
+            currentValue.slice(0, lineStart) +
+            currentValue.slice(currentCursor);
+          nextCursorOffset = lineStart;
         }
       } else if (key.ctrl && input === "w") {
         // Ctrl+W: Delete previous word (unix-style, Option+Delete equivalent)


### PR DESCRIPTION
## Summary
- Add up/down arrow navigation within multiline text (falls back to parent handler on first/last line)
- Add Ctrl+A/E keybindings for beginning/end of current line navigation
- Add Option+B/F keybindings for word navigation (emacs-style)
- Fix Cmd+Delete (Ctrl+U) to only delete to beginning of current line instead of entire text
- Fix cursor rendering for newlines (show inverse space at end of line)

## Test plan
- [ ] Type multiline text and verify up/down arrows navigate between lines
- [ ] On first line, verify up arrow triggers parent handler (e.g., history navigation)
- [ ] On last line, verify down arrow triggers parent handler
- [ ] Test Ctrl+A moves to beginning of current line
- [ ] Test Ctrl+E moves to end of current line
- [ ] Test Option+B moves to previous word boundary
- [ ] Test Option+F moves to next word boundary
- [ ] Test Ctrl+U only deletes text from cursor to beginning of current line (not entire text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)