### PR TITLE
Refactor approval system to discriminated union

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -139,7 +139,11 @@ async function main() {
       },
       agentOptions: {
         sandbox,
-        mode: "interactive",
+        approval: {
+          type: "interactive",
+          autoApprove: "off",
+          sessionRules: [],
+        },
         ...(agentsMd?.content && {
           customInstructions: agentsMd.content,
         }),

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -110,10 +110,13 @@ export async function POST(req: Request) {
     messages: modelMessages,
     options: {
       sandbox,
-      mode: "interactive",
       model,
       // TODO: consider enabling approvals for non-cloud-sandbox environments
-      approvals: { autoApprove: "all" },
+      approval: {
+        type: "interactive",
+        autoApprove: "all",
+        sessionRules: [],
+      },
     },
     abortSignal: req.signal,
   });

--- a/docs/plans/approval-config-refactor.md
+++ b/docs/plans/approval-config-refactor.md
@@ -1,6 +1,6 @@
 # Plan: Refactor Approval Config to Discriminated Union
 
-**Status:** Incomplete / Not Implemented
+**Status:** Implemented
 
 ## Problem
 

--- a/packages/agent/deep-agent.ts
+++ b/packages/agent/deep-agent.ts
@@ -48,11 +48,11 @@ export const defaultModelLabel = defaultModel.modelId;
 const tools = {
   todo_write: todoWriteTool,
   read: readFileTool(),
-  write: writeFileTool({ needsApproval: true }),
-  edit: editFileTool({ needsApproval: true }),
+  write: writeFileTool(),
+  edit: editFileTool(),
   grep: grepTool(),
   glob: globTool(),
-  bash: bashTool({ needsApproval: true }),
+  bash: bashTool(),
   task: taskTool,
 } satisfies ToolSet;
 

--- a/packages/agent/deep-agent.ts
+++ b/packages/agent/deep-agent.ts
@@ -101,9 +101,6 @@ export const deepAgent = new ToolLoopAgent({
       experimental_context: { sandbox, approval },
     };
   },
-  // Sandbox lifecycle is managed by the consumer, not the agent.
-  // Consumers should call sandbox.stop() when they're done with the sandbox.
-  onFinish: async () => {},
 });
 
 export function extractTodosFromStep(

--- a/packages/agent/deep-agent.ts
+++ b/packages/agent/deep-agent.ts
@@ -18,25 +18,26 @@ import {
   taskTool,
 } from "./tools";
 import { buildSystemPrompt } from "./system-prompt";
-import type { TodoItem, AgentMode, ApprovalRule } from "./types";
+import type { TodoItem, ApprovalConfig } from "./types";
 import { approvalRuleSchema } from "./types";
 import { addCacheControl, compactContext } from "./context-management";
 import type { Sandbox } from "@open-harness/sandbox";
 
-const agentModeSchema = z.enum(["interactive", "background"]);
-const autoApproveSchema = z.enum(["off", "edits", "all"]);
-
-const approvalsSchema = z.object({
-  autoApprove: autoApproveSchema.optional(),
-  rules: z.array(approvalRuleSchema).optional(),
-});
+const approvalConfigSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("interactive"),
+    autoApprove: z.enum(["off", "edits", "all"]).default("off"),
+    sessionRules: z.array(approvalRuleSchema).default([]),
+  }),
+  z.object({ type: z.literal("background") }),
+  z.object({ type: z.literal("delegated") }),
+]);
 
 const callOptionsSchema = z.object({
   sandbox: z.custom<Sandbox>(),
-  mode: agentModeSchema,
+  approval: approvalConfigSchema,
   model: z.custom<LanguageModel>().optional(),
   customInstructions: z.string().optional(),
-  approvals: approvalsSchema.optional(),
 });
 
 export type DeepAgentCallOptions = z.infer<typeof callOptionsSchema>;
@@ -70,15 +71,16 @@ export const deepAgent = new ToolLoopAgent({
   prepareCall: ({ options, model, ...settings }) => {
     if (!options) {
       throw new Error(
-        "Deep agent requires call options with sandbox and mode.",
+        "Deep agent requires call options with sandbox and approval config.",
       );
     }
-    const mode: AgentMode = options.mode;
+    const approval: ApprovalConfig = options.approval;
     const callModel = options.model ?? model;
-    const autoApprove = options.approvals?.autoApprove ?? "off";
-    const approvalRules: ApprovalRule[] = options.approvals?.rules ?? [];
     const customInstructions = options.customInstructions;
     const sandbox = options.sandbox;
+
+    // Derive mode for system prompt (interactive vs background)
+    const mode = approval.type === "background" ? "background" : "interactive";
 
     const instructions = buildSystemPrompt({
       cwd: sandbox.workingDirectory,
@@ -96,7 +98,7 @@ export const deepAgent = new ToolLoopAgent({
         model: callModel,
       }),
       instructions,
-      experimental_context: { sandbox, mode, autoApprove, approvalRules },
+      experimental_context: { sandbox, approval },
     };
   },
   // Sandbox lifecycle is managed by the consumer, not the agent.

--- a/packages/agent/docs/approval-system.md
+++ b/packages/agent/docs/approval-system.md
@@ -1,0 +1,257 @@
+# Tool Approval System
+
+This document explains how tool approvals work in Open Harness.
+
+## Overview
+
+The approval system controls when tools require user confirmation before executing. It uses a discriminated union pattern to make trust models explicit and type-safe.
+
+## Approval Configuration
+
+The `ApprovalConfig` type defines three trust models:
+
+```typescript
+type ApprovalConfig =
+  | {
+      type: "interactive";
+      autoApprove: "off" | "edits" | "all";
+      sessionRules: ApprovalRule[];
+    }
+  | { type: "background" }
+  | { type: "delegated" };
+```
+
+### Interactive Mode
+
+Used for local development with human oversight.
+
+- **`autoApprove: "off"`** - All potentially dangerous operations require approval
+- **`autoApprove: "edits"`** - Write/edit operations inside the working directory auto-approve
+- **`autoApprove: "all"`** - All operations inside the working directory auto-approve
+- **`sessionRules`** - User-created rules that persist for the session
+
+### Background Mode
+
+Used for async cloud execution (e.g., Vercel sandbox). Auto-approves all tools because safety relies on git checkpointing rather than interactive approval.
+
+### Delegated Mode
+
+Used by subagents that inherit trust from their parent agent. Auto-approves all tools unconditionally.
+
+## Approval Rules
+
+Session rules allow users to grant persistent approval for specific patterns. Rules use a discriminated union with three types:
+
+```typescript
+type ApprovalRule =
+  | { type: "command-prefix"; tool: "bash"; prefix: string }
+  | {
+      type: "path-glob";
+      tool: "read" | "write" | "edit" | "grep" | "glob";
+      glob: string;
+    }
+  | {
+      type: "subagent-type";
+      tool: "task";
+      subagentType: "explorer" | "executor";
+    };
+```
+
+### Command Prefix Rules
+
+For the bash tool. If a command starts with the prefix, it auto-approves.
+
+```typescript
+{ type: "command-prefix", tool: "bash", prefix: "npm test" }
+```
+
+### Path Glob Rules
+
+For file-based tools. If a file path matches the glob pattern, it auto-approves.
+
+```typescript
+{ type: "path-glob", tool: "write", glob: "src/**/*.ts" }
+```
+
+### Subagent Type Rules
+
+For the task tool. If the subagent type matches, it auto-approves.
+
+```typescript
+{ type: "subagent-type", tool: "task", subagentType: "executor" }
+```
+
+## Approval Flow
+
+```
+Tool Called
+    ↓
+needsApproval() function runs
+    ↓
+┌─────────────────────────────────────┐
+│ Is approval type "background"       │──Yes──→ Auto-approve
+│ or "delegated"?                     │
+└──────────────┬──────────────────────┘
+               │ No (interactive mode)
+               ↓
+┌─────────────────────────────────────┐
+│ Does operation match a session rule?│──Yes──→ Auto-approve
+└──────────────┬──────────────────────┘
+               │ No
+               ↓
+      Tool-specific logic
+               ↓
+┌─────────────────────────────────────┐
+│ Approval needed?                    │──Yes──→ Show approval panel
+└──────────────┬──────────────────────┘
+               │ No
+               ↓
+         Auto-approve
+```
+
+## Tool-Specific Logic
+
+### Write and Edit Tools
+
+1. Check session rules (can match any path, inside or outside working directory)
+2. If path is outside working directory → needs approval
+3. If inside working directory, check `autoApprove` setting:
+   - `"edits"` or `"all"` → auto-approve
+   - `"off"` → needs approval
+
+```typescript
+// Simplified logic from pathNeedsApproval()
+if (pathMatchesApprovalRule(path, tool, sessionRules)) return false;
+if (!isInsideWorkingDir) return true;
+if (autoApprove === "edits" || autoApprove === "all") return false;
+return true;
+```
+
+### Read, Grep, Glob Tools
+
+1. If path is inside working directory → auto-approve
+2. If outside, check session rules
+3. If no matching rule → needs approval
+
+```typescript
+// Simplified logic from pathNeedsApproval()
+if (isInsideWorkingDir) return false;
+if (pathMatchesApprovalRule(path, tool, sessionRules)) return false;
+return true;
+```
+
+### Bash Tool
+
+1. Check session rules for command prefix match
+2. If `cwd` is outside working directory → needs approval
+3. If `autoApprove === "all"` → auto-approve all commands
+4. Check command against safe/dangerous patterns:
+   - Safe commands (ls, cat, git status, etc.) → auto-approve
+   - Dangerous patterns (rm, git push, pipes, etc.) → needs approval
+
+```typescript
+// Simplified logic
+if (commandMatchesApprovalRule(command, sessionRules)) return false;
+if (cwdIsOutsideWorkingDirectory(cwd)) return true;
+if (autoApprove === "all") return false;
+return commandNeedsApproval(command);
+```
+
+### Task Tool (Subagents)
+
+1. Explorer subagent → never needs approval (read-only)
+2. Executor subagent:
+   - Check session rules for subagent-type match
+   - Otherwise → needs approval
+
+```typescript
+// Simplified logic
+if (subagentType !== "executor") return false;
+if (subagentMatchesApprovalRule(subagentType, sessionRules)) return false;
+return true;
+```
+
+## Subagent Trust Delegation
+
+Subagents inherit trust from the parent agent by using `{ type: "delegated" }`:
+
+```typescript
+// From executor.ts and explorer.ts
+prepareCall: ({ options, ...settings }) => ({
+  ...settings,
+  experimental_context: {
+    sandbox,
+    approval: { type: "delegated" },
+  },
+});
+```
+
+This means:
+
+- Individual tool calls within subagents auto-approve
+- Approval happens at the task level (executor requires approval before spawning)
+- Once approved, the subagent runs autonomously
+
+## Helper Functions
+
+Located in `packages/agent/tools/utils.ts`:
+
+### `shouldAutoApprove(approval: ApprovalConfig): boolean`
+
+Type guard that returns `true` for background and delegated modes. Use this first in `needsApproval` functions.
+
+```typescript
+if (shouldAutoApprove(approval)) {
+  return false; // Auto-approve
+}
+// TypeScript now knows approval.type === "interactive"
+```
+
+### `getApprovalContext(experimental_context, toolName?)`
+
+Extracts sandbox, workingDirectory, and approval config from the AI SDK context. Throws descriptive errors if context is missing.
+
+### `pathNeedsApproval(options: PathApprovalOptions): boolean`
+
+Consolidated logic for path-based tools (read, write, edit, grep, glob). Handles:
+
+- Session rule matching
+- Working directory boundary checks
+- autoApprove setting logic
+
+### `pathMatchesApprovalRule(path, tool, workingDirectory, rules): boolean`
+
+Checks if a file path matches any path-glob rules for the given tool.
+
+### `pathMatchesGlob(path, glob, baseDir, options?): boolean`
+
+Converts glob patterns to regex and tests paths. Supports `**` for recursive matching.
+
+## Key Files
+
+| File                                   | Purpose                                |
+| -------------------------------------- | -------------------------------------- |
+| `packages/agent/types.ts`              | `ApprovalConfig`, `ApprovalRule` types |
+| `packages/agent/tools/utils.ts`        | Helper functions for approval logic    |
+| `packages/agent/tools/write.ts`        | Write and edit tool approval           |
+| `packages/agent/tools/read.ts`         | Read tool approval                     |
+| `packages/agent/tools/bash.ts`         | Bash tool approval with command safety |
+| `packages/agent/tools/grep.ts`         | Grep tool approval                     |
+| `packages/agent/tools/glob.ts`         | Glob tool approval                     |
+| `packages/agent/tools/task.ts`         | Task tool approval for subagents       |
+| `packages/agent/subagents/executor.ts` | Executor with delegated approval       |
+| `packages/agent/subagents/explorer.ts` | Explorer with delegated approval       |
+
+## Design Decisions
+
+1. **Discriminated unions over boolean flags**: Makes trust models explicit and eliminates implicit precedence rules.
+
+2. **Type guards**: `shouldAutoApprove()` enables TypeScript to narrow types after the check.
+
+3. **Path-based approval**: Allows granular rules like "approve all writes in src/\*\*" without per-file prompts.
+
+4. **Delegated trust**: Subagents inherit trust, avoiding repeated approval for nested operations.
+
+5. **Session-scoped rules**: Users can create rules during a session that persist until the session ends.
+
+6. **Safe by default**: Unknown commands and paths outside working directory require approval.

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -8,7 +8,7 @@ export type { DeepAgentCallOptions } from "./deep-agent";
 export type {
   TodoItem,
   TodoStatus,
-  AgentMode,
+  ApprovalConfig,
   ApprovalRule,
 } from "./types";
 export { DEEP_AGENT_SYSTEM_PROMPT, buildSystemPrompt } from "./system-prompt";

--- a/packages/agent/subagents/executor.ts
+++ b/packages/agent/subagents/executor.ts
@@ -4,7 +4,7 @@ import { readFileTool } from "../tools/read";
 import { writeFileTool, editFileTool } from "../tools/write";
 import { grepTool } from "../tools/grep";
 import { globTool } from "../tools/glob";
-import { bashTool, commandNeedsApproval } from "../tools/bash";
+import { bashTool } from "../tools/bash";
 import type { Sandbox } from "@open-harness/sandbox";
 
 const EXECUTOR_SYSTEM_PROMPT = `You are an executor agent - a fire-and-forget subagent that completes specific, well-defined implementation tasks autonomously.
@@ -57,16 +57,13 @@ export const executorSubagent = new ToolLoopAgent({
   model: "anthropic/claude-haiku-4.5",
   instructions: EXECUTOR_SYSTEM_PROMPT,
   tools: {
+    // All tools auto-approve in delegated mode (set via prepareCall)
     read: readFileTool(),
-    write: writeFileTool({ needsApproval: false }),
-    edit: editFileTool({ needsApproval: false }),
+    write: writeFileTool(),
+    edit: editFileTool(),
     grep: grepTool(),
     glob: globTool(),
-    // Use smart approval: safe read-only commands run without approval,
-    // dangerous commands (rm, git push, etc.) still require approval
-    bash: bashTool({
-      needsApproval: ({ command }) => commandNeedsApproval(command),
-    }),
+    bash: bashTool(),
   },
   stopWhen: stepCountIs(30),
   callOptionsSchema,

--- a/packages/agent/subagents/executor.ts
+++ b/packages/agent/subagents/executor.ts
@@ -90,8 +90,7 @@ ${options.instructions}
 - Your final message MUST include both a **Summary** of what you did AND the **Answer** to the task`,
       experimental_context: {
         sandbox,
-        workingDirectory: sandbox.workingDirectory,
-        autoApprove: "all",
+        approval: { type: "delegated" },
       },
     };
   },

--- a/packages/agent/subagents/explorer.ts
+++ b/packages/agent/subagents/explorer.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { readFileTool } from "../tools/read";
 import { grepTool } from "../tools/grep";
 import { globTool } from "../tools/glob";
-import { bashTool, commandNeedsApproval } from "../tools/bash";
+import { bashTool } from "../tools/bash";
 import type { Sandbox } from "@open-harness/sandbox";
 
 const EXPLORER_SYSTEM_PROMPT = `You are an explorer agent - a fast, read-only subagent specialized for exploring codebases.
@@ -70,14 +70,11 @@ export const explorerSubagent = new ToolLoopAgent({
   model: "anthropic/claude-haiku-4.5",
   instructions: EXPLORER_SYSTEM_PROMPT,
   tools: {
+    // All tools auto-approve in delegated mode (set via prepareCall)
     read: readFileTool(),
     grep: grepTool(),
     glob: globTool(),
-    // Use smart approval: safe read-only commands run without approval,
-    // dangerous commands are blocked (explorer is read-only anyway)
-    bash: bashTool({
-      needsApproval: ({ command }) => commandNeedsApproval(command),
-    }),
+    bash: bashTool(),
   },
   stopWhen: stepCountIs(30),
   callOptionsSchema,

--- a/packages/agent/subagents/explorer.ts
+++ b/packages/agent/subagents/explorer.ts
@@ -101,8 +101,7 @@ ${options.instructions}
 - Your final message MUST include both a **Summary** of what you searched AND the **Answer** to the task`,
       experimental_context: {
         sandbox,
-        workingDirectory: sandbox.workingDirectory,
-        autoApprove: "all",
+        approval: { type: "delegated" },
       },
     };
   },

--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -1,7 +1,13 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
-import { isPathWithinDirectory, getSandbox, getApprovalContext } from "./utils";
+import {
+  isPathWithinDirectory,
+  getSandbox,
+  getApprovalContext,
+  shouldAutoApprove,
+  getSessionRules,
+} from "./utils";
 import type { ApprovalRule } from "../types";
 
 const TIMEOUT_MS = 120_000;
@@ -131,30 +137,40 @@ export const bashTool = (options?: ToolOptions) =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "bash");
-      // Check if command matches any saved approval rules
-      if (commandMatchesApprovalRule(args.command, ctx.approvalRules)) {
+      const { approval } = ctx;
+
+      // Check if command matches any saved session rules
+      if (commandMatchesApprovalRule(args.command, getSessionRules(approval))) {
         return false;
       }
-      // Need approval if cwd is outside working directory (even in background mode)
+
+      // Need approval if cwd is outside working directory (even in background/delegated mode)
       if (cwdIsOutsideWorkingDirectory(args.cwd, ctx.workingDirectory)) {
         return true;
       }
-      // In background mode, auto-approve all operations within working directory
-      if (ctx.mode === "background") {
+
+      // Background and delegated modes auto-approve all operations within working directory
+      if (shouldAutoApprove(approval)) {
         return false;
       }
-      // Auto-approve bash commands within working directory in interactive mode
-      if (ctx.mode === "interactive" && ctx.autoApprove === "all") {
-        return false;
-      }
-      // Check command safety
-      if (commandNeedsApproval(args.command)) {
-        // If command is dangerous, check user's approval setting
-        if (typeof options?.needsApproval === "function") {
-          return options.needsApproval(args);
+
+      // Interactive mode: check autoApprove setting and command safety
+      if (approval.type === "interactive") {
+        // Auto-approve all bash commands when autoApprove is "all"
+        if (approval.autoApprove === "all") {
+          return false;
         }
-        return options?.needsApproval ?? true;
+
+        // Check command safety
+        if (commandNeedsApproval(args.command)) {
+          // If command is dangerous, check user's approval setting
+          if (typeof options?.needsApproval === "function") {
+            return options.needsApproval(args);
+          }
+          return options?.needsApproval ?? true;
+        }
       }
+
       // Command is safe - no approval needed
       return false;
     },

--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -139,19 +139,19 @@ export const bashTool = (options?: ToolOptions) =>
       const ctx = getApprovalContext(experimental_context, "bash");
       const { approval } = ctx;
 
+      // Background and delegated modes auto-approve all operations
+      if (shouldAutoApprove(approval)) {
+        return false;
+      }
+
       // Check if command matches any saved session rules
       if (commandMatchesApprovalRule(args.command, getSessionRules(approval))) {
         return false;
       }
 
-      // Need approval if cwd is outside working directory (even in background/delegated mode)
+      // Need approval if cwd is outside working directory
       if (cwdIsOutsideWorkingDirectory(args.cwd, ctx.workingDirectory)) {
         return true;
-      }
-
-      // Background and delegated modes auto-approve all operations within working directory
-      if (shouldAutoApprove(approval)) {
-        return false;
       }
 
       // Interactive mode: check autoApprove setting and command safety

--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -6,7 +6,6 @@ import {
   getSandbox,
   getApprovalContext,
   shouldAutoApprove,
-  getSessionRules,
 } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -144,8 +143,9 @@ export const bashTool = (options?: ToolOptions) =>
         return false;
       }
 
+      // Type guard narrowed approval to interactive mode
       // Check if command matches any saved session rules
-      if (commandMatchesApprovalRule(args.command, getSessionRules(approval))) {
+      if (commandMatchesApprovalRule(args.command, approval.sessionRules)) {
         return false;
       }
 
@@ -154,21 +154,18 @@ export const bashTool = (options?: ToolOptions) =>
         return true;
       }
 
-      // Interactive mode: check autoApprove setting and command safety
-      if (approval.type === "interactive") {
-        // Auto-approve all bash commands when autoApprove is "all"
-        if (approval.autoApprove === "all") {
-          return false;
-        }
+      // Auto-approve all bash commands when autoApprove is "all"
+      if (approval.autoApprove === "all") {
+        return false;
+      }
 
-        // Check command safety
-        if (commandNeedsApproval(args.command)) {
-          // If command is dangerous, check user's approval setting
-          if (typeof options?.needsApproval === "function") {
-            return options.needsApproval(args);
-          }
-          return options?.needsApproval ?? true;
+      // Check command safety
+      if (commandNeedsApproval(args.command)) {
+        // If command is dangerous, check user's approval setting
+        if (typeof options?.needsApproval === "function") {
+          return options.needsApproval(args);
         }
+        return options?.needsApproval ?? true;
       }
 
       // Command is safe - no approval needed

--- a/packages/agent/tools/glob.ts
+++ b/packages/agent/tools/glob.ts
@@ -7,6 +7,7 @@ import {
   getSandbox,
   pathMatchesGlob,
   getApprovalContext,
+  getSessionRules,
 } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -147,27 +148,33 @@ export const globTool = () =>
   tool({
     needsApproval: (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "glob");
+      const { approval } = ctx;
+
       // If no path is provided, it defaults to working directory (no approval needed)
       if (!args.path) {
         return false;
       }
+
       const absolutePath = path.isAbsolute(args.path)
         ? args.path
         : path.resolve(ctx.workingDirectory, args.path);
+
       // Check if within working directory - no approval needed
       if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
         return false;
       }
-      // Outside working directory - check if a rule matches
+
+      // Outside working directory - check if a session rule matches
       if (
         pathMatchesApprovalRule(
           args.path,
           ctx.workingDirectory,
-          ctx.approvalRules,
+          getSessionRules(approval),
         )
       ) {
         return false;
       }
+
       return true;
     },
     description: `Find files matching a glob pattern.

--- a/packages/agent/tools/glob.ts
+++ b/packages/agent/tools/glob.ts
@@ -3,14 +3,11 @@ import { z } from "zod";
 import * as path from "path";
 import type { Sandbox } from "@open-harness/sandbox";
 import {
-  isPathWithinDirectory,
   getSandbox,
-  pathMatchesGlob,
   getApprovalContext,
-  getSessionRules,
   shouldAutoApprove,
+  pathNeedsApproval,
 } from "./utils";
-import type { ApprovalRule } from "../types";
 
 interface FileInfo {
   path: string;
@@ -115,36 +112,6 @@ const globInputSchema = z.object({
     .describe("Maximum number of results. Default: 100"),
 });
 
-/**
- * Check if a path matches any path-glob approval rules for glob operations.
- * Glob approval rules apply to paths OUTSIDE the working directory, so we need
- * to allow matching outside the base directory.
- */
-function pathMatchesApprovalRule(
-  searchPath: string,
-  workingDirectory: string,
-  approvalRules: ApprovalRule[],
-): boolean {
-  const absolutePath = path.isAbsolute(searchPath)
-    ? searchPath
-    : path.resolve(workingDirectory, searchPath);
-
-  for (const rule of approvalRules) {
-    if (rule.type === "path-glob" && rule.tool === "glob") {
-      // Glob rules apply to paths outside the working directory,
-      // so we must allow matching outside the base
-      if (
-        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
-          allowOutsideBase: true,
-        })
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 export const globTool = () =>
   tool({
     needsApproval: (args, { experimental_context }) => {
@@ -161,27 +128,12 @@ export const globTool = () =>
         return false;
       }
 
-      const absolutePath = path.isAbsolute(args.path)
-        ? args.path
-        : path.resolve(ctx.workingDirectory, args.path);
-
-      // Check if within working directory - no approval needed
-      if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
-        return false;
-      }
-
-      // Outside working directory - check if a session rule matches
-      if (
-        pathMatchesApprovalRule(
-          args.path,
-          ctx.workingDirectory,
-          getSessionRules(approval),
-        )
-      ) {
-        return false;
-      }
-
-      return true;
+      return pathNeedsApproval({
+        path: args.path,
+        tool: "glob",
+        approval,
+        workingDirectory: ctx.workingDirectory,
+      });
     },
     description: `Find files matching a glob pattern.
 

--- a/packages/agent/tools/glob.ts
+++ b/packages/agent/tools/glob.ts
@@ -8,6 +8,7 @@ import {
   pathMatchesGlob,
   getApprovalContext,
   getSessionRules,
+  shouldAutoApprove,
 } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -149,6 +150,11 @@ export const globTool = () =>
     needsApproval: (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "glob");
       const { approval } = ctx;
+
+      // Background and delegated modes auto-approve all operations
+      if (shouldAutoApprove(approval)) {
+        return false;
+      }
 
       // If no path is provided, it defaults to working directory (no approval needed)
       if (!args.path) {

--- a/packages/agent/tools/grep.ts
+++ b/packages/agent/tools/grep.ts
@@ -3,14 +3,11 @@ import { z } from "zod";
 import * as path from "path";
 import type { Sandbox } from "@open-harness/sandbox";
 import {
-  isPathWithinDirectory,
   getSandbox,
-  pathMatchesGlob,
   getApprovalContext,
-  getSessionRules,
   shouldAutoApprove,
+  pathNeedsApproval,
 } from "./utils";
-import type { ApprovalRule } from "../types";
 
 interface GrepMatch {
   file: string;
@@ -106,36 +103,6 @@ const grepInputSchema = z.object({
     .describe("Case-sensitive search. Default: true"),
 });
 
-/**
- * Check if a path matches any path-glob approval rules for grep operations.
- * Grep approval rules apply to paths OUTSIDE the working directory, so we need
- * to allow matching outside the base directory.
- */
-function pathMatchesApprovalRule(
-  searchPath: string,
-  workingDirectory: string,
-  approvalRules: ApprovalRule[],
-): boolean {
-  const absolutePath = path.isAbsolute(searchPath)
-    ? searchPath
-    : path.resolve(workingDirectory, searchPath);
-
-  for (const rule of approvalRules) {
-    if (rule.type === "path-glob" && rule.tool === "grep") {
-      // Grep rules apply to paths outside the working directory,
-      // so we must allow matching outside the base
-      if (
-        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
-          allowOutsideBase: true,
-        })
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 export const grepTool = () =>
   tool({
     needsApproval: (args, { experimental_context }) => {
@@ -147,27 +114,12 @@ export const grepTool = () =>
         return false;
       }
 
-      const absolutePath = path.isAbsolute(args.path)
-        ? args.path
-        : path.resolve(ctx.workingDirectory, args.path);
-
-      // Check if within working directory - no approval needed
-      if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
-        return false;
-      }
-
-      // Outside working directory - check if a session rule matches
-      if (
-        pathMatchesApprovalRule(
-          args.path,
-          ctx.workingDirectory,
-          getSessionRules(approval),
-        )
-      ) {
-        return false;
-      }
-
-      return true;
+      return pathNeedsApproval({
+        path: args.path,
+        tool: "grep",
+        approval,
+        workingDirectory: ctx.workingDirectory,
+      });
     },
     description: `Search for patterns in files using JavaScript regular expressions.
 

--- a/packages/agent/tools/grep.ts
+++ b/packages/agent/tools/grep.ts
@@ -8,6 +8,7 @@ import {
   pathMatchesGlob,
   getApprovalContext,
   getSessionRules,
+  shouldAutoApprove,
 } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -140,6 +141,12 @@ export const grepTool = () =>
     needsApproval: (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "grep");
       const { approval } = ctx;
+
+      // Background and delegated modes auto-approve all operations
+      if (shouldAutoApprove(approval)) {
+        return false;
+      }
+
       const absolutePath = path.isAbsolute(args.path)
         ? args.path
         : path.resolve(ctx.workingDirectory, args.path);

--- a/packages/agent/tools/grep.ts
+++ b/packages/agent/tools/grep.ts
@@ -7,6 +7,7 @@ import {
   getSandbox,
   pathMatchesGlob,
   getApprovalContext,
+  getSessionRules,
 } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -138,23 +139,27 @@ export const grepTool = () =>
   tool({
     needsApproval: (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "grep");
+      const { approval } = ctx;
       const absolutePath = path.isAbsolute(args.path)
         ? args.path
         : path.resolve(ctx.workingDirectory, args.path);
+
       // Check if within working directory - no approval needed
       if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
         return false;
       }
-      // Outside working directory - check if a rule matches
+
+      // Outside working directory - check if a session rule matches
       if (
         pathMatchesApprovalRule(
           args.path,
           ctx.workingDirectory,
-          ctx.approvalRules,
+          getSessionRules(approval),
         )
       ) {
         return false;
       }
+
       return true;
     },
     description: `Search for patterns in files using JavaScript regular expressions.

--- a/packages/agent/tools/read.ts
+++ b/packages/agent/tools/read.ts
@@ -8,6 +8,7 @@ import {
   getApprovalContext,
   pathMatchesGlob,
   getSessionRules,
+  shouldAutoApprove,
 } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -94,6 +95,12 @@ export const readFileTool = () =>
     needsApproval: (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "read");
       const { approval } = ctx;
+
+      // Background and delegated modes auto-approve all operations
+      if (shouldAutoApprove(approval)) {
+        return false;
+      }
+
       const absolutePath = resolveFilePath(args.filePath, ctx.workingDirectory);
 
       // Check if within working directory - no approval needed

--- a/packages/agent/tools/read.ts
+++ b/packages/agent/tools/read.ts
@@ -3,14 +3,11 @@ import { z } from "zod";
 import * as path from "path";
 import * as fs from "fs";
 import {
-  isPathWithinDirectory,
   getSandbox,
   getApprovalContext,
-  pathMatchesGlob,
-  getSessionRules,
   shouldAutoApprove,
+  pathNeedsApproval,
 } from "./utils";
-import type { ApprovalRule } from "../types";
 
 const readInputSchema = z.object({
   filePath: z
@@ -60,36 +57,6 @@ function resolveFilePath(filePath: string, workingDirectory: string): string {
   return absolutePath;
 }
 
-/**
- * Check if a file path matches any path-glob approval rules for read operations.
- * Read approval rules apply to paths OUTSIDE the working directory, so we need
- * to allow matching outside the base directory.
- */
-function pathMatchesApprovalRule(
-  filePath: string,
-  workingDirectory: string,
-  approvalRules: ApprovalRule[],
-): boolean {
-  const absolutePath = path.isAbsolute(filePath)
-    ? filePath
-    : path.resolve(workingDirectory, filePath);
-
-  for (const rule of approvalRules) {
-    if (rule.type === "path-glob" && rule.tool === "read") {
-      // Read rules apply to paths outside the working directory,
-      // so we must allow matching outside the base
-      if (
-        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
-          allowOutsideBase: true,
-        })
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 export const readFileTool = () =>
   tool({
     needsApproval: (args, { experimental_context }) => {
@@ -101,26 +68,12 @@ export const readFileTool = () =>
         return false;
       }
 
-      const absolutePath = resolveFilePath(args.filePath, ctx.workingDirectory);
-
-      // Check if within working directory - no approval needed
-      if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
-        return false;
-      }
-
-      // Check if path matches any saved session rules
-      if (
-        pathMatchesApprovalRule(
-          args.filePath,
-          ctx.workingDirectory,
-          getSessionRules(approval),
-        )
-      ) {
-        return false;
-      }
-
-      // Outside working directory - requires approval
-      return true;
+      return pathNeedsApproval({
+        path: resolveFilePath(args.filePath, ctx.workingDirectory),
+        tool: "read",
+        approval,
+        workingDirectory: ctx.workingDirectory,
+      });
     },
     description: `Read a file from the filesystem.
 

--- a/packages/agent/tools/read.ts
+++ b/packages/agent/tools/read.ts
@@ -7,6 +7,7 @@ import {
   getSandbox,
   getApprovalContext,
   pathMatchesGlob,
+  getSessionRules,
 } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -92,21 +93,25 @@ export const readFileTool = () =>
   tool({
     needsApproval: (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "read");
+      const { approval } = ctx;
       const absolutePath = resolveFilePath(args.filePath, ctx.workingDirectory);
+
       // Check if within working directory - no approval needed
       if (isPathWithinDirectory(absolutePath, ctx.workingDirectory)) {
         return false;
       }
-      // Check if path matches any saved approval rules
+
+      // Check if path matches any saved session rules
       if (
         pathMatchesApprovalRule(
           args.filePath,
           ctx.workingDirectory,
-          ctx.approvalRules,
+          getSessionRules(approval),
         )
       ) {
         return false;
       }
+
       // Outside working directory - requires approval
       return true;
     },

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -2,12 +2,7 @@ import { tool, readUIMessageStream, type UIToolInvocation } from "ai";
 import { z } from "zod";
 import { explorerSubagent } from "../subagents/explorer";
 import { executorSubagent } from "../subagents/executor";
-import {
-  getSandbox,
-  getApprovalContext,
-  shouldAutoApprove,
-  getSessionRules,
-} from "./utils";
+import { getSandbox, getApprovalContext, shouldAutoApprove } from "./utils";
 import type { ApprovalRule } from "../types";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
@@ -62,8 +57,9 @@ export const taskTool = tool({
       return false;
     }
 
+    // Type guard narrowed approval to interactive mode
     // Check if a session rule matches this subagent type
-    if (subagentMatchesApprovalRule(subagentType, getSessionRules(approval))) {
+    if (subagentMatchesApprovalRule(subagentType, approval.sessionRules)) {
       return false;
     }
 

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -2,7 +2,12 @@ import { tool, readUIMessageStream, type UIToolInvocation } from "ai";
 import { z } from "zod";
 import { explorerSubagent } from "../subagents/explorer";
 import { executorSubagent } from "../subagents/executor";
-import { getSandbox, getApprovalContext } from "./utils";
+import {
+  getSandbox,
+  getApprovalContext,
+  shouldAutoApprove,
+  getSessionRules,
+} from "./utils";
 import type { ApprovalRule } from "../types";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
@@ -45,18 +50,23 @@ export const taskTool = tool({
   // Explorer is read-only, so no approval needed
   needsApproval: ({ subagentType }, { experimental_context }) => {
     const ctx = getApprovalContext(experimental_context, "task");
+    const { approval } = ctx;
+
     // Explorer never needs approval
     if (subagentType !== "executor") {
       return false;
     }
-    // In background mode, auto-approve
-    if (ctx.mode === "background") {
+
+    // Background and delegated modes auto-approve
+    if (shouldAutoApprove(approval)) {
       return false;
     }
-    // Check if a rule matches this subagent type
-    if (subagentMatchesApprovalRule(subagentType, ctx.approvalRules)) {
+
+    // Check if a session rule matches this subagent type
+    if (subagentMatchesApprovalRule(subagentType, getSessionRules(approval))) {
       return false;
     }
+
     // Default: executor needs approval
     return true;
   },

--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -1,10 +1,5 @@
 import * as path from "path";
-import type {
-  AgentContext,
-  AgentMode,
-  AutoApprove,
-  ApprovalRule,
-} from "../types";
+import type { AgentContext, ApprovalConfig, ApprovalRule } from "../types";
 import type { Sandbox } from "@open-harness/sandbox";
 import type { ModelMessage } from "ai";
 
@@ -56,35 +51,34 @@ export function getSandbox(
 }
 
 /**
- * Get agent mode from experimental context.
- * Defaults to 'interactive' if not set (backward compatibility).
+ * Check if the approval config implies full trust (auto-approve everything within sandbox).
+ * Returns true for background and delegated modes.
  *
- * @param experimental_context - The context passed to tool execute functions
- * @returns The agent mode ('interactive' or 'background')
+ * @param approval - The approval configuration
+ * @returns true if the context implies full trust
  */
-export function getMode(experimental_context: unknown): AgentMode {
-  const context = experimental_context as AgentContext | undefined;
-  return context?.mode ?? "interactive";
+export function shouldAutoApprove(approval: ApprovalConfig): boolean {
+  return approval.type === "background" || approval.type === "delegated";
 }
 
 /**
- * Check if the agent is running in background mode.
- * Useful for conditional logic in tools.
+ * Get session rules from an approval config.
+ * Returns empty array for background and delegated modes.
  *
- * @param experimental_context - The context passed to tool execute functions
- * @returns true if running in background mode
+ * @param approval - The approval configuration
+ * @returns Array of approval rules, or empty array if not in interactive mode
  */
-export function isBackgroundMode(experimental_context: unknown): boolean {
-  return getMode(experimental_context) === "background";
+export function getSessionRules(approval: ApprovalConfig): ApprovalRule[] {
+  return approval.type === "interactive" ? approval.sessionRules : [];
 }
 
 /**
  * Get the full approval context from experimental_context.
- * Used by needsApproval functions to access mode, autoApprove, and approvalRules.
+ * Used by needsApproval functions to access approval configuration.
  *
  * @param experimental_context - The context passed to needsApproval functions
  * @param toolName - Optional tool name for better error messages
- * @returns Object with sandbox, mode, autoApprove, and approvalRules
+ * @returns Object with sandbox, workingDirectory, and approval config
  */
 export function getApprovalContext(
   experimental_context: unknown,
@@ -92,9 +86,7 @@ export function getApprovalContext(
 ): {
   sandbox: Sandbox;
   workingDirectory: string;
-  mode: AgentMode;
-  autoApprove: AutoApprove;
-  approvalRules: ApprovalRule[];
+  approval: ApprovalConfig;
 } {
   const context = experimental_context as AgentContext | undefined;
   if (!context?.sandbox) {
@@ -107,12 +99,18 @@ export function getApprovalContext(
         "Ensure the agent's prepareCall sets experimental_context: { sandbox, ... }",
     );
   }
+
+  // Default to interactive mode with no auto-approve if approval config is missing
+  const defaultApproval: ApprovalConfig = {
+    type: "interactive",
+    autoApprove: "off",
+    sessionRules: [],
+  };
+
   return {
     sandbox: context.sandbox,
     workingDirectory: context.sandbox.workingDirectory,
-    mode: context.mode ?? "interactive",
-    autoApprove: context.autoApprove ?? "off",
-    approvalRules: context.approvalRules ?? [],
+    approval: context.approval ?? defaultApproval,
   };
 }
 
@@ -169,7 +167,6 @@ export function pathMatchesGlob(
   }
 }
 
-
 export type ToolNeedsApprovalFunction<INPUT> = (
   input: INPUT,
   options: {
@@ -192,4 +189,3 @@ export type ToolNeedsApprovalFunction<INPUT> = (
     experimental_context?: unknown;
   },
 ) => boolean | PromiseLike<boolean>;
-

--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -54,10 +54,14 @@ export function getSandbox(
  * Check if the approval config implies full trust (auto-approve everything within sandbox).
  * Returns true for background and delegated modes.
  *
+ * This is a type guard - after checking, TypeScript narrows the type.
+ *
  * @param approval - The approval configuration
  * @returns true if the context implies full trust
  */
-export function shouldAutoApprove(approval: ApprovalConfig): boolean {
+export function shouldAutoApprove(
+  approval: ApprovalConfig,
+): approval is { type: "background" } | { type: "delegated" } {
   return approval.type === "background" || approval.type === "delegated";
 }
 
@@ -164,6 +168,129 @@ export function pathMatchesGlob(
   } catch {
     // If regex construction fails (malformed pattern), treat as no match
     return false;
+  }
+}
+
+/**
+ * Tools that can have path-glob approval rules.
+ */
+export type PathToolName = "read" | "write" | "edit" | "grep" | "glob";
+
+/**
+ * Check if a file path matches any path-glob approval rules for a specific tool.
+ * Rules can apply to paths outside the working directory, so we allow matching outside the base.
+ */
+export function pathMatchesApprovalRule(
+  filePath: string,
+  tool: PathToolName,
+  workingDirectory: string,
+  approvalRules: ApprovalRule[],
+): boolean {
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(workingDirectory, filePath);
+
+  for (const rule of approvalRules) {
+    if (rule.type === "path-glob" && rule.tool === tool) {
+      if (
+        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
+          allowOutsideBase: true,
+        })
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Options for checking if a path-based operation needs approval.
+ */
+type PathApprovalOptions = {
+  /** The file path to check */
+  path: string;
+  /** The tool making the request */
+  tool: PathToolName;
+  /** The approval config (must be interactive - use shouldAutoApprove first) */
+  approval: {
+    type: "interactive";
+    autoApprove: "off" | "edits" | "all";
+    sessionRules: ApprovalRule[];
+  };
+  /** The working directory for path resolution */
+  workingDirectory: string;
+};
+
+/**
+ * Determines if a path-based operation needs approval.
+ *
+ * Call shouldAutoApprove() first - this function assumes interactive mode.
+ *
+ * Logic:
+ * - Read-only tools (read, grep, glob): auto-approve inside working dir, check session rules outside
+ * - Write tools (write, edit): check session rules first, then working dir + autoApprove setting
+ *
+ * @returns true if approval is needed, false if auto-approved
+ */
+export function pathNeedsApproval(options: PathApprovalOptions): boolean {
+  const { path: filePath, tool, approval, workingDirectory } = options;
+
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(workingDirectory, filePath);
+
+  const isInsideWorkingDir = isPathWithinDirectory(
+    absolutePath,
+    workingDirectory,
+  );
+  const isWriteTool = tool === "write" || tool === "edit";
+
+  if (isWriteTool) {
+    // Write tools: session rules can auto-approve any path (inside or outside)
+    if (
+      pathMatchesApprovalRule(
+        filePath,
+        tool,
+        workingDirectory,
+        approval.sessionRules,
+      )
+    ) {
+      return false;
+    }
+
+    // Outside working directory without matching rule = needs approval
+    if (!isInsideWorkingDir) {
+      return true;
+    }
+
+    // Inside working directory: check autoApprove setting
+    if (approval.autoApprove === "edits" || approval.autoApprove === "all") {
+      return false;
+    }
+
+    // Inside working directory but autoApprove doesn't cover edits
+    return true;
+  } else {
+    // Read-only tools: inside working directory = auto-approve
+    if (isInsideWorkingDir) {
+      return false;
+    }
+
+    // Outside working directory: check session rules
+    if (
+      pathMatchesApprovalRule(
+        filePath,
+        tool,
+        workingDirectory,
+        approval.sessionRules,
+      )
+    ) {
+      return false;
+    }
+
+    // Outside working directory without matching rule = needs approval
+    return true;
   }
 }
 

--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -66,17 +66,6 @@ export function shouldAutoApprove(
 }
 
 /**
- * Get session rules from an approval config.
- * Returns empty array for background and delegated modes.
- *
- * @param approval - The approval configuration
- * @returns Array of approval rules, or empty array if not in interactive mode
- */
-export function getSessionRules(approval: ApprovalConfig): ApprovalRule[] {
-  return approval.type === "interactive" ? approval.sessionRules : [];
-}
-
-/**
  * Get the full approval context from experimental_context.
  * Used by needsApproval functions to access approval configuration.
  *

--- a/packages/agent/tools/write.ts
+++ b/packages/agent/tools/write.ts
@@ -6,6 +6,8 @@ import {
   getSandbox,
   pathMatchesGlob,
   getApprovalContext,
+  shouldAutoApprove,
+  getSessionRules,
 } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -92,33 +94,45 @@ export const writeFileTool = (options?: WriteToolOptions) =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "write");
+      const { approval } = ctx;
       const isOutside = isOutsideWorkingDirectory(
         args.filePath,
         ctx.workingDirectory,
       );
-      // Check if path matches any saved approval rules (works for both inside and outside paths)
+
+      // Check if path matches any saved session rules (works for both inside and outside paths)
       if (
         pathMatchesApprovalRule(
           args.filePath,
           "write",
           ctx.workingDirectory,
-          ctx.approvalRules,
+          getSessionRules(approval),
         )
       ) {
         return false;
       }
+
       // If outside working directory and no approval rule matched, require approval
       if (isOutside) {
         return true;
       }
-      // In background mode, auto-approve all operations within working directory
-      if (ctx.mode === "background") {
+
+      // Background and delegated modes auto-approve all operations within working directory
+      if (shouldAutoApprove(approval)) {
         return false;
       }
-      // Auto-approve edits when autoApprove is "edits" or "all"
-      if (ctx.autoApprove === "edits" || ctx.autoApprove === "all") {
-        return false;
+
+      // Interactive mode: check autoApprove setting
+      if (approval.type === "interactive") {
+        // Auto-approve edits when autoApprove is "edits" or "all"
+        if (
+          approval.autoApprove === "edits" ||
+          approval.autoApprove === "all"
+        ) {
+          return false;
+        }
       }
+
       // Otherwise use the configured approval setting
       if (typeof options?.needsApproval === "function") {
         return options.needsApproval(args);
@@ -187,33 +201,45 @@ export const editFileTool = (options?: EditToolOptions) =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "edit");
+      const { approval } = ctx;
       const isOutside = isOutsideWorkingDirectory(
         args.filePath,
         ctx.workingDirectory,
       );
-      // Check if path matches any saved approval rules (works for both inside and outside paths)
+
+      // Check if path matches any saved session rules (works for both inside and outside paths)
       if (
         pathMatchesApprovalRule(
           args.filePath,
           "edit",
           ctx.workingDirectory,
-          ctx.approvalRules,
+          getSessionRules(approval),
         )
       ) {
         return false;
       }
+
       // If outside working directory and no approval rule matched, require approval
       if (isOutside) {
         return true;
       }
-      // In background mode, auto-approve all operations within working directory
-      if (ctx.mode === "background") {
+
+      // Background and delegated modes auto-approve all operations within working directory
+      if (shouldAutoApprove(approval)) {
         return false;
       }
-      // Auto-approve edits when autoApprove is "edits" or "all"
-      if (ctx.autoApprove === "edits" || ctx.autoApprove === "all") {
-        return false;
+
+      // Interactive mode: check autoApprove setting
+      if (approval.type === "interactive") {
+        // Auto-approve edits when autoApprove is "edits" or "all"
+        if (
+          approval.autoApprove === "edits" ||
+          approval.autoApprove === "all"
+        ) {
+          return false;
+        }
       }
+
       // Otherwise use the configured approval setting
       if (typeof options?.needsApproval === "function") {
         return options.needsApproval(args);

--- a/packages/agent/tools/write.ts
+++ b/packages/agent/tools/write.ts
@@ -2,11 +2,10 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import {
-  isPathWithinDirectory,
   getSandbox,
   getApprovalContext,
   shouldAutoApprove,
-  pathMatchesApprovalRule,
+  pathNeedsApproval,
 } from "./utils";
 
 const writeInputSchema = z.object({
@@ -30,34 +29,7 @@ const editInputSchema = z.object({
     .describe("Line number where oldString starts (for diff display)"),
 });
 
-type WriteInput = z.infer<typeof writeInputSchema>;
-type EditInput = z.infer<typeof editInputSchema>;
-
-type WriteApprovalFn = (args: WriteInput) => boolean | Promise<boolean>;
-type EditApprovalFn = (args: EditInput) => boolean | Promise<boolean>;
-
-interface WriteToolOptions {
-  needsApproval?: boolean | WriteApprovalFn;
-}
-
-interface EditToolOptions {
-  needsApproval?: boolean | EditApprovalFn;
-}
-
-/**
- * Check if a path is outside the working directory.
- */
-function isOutsideWorkingDirectory(
-  filePath: string,
-  workingDirectory: string,
-): boolean {
-  const absolutePath = path.isAbsolute(filePath)
-    ? filePath
-    : path.resolve(workingDirectory, filePath);
-  return !isPathWithinDirectory(absolutePath, workingDirectory);
-}
-
-export const writeFileTool = (options?: WriteToolOptions) =>
+export const writeFileTool = () =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "write");
@@ -68,38 +40,12 @@ export const writeFileTool = (options?: WriteToolOptions) =>
         return false;
       }
 
-      const isOutside = isOutsideWorkingDirectory(
-        args.filePath,
-        ctx.workingDirectory,
-      );
-
-      // Check if path matches any saved session rules (works for both inside and outside paths)
-      if (
-        pathMatchesApprovalRule(
-          args.filePath,
-          "write",
-          ctx.workingDirectory,
-          approval.sessionRules,
-        )
-      ) {
-        return false;
-      }
-
-      // If outside working directory and no approval rule matched, require approval
-      if (isOutside) {
-        return true;
-      }
-
-      // Inside working directory: check autoApprove setting
-      if (approval.autoApprove === "edits" || approval.autoApprove === "all") {
-        return false;
-      }
-
-      // Otherwise use the configured approval setting
-      if (typeof options?.needsApproval === "function") {
-        return options.needsApproval(args);
-      }
-      return options?.needsApproval ?? true;
+      return pathNeedsApproval({
+        path: args.filePath,
+        tool: "write",
+        approval,
+        workingDirectory: ctx.workingDirectory,
+      });
     },
     description: `Write content to a file on the filesystem.
 
@@ -159,7 +105,7 @@ EXAMPLES:
     },
   });
 
-export const editFileTool = (options?: EditToolOptions) =>
+export const editFileTool = () =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "edit");
@@ -170,38 +116,12 @@ export const editFileTool = (options?: EditToolOptions) =>
         return false;
       }
 
-      const isOutside = isOutsideWorkingDirectory(
-        args.filePath,
-        ctx.workingDirectory,
-      );
-
-      // Check if path matches any saved session rules (works for both inside and outside paths)
-      if (
-        pathMatchesApprovalRule(
-          args.filePath,
-          "edit",
-          ctx.workingDirectory,
-          approval.sessionRules,
-        )
-      ) {
-        return false;
-      }
-
-      // If outside working directory and no approval rule matched, require approval
-      if (isOutside) {
-        return true;
-      }
-
-      // Inside working directory: check autoApprove setting
-      if (approval.autoApprove === "edits" || approval.autoApprove === "all") {
-        return false;
-      }
-
-      // Otherwise use the configured approval setting
-      if (typeof options?.needsApproval === "function") {
-        return options.needsApproval(args);
-      }
-      return options?.needsApproval ?? true;
+      return pathNeedsApproval({
+        path: args.filePath,
+        tool: "edit",
+        approval,
+        workingDirectory: ctx.workingDirectory,
+      });
     },
     description: `Perform exact string replacement in a file.
 

--- a/packages/agent/tools/write.ts
+++ b/packages/agent/tools/write.ts
@@ -4,12 +4,10 @@ import * as path from "path";
 import {
   isPathWithinDirectory,
   getSandbox,
-  pathMatchesGlob,
   getApprovalContext,
   shouldAutoApprove,
-  getSessionRules,
+  pathMatchesApprovalRule,
 } from "./utils";
-import type { ApprovalRule } from "../types";
 
 const writeInputSchema = z.object({
   filePath: z.string().describe("Absolute path to the file to write"),
@@ -59,37 +57,6 @@ function isOutsideWorkingDirectory(
   return !isPathWithinDirectory(absolutePath, workingDirectory);
 }
 
-/**
- * Check if a file path matches any path-glob approval rules for a specific tool.
- * Write/edit approval rules can apply to paths outside the working directory,
- * so we allow matching outside the base directory.
- */
-function pathMatchesApprovalRule(
-  filePath: string,
-  toolName: "write" | "edit",
-  workingDirectory: string,
-  approvalRules: ApprovalRule[],
-): boolean {
-  const absolutePath = path.isAbsolute(filePath)
-    ? filePath
-    : path.resolve(workingDirectory, filePath);
-
-  for (const rule of approvalRules) {
-    if (rule.type === "path-glob" && rule.tool === toolName) {
-      // Rules can apply to paths outside the working directory,
-      // so we must allow matching outside the base
-      if (
-        pathMatchesGlob(absolutePath, rule.glob, workingDirectory, {
-          allowOutsideBase: true,
-        })
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 export const writeFileTool = (options?: WriteToolOptions) =>
   tool({
     needsApproval: async (args, { experimental_context }) => {
@@ -112,7 +79,7 @@ export const writeFileTool = (options?: WriteToolOptions) =>
           args.filePath,
           "write",
           ctx.workingDirectory,
-          getSessionRules(approval),
+          approval.sessionRules,
         )
       ) {
         return false;
@@ -123,15 +90,9 @@ export const writeFileTool = (options?: WriteToolOptions) =>
         return true;
       }
 
-      // Interactive mode: check autoApprove setting
-      if (approval.type === "interactive") {
-        // Auto-approve edits when autoApprove is "edits" or "all"
-        if (
-          approval.autoApprove === "edits" ||
-          approval.autoApprove === "all"
-        ) {
-          return false;
-        }
+      // Inside working directory: check autoApprove setting
+      if (approval.autoApprove === "edits" || approval.autoApprove === "all") {
+        return false;
       }
 
       // Otherwise use the configured approval setting
@@ -220,7 +181,7 @@ export const editFileTool = (options?: EditToolOptions) =>
           args.filePath,
           "edit",
           ctx.workingDirectory,
-          getSessionRules(approval),
+          approval.sessionRules,
         )
       ) {
         return false;
@@ -231,15 +192,9 @@ export const editFileTool = (options?: EditToolOptions) =>
         return true;
       }
 
-      // Interactive mode: check autoApprove setting
-      if (approval.type === "interactive") {
-        // Auto-approve edits when autoApprove is "edits" or "all"
-        if (
-          approval.autoApprove === "edits" ||
-          approval.autoApprove === "all"
-        ) {
-          return false;
-        }
+      // Inside working directory: check autoApprove setting
+      if (approval.autoApprove === "edits" || approval.autoApprove === "all") {
+        return false;
       }
 
       // Otherwise use the configured approval setting

--- a/packages/agent/tools/write.ts
+++ b/packages/agent/tools/write.ts
@@ -95,6 +95,12 @@ export const writeFileTool = (options?: WriteToolOptions) =>
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "write");
       const { approval } = ctx;
+
+      // Background and delegated modes auto-approve all operations
+      if (shouldAutoApprove(approval)) {
+        return false;
+      }
+
       const isOutside = isOutsideWorkingDirectory(
         args.filePath,
         ctx.workingDirectory,
@@ -115,11 +121,6 @@ export const writeFileTool = (options?: WriteToolOptions) =>
       // If outside working directory and no approval rule matched, require approval
       if (isOutside) {
         return true;
-      }
-
-      // Background and delegated modes auto-approve all operations within working directory
-      if (shouldAutoApprove(approval)) {
-        return false;
       }
 
       // Interactive mode: check autoApprove setting
@@ -202,6 +203,12 @@ export const editFileTool = (options?: EditToolOptions) =>
     needsApproval: async (args, { experimental_context }) => {
       const ctx = getApprovalContext(experimental_context, "edit");
       const { approval } = ctx;
+
+      // Background and delegated modes auto-approve all operations
+      if (shouldAutoApprove(approval)) {
+        return false;
+      }
+
       const isOutside = isOutsideWorkingDirectory(
         args.filePath,
         ctx.workingDirectory,
@@ -222,11 +229,6 @@ export const editFileTool = (options?: EditToolOptions) =>
       // If outside working directory and no approval rule matched, require approval
       if (isOutside) {
         return true;
-      }
-
-      // Background and delegated modes auto-approve all operations within working directory
-      if (shouldAutoApprove(approval)) {
-        return false;
       }
 
       // Interactive mode: check autoApprove setting

--- a/packages/agent/types.ts
+++ b/packages/agent/types.ts
@@ -14,27 +14,24 @@ export const todoItemSchema = z.object({
 export type TodoItem = z.infer<typeof todoItemSchema>;
 
 /**
- * Agent execution modes that control behavior based on execution context.
+ * Approval configuration using a discriminated union that makes the trust model explicit.
  *
- * - 'interactive': Human in the loop, local development. Tool approval required for writes/bash.
+ * - 'interactive': Human in the loop, local development. Uses autoApprove and sessionRules.
  * - 'background': Async execution, cloud sandbox. Auto-approve all tools, checkpoint via git.
+ * - 'delegated': Subagent inherits trust from parent agent. Auto-approve all tools.
  */
-export type AgentMode = "interactive" | "background";
-
-/**
- * Auto-approve settings for tool operations in interactive mode.
- *
- * - 'off': All destructive operations require manual approval (default)
- * - 'edits': Auto-approve file edits and writes within working directory
- * - 'all': Auto-approve all operations within working directory (edits + bash)
- */
-export type AutoApprove = "off" | "edits" | "all";
+export type ApprovalConfig =
+  | {
+      type: "interactive";
+      autoApprove: "off" | "edits" | "all";
+      sessionRules: ApprovalRule[];
+    }
+  | { type: "background" }
+  | { type: "delegated" };
 
 export interface AgentContext {
   sandbox: Sandbox;
-  mode: AgentMode;
-  autoApprove: AutoApprove;
-  approvalRules: ApprovalRule[];
+  approval: ApprovalConfig;
 }
 
 /**

--- a/packages/tui/config.ts
+++ b/packages/tui/config.ts
@@ -1,5 +1,5 @@
 import { deepAgent } from "@open-harness/agent";
-import type { AgentMode } from "@open-harness/agent";
+import type { ApprovalConfig } from "@open-harness/agent";
 import type { Sandbox } from "@open-harness/sandbox";
 import type { TUIAgentCallOptions } from "./types.js";
 
@@ -7,13 +7,20 @@ import type { TUIAgentCallOptions } from "./types.js";
 export const tuiAgent = deepAgent;
 export const pasteCollapseLineThreshold = 5;
 
+// Default approval config for interactive mode
+const defaultApprovalConfig: ApprovalConfig = {
+  type: "interactive",
+  autoApprove: "off",
+  sessionRules: [],
+};
+
 // Default agent options factory
 export function createDefaultAgentOptions(
   sandbox: Sandbox,
-  mode: AgentMode = "interactive",
+  approval: ApprovalConfig = defaultApprovalConfig,
 ): TUIAgentCallOptions {
   return {
     sandbox,
-    mode,
+    approval,
   };
 }

--- a/packages/tui/transport.ts
+++ b/packages/tui/transport.ts
@@ -43,22 +43,24 @@ export function createAgentTransport({
         emptyMessages: "remove",
       });
 
-      // Get current settings at request time
-      const autoApprove = getAutoApprove
-        ? getAutoApprove()
-        : (agentOptions.approvals?.autoApprove ?? "off");
-      const approvalRules = getApprovalRules
-        ? getApprovalRules()
-        : (agentOptions.approvals?.rules ?? []);
-      const approvals = {
-        ...agentOptions.approvals,
-        autoApprove,
-        rules: approvalRules,
-      };
+      // Get current settings at request time and build approval config
+      const autoApprove = getAutoApprove ? getAutoApprove() : "off";
+      const sessionRules = getApprovalRules ? getApprovalRules() : [];
+
+      // Build the approval config based on the current base config type
+      const baseApproval = agentOptions.approval;
+      const approval =
+        baseApproval.type === "interactive"
+          ? {
+              type: "interactive" as const,
+              autoApprove,
+              sessionRules,
+            }
+          : baseApproval;
 
       const result = await agent.stream({
         messages: prunedMessages,
-        options: { ...agentOptions, approvals },
+        options: { ...agentOptions, approval },
         abortSignal: abortSignal ?? undefined,
         experimental_transform: smoothStream(),
       });

--- a/packages/tui/transport.ts
+++ b/packages/tui/transport.ts
@@ -49,14 +49,22 @@ export function createAgentTransport({
 
       // Build the approval config based on the current base config type
       const baseApproval = agentOptions.approval;
-      const approval =
-        baseApproval.type === "interactive"
-          ? {
-              type: "interactive" as const,
-              autoApprove,
-              sessionRules,
-            }
-          : baseApproval;
+      let approval: typeof baseApproval;
+      switch (baseApproval.type) {
+        case "interactive":
+          // Interactive mode: inject current UI settings
+          approval = {
+            type: "interactive",
+            autoApprove,
+            sessionRules,
+          };
+          break;
+        case "background":
+        case "delegated":
+          // These modes are fully trusted - pass through unchanged
+          approval = baseApproval;
+          break;
+      }
 
       const result = await agent.stream({
         messages: prunedMessages,


### PR DESCRIPTION
Replace separate mode/autoApprove/approvalRules fields with a single ApprovalConfig discriminated union that makes trust models explicit and type-safe.

- **What changed**: `AgentContext` now uses `approval: ApprovalConfig` instead of `mode`, `autoApprove`, and `approvalRules` fields. Added three trust models: interactive (with configurable auto-approval), background (full trust via git checkpointing), and delegated (subagents inherit parent trust).
- **Why**: Eliminates implicit precedence rules and ambiguity. Discriminated union enforces that only interactive mode has `autoApprove` and `sessionRules`, making the trust model explicit at the type level.
- **How**: Consolidated approval logic into helper functions (`shouldAutoApprove`, `pathNeedsApproval`) and simplified tool implementations. Updated all call sites in CLI, Web API, and subagents to use the new config. Removed per-tool `needsApproval` option parameters in favor of context-driven logic.