### PR TITLE
Fix directory glob matching and add support for glob/grep approval rules

### DIFF
--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -162,13 +162,20 @@ export function pathMatchesGlob(
       .replace(/\//g, "\\/"); // Escape path separators
 
     const regex = new RegExp(`^${globRegex}`);
-    return regex.test(relativePath);
+    if (regex.test(relativePath)) {
+      return true;
+    }
+    // If glob ends with /** and path doesn't end with /, try adding trailing /
+    // This allows directory paths to match their own glob (e.g., "apps" matches "apps/**")
+    if (glob.endsWith("/**") && !relativePath.endsWith("/")) {
+      return regex.test(relativePath + "/");
+    }
+    return false;
   } catch {
     // If regex construction fails (malformed pattern), treat as no match
     return false;
   }
 }
-
 
 export type ToolNeedsApprovalFunction<INPUT> = (
   input: INPUT,
@@ -192,4 +199,3 @@ export type ToolNeedsApprovalFunction<INPUT> = (
     experimental_context?: unknown;
   },
 ) => boolean | PromiseLike<boolean>;
-

--- a/packages/tui/lib/approval.ts
+++ b/packages/tui/lib/approval.ts
@@ -228,9 +228,7 @@ export function inferApprovalRule(
     }
 
     case "tool-glob": {
-      const searchPath = String(part.input?.path ?? "");
-      if (!searchPath) return null;
-
+      const searchPath = String(part.input?.path ?? cwd);
       return {
         type: "path-glob",
         tool: "glob",
@@ -239,9 +237,7 @@ export function inferApprovalRule(
     }
 
     case "tool-grep": {
-      const searchPath = String(part.input?.path ?? "");
-      if (!searchPath) return null;
-
+      const searchPath = String(part.input?.path ?? cwd);
       return {
         type: "path-glob",
         tool: "grep",

--- a/packages/tui/lib/approval.ts
+++ b/packages/tui/lib/approval.ts
@@ -28,7 +28,7 @@ function getCommandPrefix(command: string): string {
 
 /**
  * Get glob pattern for a file path's directory.
- * Used for path-glob approval rules.
+ * Used for path-glob approval rules when the input is a file path.
  */
 function getDirectoryGlob(filePath: string, cwd: string): string {
   const absolutePath = path.isAbsolute(filePath)
@@ -37,6 +37,20 @@ function getDirectoryGlob(filePath: string, cwd: string): string {
   const relativePath = path.relative(cwd, absolutePath);
   const dirPath = path.dirname(relativePath);
   return dirPath === "." ? "**" : `${dirPath}/**`;
+}
+
+/**
+ * Get glob pattern for a directory path.
+ * Used for path-glob approval rules when the input is already a directory (e.g., glob/grep search paths).
+ */
+function getPathGlob(dirPath: string, cwd: string): string {
+  const absolutePath = path.isAbsolute(dirPath)
+    ? dirPath
+    : path.resolve(cwd, dirPath);
+  const relativePath = path.relative(cwd, absolutePath);
+  return relativePath === "" || relativePath === "."
+    ? "**"
+    : `${relativePath}/**`;
 }
 
 /**
@@ -113,7 +127,7 @@ export function getToolApprovalInfo(
     case "tool-glob": {
       const pattern = String(part.input?.pattern ?? "");
       const searchPath = String(part.input?.path ?? cwd);
-      const glob = getDirectoryGlob(searchPath, cwd);
+      const glob = getPathGlob(searchPath, cwd);
       return {
         toolType: "Glob",
         toolCommand: `"${pattern}" in ${searchPath}`,
@@ -125,7 +139,7 @@ export function getToolApprovalInfo(
     case "tool-grep": {
       const pattern = String(part.input?.pattern ?? "");
       const searchPath = String(part.input?.path ?? cwd);
-      const glob = getDirectoryGlob(searchPath, cwd);
+      const glob = getPathGlob(searchPath, cwd);
       return {
         toolType: "Grep",
         toolCommand: `"${pattern}" in ${searchPath}`,
@@ -220,7 +234,7 @@ export function inferApprovalRule(
       return {
         type: "path-glob",
         tool: "glob",
-        glob: getDirectoryGlob(searchPath, cwd),
+        glob: getPathGlob(searchPath, cwd),
       };
     }
 
@@ -231,7 +245,7 @@ export function inferApprovalRule(
       return {
         type: "path-glob",
         tool: "grep",
-        glob: getDirectoryGlob(searchPath, cwd),
+        glob: getPathGlob(searchPath, cwd),
       };
     }
 

--- a/packages/tui/lib/approval.ts
+++ b/packages/tui/lib/approval.ts
@@ -110,6 +110,30 @@ export function getToolApprovalInfo(
       };
     }
 
+    case "tool-glob": {
+      const pattern = String(part.input?.pattern ?? "");
+      const searchPath = String(part.input?.path ?? cwd);
+      const glob = getDirectoryGlob(searchPath, cwd);
+      return {
+        toolType: "Glob",
+        toolCommand: `"${pattern}" in ${searchPath}`,
+        toolDescription: "Search files outside working directory",
+        dontAskAgainPattern: `globs in ${glob}`,
+      };
+    }
+
+    case "tool-grep": {
+      const pattern = String(part.input?.pattern ?? "");
+      const searchPath = String(part.input?.path ?? cwd);
+      const glob = getDirectoryGlob(searchPath, cwd);
+      return {
+        toolType: "Grep",
+        toolCommand: `"${pattern}" in ${searchPath}`,
+        toolDescription: "Search content outside working directory",
+        dontAskAgainPattern: `greps in ${glob}`,
+      };
+    }
+
     default: {
       const toolName = getToolName(part);
       return {
@@ -186,6 +210,28 @@ export function inferApprovalRule(
         type: "subagent-type",
         tool: "task",
         subagentType,
+      };
+    }
+
+    case "tool-glob": {
+      const searchPath = String(part.input?.path ?? "");
+      if (!searchPath) return null;
+
+      return {
+        type: "path-glob",
+        tool: "glob",
+        glob: getDirectoryGlob(searchPath, cwd),
+      };
+    }
+
+    case "tool-grep": {
+      const searchPath = String(part.input?.path ?? "");
+      if (!searchPath) return null;
+
+      return {
+        type: "path-glob",
+        tool: "grep",
+        glob: getDirectoryGlob(searchPath, cwd),
       };
     }
 


### PR DESCRIPTION
This PR fixes glob pattern matching for directory paths and extends approval rule support to glob and grep tools.

- **Fix pathMatchesGlob**: Directory paths without trailing slashes now match their own glob pattern (e.g., "apps" matches "apps/**"), enabling proper "don't ask again" behavior for directory-level operations
- **Add getPathGlob helper**: New function to generate glob patterns for directory paths, used by glob and grep approval rules
- **Add glob/grep approval support**: Extended `getToolApprovalInfo` and `inferApprovalRule` to handle "tool-glob" and "tool-grep" cases, enabling approval rule generation for file search operations
- **Improve documentation**: Clarified that `getDirectoryGlob` is used specifically when input is a file path