### PR TITLE
Add model selection and settings persistence to TUI

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
 import { defaultModelLabel } from "@open-harness/agent";
-import { createTUI } from "@open-harness/tui";
+import {
+  createTUI,
+  loadSettings,
+  saveSettings,
+  type Settings,
+} from "@open-harness/tui";
 import { loadAgentsMd } from "./agents-md";
 import { onCleanup, cleanup } from "./cleanup-handler";
 import {
@@ -129,6 +134,16 @@ async function main() {
     // Load agents.md files from the working directory hierarchy
     const agentsMd = await loadAgentsMd(workingDirectory);
 
+    // Load user settings from config file
+    const settings = await loadSettings();
+
+    // Callback to save settings when they change
+    const handleSettingsChange = (newSettings: Settings) => {
+      saveSettings(newSettings).catch((err) => {
+        console.error("Failed to save settings:", err);
+      });
+    };
+
     await createTUI({
       initialPrompt: parsed.initialPrompt,
       workingDirectory: sandbox.workingDirectory,
@@ -148,6 +163,8 @@ async function main() {
           customInstructions: agentsMd.content,
         }),
       },
+      initialSettings: settings,
+      onSettingsChange: handleSettingsChange,
       // Auto-accept all tools in sandbox mode since it's an isolated environment
       ...(isRemoteSandbox && { initialAutoAcceptMode: "all" }),
     });

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -5,6 +5,7 @@ import {
   createTUI,
   loadSettings,
   saveSettings,
+  fetchAvailableModels,
   type Settings,
 } from "@open-harness/tui";
 import { loadAgentsMd } from "./agents-md";
@@ -134,8 +135,11 @@ async function main() {
     // Load agents.md files from the working directory hierarchy
     const agentsMd = await loadAgentsMd(workingDirectory);
 
-    // Load user settings from config file
-    const settings = await loadSettings();
+    // Load user settings and available models in parallel
+    const [settings, availableModels] = await Promise.all([
+      loadSettings(),
+      fetchAvailableModels(),
+    ]);
 
     // Callback to save settings when they change
     const handleSettingsChange = (newSettings: Settings) => {
@@ -165,6 +169,7 @@ async function main() {
       },
       initialSettings: settings,
       onSettingsChange: handleSettingsChange,
+      availableModels,
       // Auto-accept all tools in sandbox mode since it's an isolated environment
       ...(isRemoteSandbox && { initialAutoAcceptMode: "all" }),
     });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "zod": "^4.3.5"
   },
   "scripts": {
-    "cli": "bun run --cwd apps/cli dev",
+    "cli": "AI_SDK_LOG_WARNINGS=false bun run --cwd apps/cli dev",
     "web": "cd apps/web/ && bun run dev",
     "dev": "turbo dev",
     "build": "turbo build",

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -5,6 +5,7 @@ export {
   extractTodosFromStep,
 } from "./deep-agent";
 export type { DeepAgentCallOptions } from "./deep-agent";
+export { gateway } from "./models";
 export type {
   TodoItem,
   TodoStatus,

--- a/packages/tui/app.tsx
+++ b/packages/tui/app.tsx
@@ -11,11 +11,14 @@ import { renderMarkdown } from "./lib/markdown";
 import { useChatContext } from "./chat-context";
 import { ToolCall, getToolApprovalInfo } from "./components/tool-call";
 import { ApprovalPanel } from "./components/approval-panel";
+import { SettingsPanel } from "./components/settings-panel";
 import { TaskGroupView } from "./components/task-group-view";
 import { StatusBar, StandaloneTodoList } from "./components/status-bar";
 import { InputBox } from "./components/input-box";
 import { Header } from "./components/header";
 import { defaultModelLabel } from "@open-harness/agent";
+import { AVAILABLE_MODELS, getModelDisplayName } from "./lib/models";
+import type { SlashCommandAction } from "./lib/slash-commands";
 import { pasteCollapseLineThreshold } from "./config";
 import { extractTodosFromLastAssistantMessage } from "./utils/extract-todos";
 import type {
@@ -511,7 +514,14 @@ const ExpandedViewIndicator = memo(function ExpandedViewIndicator() {
 
 function AppContent({ options }: AppProps) {
   const { exit } = useApp();
-  const { chat, state, cycleAutoAcceptMode } = useChatContext();
+  const {
+    chat,
+    state,
+    cycleAutoAcceptMode,
+    openPanel,
+    closePanel,
+    updateSettings,
+  } = useChatContext();
   const { isExpanded, toggleExpanded } = useExpandedView();
   const { isTodoVisible, toggleTodoView } = useTodoView();
   const [wasInterrupted, setWasInterrupted] = useState(false);
@@ -595,13 +605,28 @@ function AppContent({ options }: AppProps) {
     [isStreaming, sendMessage],
   );
 
+  const handleCommandSelect = useCallback(
+    (action: SlashCommandAction) => {
+      switch (action) {
+        case "open-model-select":
+          openPanel({ type: "model-select" });
+          break;
+      }
+    },
+    [openPanel],
+  );
+
   // Show message list with either approval panel or input box at bottom
   return (
     <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
       <Header
         name={options?.header?.name}
         version={options?.header?.version}
-        model={options?.header?.model ?? defaultModelLabel}
+        model={
+          state.settings.modelId
+            ? getModelDisplayName(state.settings.modelId)
+            : (options?.header?.model ?? defaultModelLabel)
+        }
         cwd={state.workingDirectory}
       />
 
@@ -616,8 +641,31 @@ function AppContent({ options }: AppProps) {
 
       <ErrorDisplay error={error} />
 
+      {/* Show settings panel when active (replaces input) */}
+      {state.activePanel.type === "model-select" && (
+        <SettingsPanel
+          title="Select model"
+          description="Choose the AI model for this session"
+          options={AVAILABLE_MODELS.map((m) => ({
+            id: m.id,
+            name: m.name,
+            description: m.description,
+            meta: m.pricing
+              ? `${m.pricing.input} in · ${m.pricing.output} out`
+              : undefined,
+          }))}
+          currentId={state.settings.modelId ?? ""}
+          onSelect={(id) => {
+            updateSettings({ modelId: id });
+            closePanel();
+          }}
+          onCancel={closePanel}
+        />
+      )}
+
       {/* Show approval panel when there's a pending approval (replaces status bar and input) */}
-      {hasPendingApproval &&
+      {state.activePanel.type === "none" &&
+      hasPendingApproval &&
       activeApprovalId &&
       approvalInfo &&
       pendingToolPart ? (
@@ -629,7 +677,7 @@ function AppContent({ options }: AppProps) {
           dontAskAgainPattern={approvalInfo.dontAskAgainPattern}
           toolPart={pendingToolPart}
         />
-      ) : (
+      ) : state.activePanel.type === "none" ? (
         <>
           {/* Show streaming status bar when streaming */}
           {isStreaming && <StreamingStatusBar messages={messages} />}
@@ -645,6 +693,7 @@ function AppContent({ options }: AppProps) {
               onSubmit={handleSubmit}
               autoAcceptMode={state.autoAcceptMode}
               onToggleAutoAccept={cycleAutoAcceptMode}
+              onCommandSelect={handleCommandSelect}
               disabled={isStreaming}
               inputTokens={state.usage.inputTokens ?? 0}
               contextLimit={state.contextLimit}
@@ -652,7 +701,7 @@ function AppContent({ options }: AppProps) {
             />
           )}
         </>
-      )}
+      ) : null}
 
       {isExpanded && <ExpandedViewIndicator />}
     </Box>

--- a/packages/tui/app.tsx
+++ b/packages/tui/app.tsx
@@ -17,7 +17,7 @@ import { StatusBar, StandaloneTodoList } from "./components/status-bar";
 import { InputBox } from "./components/input-box";
 import { Header } from "./components/header";
 import { defaultModelLabel } from "@open-harness/agent";
-import { AVAILABLE_MODELS, getModelDisplayName } from "./lib/models";
+import { getModelDisplayName } from "./lib/models";
 import type { SlashCommandAction } from "./lib/slash-commands";
 import { pasteCollapseLineThreshold } from "./config";
 import { extractTodosFromLastAssistantMessage } from "./utils/extract-todos";
@@ -646,10 +646,9 @@ function AppContent({ options }: AppProps) {
         <SettingsPanel
           title="Select model"
           description="Choose the AI model for this session"
-          options={AVAILABLE_MODELS.map((m) => ({
+          options={state.availableModels.map((m) => ({
             id: m.id,
             name: m.name,
-            description: m.description,
             meta: m.pricing
               ? `${m.pricing.input} in · ${m.pricing.output} out`
               : undefined,

--- a/packages/tui/app.tsx
+++ b/packages/tui/app.tsx
@@ -17,7 +17,6 @@ import { StatusBar, StandaloneTodoList } from "./components/status-bar";
 import { InputBox } from "./components/input-box";
 import { Header } from "./components/header";
 import { defaultModelLabel } from "@open-harness/agent";
-import { getModelDisplayName } from "./lib/models";
 import type { SlashCommandAction } from "./lib/slash-commands";
 import { pasteCollapseLineThreshold } from "./config";
 import { extractTodosFromLastAssistantMessage } from "./utils/extract-todos";
@@ -623,9 +622,7 @@ function AppContent({ options }: AppProps) {
         name={options?.header?.name}
         version={options?.header?.version}
         model={
-          state.settings.modelId
-            ? getModelDisplayName(state.settings.modelId)
-            : (options?.header?.model ?? defaultModelLabel)
+          state.settings.modelId ?? options?.header?.model ?? defaultModelLabel
         }
         cwd={state.workingDirectory}
       />

--- a/packages/tui/app.tsx
+++ b/packages/tui/app.tsx
@@ -615,6 +615,28 @@ function AppContent({ options }: AppProps) {
     [openPanel],
   );
 
+  // Memoize model options to prevent re-renders in SettingsPanel
+  const modelOptions = useMemo(
+    () =>
+      state.availableModels.map((m) => ({
+        id: m.id,
+        name: m.name,
+        meta: m.pricing
+          ? `${m.pricing.input} in · ${m.pricing.output} out`
+          : undefined,
+      })),
+    [state.availableModels],
+  );
+
+  // Memoize model selection handler to prevent re-renders
+  const handleModelSelect = useCallback(
+    (id: string) => {
+      updateSettings({ modelId: id });
+      closePanel();
+    },
+    [updateSettings, closePanel],
+  );
+
   // Show message list with either approval panel or input box at bottom
   return (
     <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
@@ -643,18 +665,9 @@ function AppContent({ options }: AppProps) {
         <SettingsPanel
           title="Select model"
           description="Choose the AI model for this session"
-          options={state.availableModels.map((m) => ({
-            id: m.id,
-            name: m.name,
-            meta: m.pricing
-              ? `${m.pricing.input} in · ${m.pricing.output} out`
-              : undefined,
-          }))}
+          options={modelOptions}
           currentId={state.settings.modelId ?? ""}
-          onSelect={(id) => {
-            updateSettings({ modelId: id });
-            closePanel();
-          }}
+          onSelect={handleModelSelect}
           onCancel={closePanel}
         />
       )}

--- a/packages/tui/chat-context.tsx
+++ b/packages/tui/chat-context.tsx
@@ -20,7 +20,10 @@ import type {
   AutoAcceptMode,
   ApprovalRule,
 } from "./types";
+import type { Settings } from "./lib/settings";
 import { getContextLimit } from "@open-harness/agent";
+
+export type PanelState = { type: "none" } | { type: "model-select" };
 
 type ChatState = {
   model?: string;
@@ -30,6 +33,8 @@ type ChatState = {
   sessionUsage: LanguageModelUsage;
   contextLimit: number;
   approvalRules: ApprovalRule[];
+  settings: Settings;
+  activePanel: PanelState;
 };
 
 type ChatContextValue = {
@@ -39,6 +44,9 @@ type ChatContextValue = {
   cycleAutoAcceptMode: () => void;
   addApprovalRule: (rule: ApprovalRule) => void;
   clearApprovalRules: () => void;
+  updateSettings: (updates: Partial<Settings>) => void;
+  openPanel: (panel: PanelState) => void;
+  closePanel: () => void;
 };
 
 const ChatContext = createContext<ChatContextValue | undefined>(undefined);
@@ -51,6 +59,8 @@ type ChatProviderProps = {
   model?: string;
   workingDirectory?: string;
   initialAutoAcceptMode?: AutoAcceptMode;
+  initialSettings?: Settings;
+  onSettingsChange?: (settings: Settings) => void;
 };
 
 const DEFAULT_USAGE: LanguageModelUsage = {
@@ -113,6 +123,8 @@ export function ChatProvider({
   model,
   workingDirectory,
   initialAutoAcceptMode = "off",
+  initialSettings = {},
+  onSettingsChange,
 }: ChatProviderProps) {
   const [autoAcceptMode, setAutoAcceptMode] = useState<AutoAcceptMode>(
     initialAutoAcceptMode,
@@ -121,12 +133,16 @@ export function ChatProvider({
   const [sessionUsage, setSessionUsage] =
     useState<LanguageModelUsage>(DEFAULT_USAGE);
   const [approvalRules, setApprovalRules] = useState<ApprovalRule[]>([]);
+  const [settings, setSettings] = useState<Settings>(initialSettings);
+  const [activePanel, setActivePanel] = useState<PanelState>({ type: "none" });
 
   // Use refs to pass current values to transport without recreating it
   const autoAcceptModeRef = useRef(autoAcceptMode);
   autoAcceptModeRef.current = autoAcceptMode;
   const approvalRulesRef = useRef(approvalRules);
   approvalRulesRef.current = approvalRules;
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
 
   const contextLimit = useMemo(() => getContextLimit(model ?? ""), [model]);
 
@@ -157,6 +173,7 @@ export function ChatProvider({
         agentOptions,
         getAutoApprove: () => autoAcceptModeRef.current,
         getApprovalRules: () => approvalRulesRef.current,
+        getSettings: () => settingsRef.current,
         onUsageUpdate: handleUsageUpdate,
       }),
     [agentOptions, handleUsageUpdate],
@@ -174,13 +191,15 @@ export function ChatProvider({
 
   const state: ChatState = useMemo(
     () => ({
-      model,
+      model: settings.modelId ?? model,
       autoAcceptMode,
       workingDirectory,
       usage,
       sessionUsage,
       contextLimit,
       approvalRules,
+      settings,
+      activePanel,
     }),
     [
       model,
@@ -190,6 +209,8 @@ export function ChatProvider({
       sessionUsage,
       contextLimit,
       approvalRules,
+      settings,
+      activePanel,
     ],
   );
 
@@ -201,6 +222,25 @@ export function ChatProvider({
     });
   };
 
+  const updateSettings = useCallback(
+    (updates: Partial<Settings>) => {
+      setSettings((prev) => {
+        const newSettings = { ...prev, ...updates };
+        onSettingsChange?.(newSettings);
+        return newSettings;
+      });
+    },
+    [onSettingsChange],
+  );
+
+  const openPanel = useCallback((panel: PanelState) => {
+    setActivePanel(panel);
+  }, []);
+
+  const closePanel = useCallback(() => {
+    setActivePanel({ type: "none" });
+  }, []);
+
   return (
     <ChatContext.Provider
       value={{
@@ -210,6 +250,9 @@ export function ChatProvider({
         cycleAutoAcceptMode,
         addApprovalRule,
         clearApprovalRules,
+        updateSettings,
+        openPanel,
+        closePanel,
       }}
     >
       {children}

--- a/packages/tui/chat-context.tsx
+++ b/packages/tui/chat-context.tsx
@@ -21,6 +21,7 @@ import type {
   ApprovalRule,
 } from "./types";
 import type { Settings } from "./lib/settings";
+import { AVAILABLE_MODELS, type ModelInfo } from "./lib/models";
 import { getContextLimit } from "@open-harness/agent";
 
 export type PanelState = { type: "none" } | { type: "model-select" };
@@ -35,6 +36,7 @@ type ChatState = {
   approvalRules: ApprovalRule[];
   settings: Settings;
   activePanel: PanelState;
+  availableModels: ModelInfo[];
 };
 
 type ChatContextValue = {
@@ -61,6 +63,7 @@ type ChatProviderProps = {
   initialAutoAcceptMode?: AutoAcceptMode;
   initialSettings?: Settings;
   onSettingsChange?: (settings: Settings) => void;
+  availableModels?: ModelInfo[];
 };
 
 const DEFAULT_USAGE: LanguageModelUsage = {
@@ -125,6 +128,7 @@ export function ChatProvider({
   initialAutoAcceptMode = "off",
   initialSettings = {},
   onSettingsChange,
+  availableModels = AVAILABLE_MODELS,
 }: ChatProviderProps) {
   const [autoAcceptMode, setAutoAcceptMode] = useState<AutoAcceptMode>(
     initialAutoAcceptMode,
@@ -144,7 +148,11 @@ export function ChatProvider({
   const settingsRef = useRef(settings);
   settingsRef.current = settings;
 
-  const contextLimit = useMemo(() => getContextLimit(model ?? ""), [model]);
+  const effectiveModel = settings.modelId ?? model ?? "";
+  const contextLimit = useMemo(
+    () => getContextLimit(effectiveModel),
+    [effectiveModel],
+  );
 
   const handleUsageUpdate = useCallback((newUsage: LanguageModelUsage) => {
     setUsage(newUsage);
@@ -191,7 +199,7 @@ export function ChatProvider({
 
   const state: ChatState = useMemo(
     () => ({
-      model: settings.modelId ?? model,
+      model: effectiveModel,
       autoAcceptMode,
       workingDirectory,
       usage,
@@ -200,9 +208,10 @@ export function ChatProvider({
       approvalRules,
       settings,
       activePanel,
+      availableModels,
     }),
     [
-      model,
+      effectiveModel,
       autoAcceptMode,
       workingDirectory,
       usage,
@@ -211,6 +220,7 @@ export function ChatProvider({
       approvalRules,
       settings,
       activePanel,
+      availableModels,
     ],
   );
 

--- a/packages/tui/components/input-box.tsx
+++ b/packages/tui/components/input-box.tsx
@@ -12,6 +12,12 @@ import { TextInput } from "./text-input";
 import { Suggestions, type Suggestion } from "./suggestions";
 import { getFileSuggestions, extractMention } from "../lib/file-suggestions";
 import {
+  extractSlashCommand,
+  getCommandSuggestions,
+  getCommandAction,
+  type SlashCommandAction,
+} from "../lib/slash-commands";
+import {
   countLines,
   createPasteToken,
   expandPasteTokens,
@@ -37,6 +43,7 @@ type InputBoxProps = {
   onSubmit: (value: string, files?: FileUIPart[]) => void;
   autoAcceptMode: AutoAcceptMode;
   onToggleAutoAccept: () => void;
+  onCommandSelect?: (action: SlashCommandAction) => void;
   disabled?: boolean;
   inputTokens?: number;
   contextLimit?: number;
@@ -112,6 +119,7 @@ export const InputBox = memo(function InputBox({
   onSubmit,
   autoAcceptMode,
   onToggleAutoAccept,
+  onCommandSelect,
   disabled = false,
   inputTokens = 0,
   contextLimit = 0,
@@ -124,6 +132,10 @@ export const InputBox = memo(function InputBox({
   const [mentionInfo, setMentionInfo] = useState<{
     mentionStart: number;
     partialPath: string;
+  } | null>(null);
+  const [commandInfo, setCommandInfo] = useState<{
+    commandStart: number;
+    partialCommand: string;
   } | null>(null);
   const [pasteBlocks, setPasteBlocks] = useState<PasteBlock[]>([]);
   const [imageBlocks, setImageBlocks] = useState<ImageBlock[]>([]);
@@ -166,6 +178,7 @@ export const InputBox = memo(function InputBox({
       } else if (suggestions.length > 0) {
         setSuggestions([]);
         setMentionInfo(null);
+        setCommandInfo(null);
       }
     }
     // Ctrl+V to paste image
@@ -201,6 +214,20 @@ export const InputBox = memo(function InputBox({
 
   // Update suggestions when cursor position or value changes (debounced)
   useEffect(() => {
+    // Check for slash commands first (priority over @ mentions)
+    const command = extractSlashCommand(value, cursorPosition);
+    if (command) {
+      setCommandInfo(command);
+      setMentionInfo(null);
+      setSuggestions(getCommandSuggestions(command.partialCommand));
+      setSelectedIndex(0);
+      return;
+    }
+
+    // Clear command info if not in a command
+    setCommandInfo(null);
+
+    // Check for @ mentions
     const mention = extractMention(value, cursorPosition);
     setMentionInfo(mention);
 
@@ -348,35 +375,62 @@ export const InputBox = memo(function InputBox({
   }, [suggestions.length]);
 
   const selectSuggestion = useCallback(() => {
-    if (suggestions.length > 0 && mentionInfo) {
-      const selected = suggestions[selectedIndex];
-      if (selected) {
-        // Replace the partial path with the selected suggestion + space
-        const before = value.slice(0, mentionInfo.mentionStart + 1); // Include @
-        const after = value.slice(cursorPosition);
-        const newValue = before + selected.value + " " + after;
-        updateValue(newValue);
-        // Update cursor position to after the space
-        const newCursorPos =
-          mentionInfo.mentionStart + 1 + selected.value.length + 1;
-        setCursorPosition(newCursorPos);
-        // Close suggestions after selection
+    if (suggestions.length === 0) return false;
+
+    const selected = suggestions[selectedIndex];
+    if (!selected) return false;
+
+    // Handle slash command selection
+    if (commandInfo) {
+      const action = getCommandAction(selected.value);
+      if (action && onCommandSelect) {
+        // Clear input and close suggestions
+        updateValue("");
+        setCursorPosition(0);
         setSuggestions([]);
-        setMentionInfo(null);
-        return true; // Consumed the event
+        setCommandInfo(null);
+        // Execute the command action
+        onCommandSelect(action);
+        return true;
       }
+      return false;
     }
+
+    // Handle @ mention selection
+    if (mentionInfo) {
+      // Replace the partial path with the selected suggestion + space
+      const before = value.slice(0, mentionInfo.mentionStart + 1); // Include @
+      const after = value.slice(cursorPosition);
+      const newValue = before + selected.value + " " + after;
+      updateValue(newValue);
+      // Update cursor position to after the space
+      const newCursorPos =
+        mentionInfo.mentionStart + 1 + selected.value.length + 1;
+      setCursorPosition(newCursorPos);
+      // Close suggestions after selection
+      setSuggestions([]);
+      setMentionInfo(null);
+      return true; // Consumed the event
+    }
+
     return false;
   }, [
     suggestions,
     selectedIndex,
+    commandInfo,
     mentionInfo,
     value,
     cursorPosition,
     updateValue,
+    onCommandSelect,
   ]);
 
   const handleTab = useCallback(() => {
+    // For slash commands, tab selects like enter
+    if (commandInfo) {
+      return selectSuggestion();
+    }
+
     // If a directory is selected, "enter" it instead of selecting
     if (suggestions.length > 0 && mentionInfo) {
       const selected = suggestions[selectedIndex];
@@ -399,6 +453,7 @@ export const InputBox = memo(function InputBox({
   }, [
     suggestions,
     selectedIndex,
+    commandInfo,
     mentionInfo,
     value,
     cursorPosition,
@@ -425,6 +480,7 @@ export const InputBox = memo(function InputBox({
         setCursorPosition(0);
         setSuggestions([]);
         setMentionInfo(null);
+        setCommandInfo(null);
         setImageBlocks([]);
         setSelectedImageIndex(null);
         nextImageIdRef.current = 1;

--- a/packages/tui/components/settings-panel.tsx
+++ b/packages/tui/components/settings-panel.tsx
@@ -1,0 +1,196 @@
+import React, { useState, useMemo, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+
+export type SettingsOption = {
+  id: string;
+  name: string;
+  description?: string;
+  meta?: string;
+};
+
+type SettingsPanelProps = {
+  title: string;
+  description?: string;
+  options: SettingsOption[];
+  currentId: string;
+  onSelect: (id: string) => void;
+  onCancel: () => void;
+};
+
+export function SettingsPanel({
+  title,
+  description,
+  options,
+  currentId,
+  onSelect,
+  onCancel,
+}: SettingsPanelProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Filter options based on search query
+  const filteredOptions = useMemo(() => {
+    if (!searchQuery) return options;
+    const query = searchQuery.toLowerCase();
+    return options.filter(
+      (opt) =>
+        opt.name.toLowerCase().includes(query) ||
+        opt.description?.toLowerCase().includes(query),
+    );
+  }, [options, searchQuery]);
+
+  // Reset selection when filtered options change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [filteredOptions.length]);
+
+  // Set initial selection to current value
+  useEffect(() => {
+    const currentIndex = filteredOptions.findIndex(
+      (opt) => opt.id === currentId,
+    );
+    if (currentIndex !== -1) {
+      setSelectedIndex(currentIndex);
+    }
+  }, [currentId, filteredOptions]);
+
+  useInput((input, key) => {
+    // Escape to cancel
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+
+    // Enter to confirm selection
+    if (key.return) {
+      const selected = filteredOptions[selectedIndex];
+      if (selected) {
+        onSelect(selected.id);
+      }
+      return;
+    }
+
+    // Navigation
+    const goUp =
+      key.upArrow ||
+      input === "k" ||
+      (key.ctrl && input === "p") ||
+      (key.shift && key.tab);
+    const goDown =
+      key.downArrow ||
+      input === "j" ||
+      (key.ctrl && input === "n") ||
+      (!key.shift && key.tab);
+
+    if (goUp && filteredOptions.length > 0) {
+      setSelectedIndex((prev) =>
+        prev === 0 ? filteredOptions.length - 1 : prev - 1,
+      );
+      return;
+    }
+
+    if (goDown && filteredOptions.length > 0) {
+      setSelectedIndex((prev) =>
+        prev === filteredOptions.length - 1 ? 0 : prev + 1,
+      );
+      return;
+    }
+
+    // Backspace to delete search character
+    if (key.backspace || key.delete) {
+      setSearchQuery((prev) => prev.slice(0, -1));
+      return;
+    }
+
+    // Type to search (printable characters)
+    if (input && !key.ctrl && !key.meta) {
+      setSearchQuery((prev) => prev + input);
+    }
+  });
+
+  return (
+    <Box
+      flexDirection="column"
+      marginTop={1}
+      borderStyle="single"
+      borderTop
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+      borderColor="gray"
+      paddingTop={1}
+    >
+      {/* Title */}
+      <Text color="blueBright" bold>
+        {title}
+      </Text>
+
+      {/* Description */}
+      {description && (
+        <Box marginTop={0}>
+          <Text color="gray">{description}</Text>
+        </Box>
+      )}
+
+      {/* Search indicator */}
+      {searchQuery && (
+        <Box marginTop={1}>
+          <Text color="gray">Search: </Text>
+          <Text color="yellow">{searchQuery}</Text>
+          <Text color="gray">█</Text>
+        </Box>
+      )}
+
+      {/* Options list */}
+      <Box flexDirection="column" marginTop={1}>
+        {filteredOptions.length === 0 ? (
+          <Text color="gray">No matching options</Text>
+        ) : (
+          filteredOptions.map((option, index) => {
+            const isSelected = index === selectedIndex;
+            const isCurrent = option.id === currentId;
+
+            return (
+              <Box key={option.id} flexDirection="column">
+                <Box>
+                  {/* Selection indicator */}
+                  <Text color="yellow">{isSelected ? "› " : "  "}</Text>
+
+                  {/* Current indicator (checkmark) */}
+                  <Text color="green">{isCurrent ? "✓ " : "  "}</Text>
+
+                  {/* Option number and name */}
+                  <Text
+                    color={isSelected ? "yellow" : undefined}
+                    bold={isSelected}
+                  >
+                    {index + 1}. {option.name}
+                  </Text>
+
+                  {/* Meta info (e.g., pricing) */}
+                  {option.meta && <Text color="gray"> · {option.meta}</Text>}
+                </Box>
+
+                {/* Description on separate line */}
+                {option.description && (
+                  <Box marginLeft={6}>
+                    <Text color="gray">{option.description}</Text>
+                  </Box>
+                )}
+              </Box>
+            );
+          })
+        )}
+      </Box>
+
+      {/* Footer hint */}
+      <Box marginTop={1}>
+        <Text color="gray">
+          {searchQuery
+            ? "Type to search · Enter to confirm · Esc to cancel"
+            : "Type to search · ↑↓ to navigate · Enter to confirm · Esc to cancel"}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/tui/components/settings-panel.tsx
+++ b/packages/tui/components/settings-panel.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useCallback, useRef } from "react";
+import React, {
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+} from "react";
 import { Box, Text, useInput } from "ink";
 
 export type SettingsOption = {
@@ -35,8 +41,11 @@ export function SettingsPanel({
     return index !== -1 ? index : 0;
   });
 
-  // Track previous search query to reset selection when search changes
-  const prevSearchQueryRef = useRef(searchQuery);
+  // Guard to prevent callbacks from firing during initial render
+  const isMountedRef = useRef(false);
+  useEffect(() => {
+    isMountedRef.current = true;
+  }, []);
 
   // Filter options based on search query
   const filteredOptions = useMemo(() => {
@@ -50,18 +59,15 @@ export function SettingsPanel({
     );
   }, [options, searchQuery]);
 
-  // Reset selection when search query changes (synchronously in render)
-  if (searchQuery !== prevSearchQueryRef.current) {
-    prevSearchQueryRef.current = searchQuery;
+  // Reset selection when search query changes
+  useEffect(() => {
     // Find currentId in new filtered results, or default to 0
     const currentIndex = filteredOptions.findIndex(
       (opt) => opt.id === currentId,
     );
     const newIndex = currentIndex !== -1 ? currentIndex : 0;
-    if (newIndex !== selectedIndex) {
-      setSelectedIndex(newIndex);
-    }
-  }
+    setSelectedIndex(newIndex);
+  }, [searchQuery, filteredOptions, currentId]);
 
   // Calculate visible window of options
   const { visibleOptions, startIndex } = useMemo(() => {
@@ -91,6 +97,9 @@ export function SettingsPanel({
   const filteredOptionsRef = useRef(filteredOptions);
   filteredOptionsRef.current = filteredOptions;
 
+  const selectedIndexRef = useRef(selectedIndex);
+  selectedIndexRef.current = selectedIndex;
+
   const searchQueryRef = useRef(searchQuery);
   searchQueryRef.current = searchQuery;
 
@@ -109,6 +118,9 @@ export function SettingsPanel({
         meta?: boolean;
       },
     ) => {
+      // Guard against callbacks firing during initial render
+      if (!isMountedRef.current) return;
+
       // Escape to cancel
       if (key.escape) {
         onCancel();
@@ -117,13 +129,10 @@ export function SettingsPanel({
 
       // Enter to confirm selection
       if (key.return) {
-        setSelectedIndex((currentIndex) => {
-          const selected = filteredOptionsRef.current[currentIndex];
-          if (selected) {
-            onSelect(selected.id);
-          }
-          return currentIndex;
-        });
+        const selected = filteredOptionsRef.current[selectedIndexRef.current];
+        if (selected) {
+          onSelect(selected.id);
+        }
         return;
       }
 

--- a/packages/tui/components/settings-panel.tsx
+++ b/packages/tui/components/settings-panel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useCallback, useRef } from "react";
 import { Box, Text, useInput } from "ink";
 
 export type SettingsOption = {
@@ -28,7 +28,15 @@ export function SettingsPanel({
   maxVisible = 10,
 }: SettingsPanelProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Initialize selectedIndex based on currentId - only computed once on mount
+  const [selectedIndex, setSelectedIndex] = useState(() => {
+    const index = options.findIndex((opt) => opt.id === currentId);
+    return index !== -1 ? index : 0;
+  });
+
+  // Track previous search query to reset selection when search changes
+  const prevSearchQueryRef = useRef(searchQuery);
 
   // Filter options based on search query
   const filteredOptions = useMemo(() => {
@@ -42,13 +50,18 @@ export function SettingsPanel({
     );
   }, [options, searchQuery]);
 
-  // Update selection when filtered options change - prefer current value, fallback to 0
-  useEffect(() => {
+  // Reset selection when search query changes (synchronously in render)
+  if (searchQuery !== prevSearchQueryRef.current) {
+    prevSearchQueryRef.current = searchQuery;
+    // Find currentId in new filtered results, or default to 0
     const currentIndex = filteredOptions.findIndex(
       (opt) => opt.id === currentId,
     );
-    setSelectedIndex(currentIndex !== -1 ? currentIndex : 0);
-  }, [currentId, filteredOptions]);
+    const newIndex = currentIndex !== -1 ? currentIndex : 0;
+    if (newIndex !== selectedIndex) {
+      setSelectedIndex(newIndex);
+    }
+  }
 
   // Calculate visible window of options
   const { visibleOptions, startIndex } = useMemo(() => {
@@ -74,57 +87,84 @@ export function SettingsPanel({
     };
   }, [filteredOptions, selectedIndex, maxVisible]);
 
-  useInput((input, key) => {
-    // Escape to cancel
-    if (key.escape) {
-      onCancel();
-      return;
-    }
+  // Use refs to access current values in the input handler without causing re-subscriptions
+  const filteredOptionsRef = useRef(filteredOptions);
+  filteredOptionsRef.current = filteredOptions;
 
-    // Enter to confirm selection
-    if (key.return) {
-      const selected = filteredOptions[selectedIndex];
-      if (selected) {
-        onSelect(selected.id);
+  const searchQueryRef = useRef(searchQuery);
+  searchQueryRef.current = searchQuery;
+
+  // Memoize input handler to prevent useInput from re-subscribing on every render
+  const handleInput = useCallback(
+    (
+      input: string,
+      key: {
+        escape?: boolean;
+        return?: boolean;
+        upArrow?: boolean;
+        downArrow?: boolean;
+        ctrl?: boolean;
+        backspace?: boolean;
+        delete?: boolean;
+        meta?: boolean;
+      },
+    ) => {
+      // Escape to cancel
+      if (key.escape) {
+        onCancel();
+        return;
       }
-      return;
-    }
 
-    // Navigation (vim keys only work when not searching)
-    const goUp =
-      key.upArrow ||
-      (!searchQuery && input === "k") ||
-      (key.ctrl && input === "p");
-    const goDown =
-      key.downArrow ||
-      (!searchQuery && input === "j") ||
-      (key.ctrl && input === "n");
+      // Enter to confirm selection
+      if (key.return) {
+        setSelectedIndex((currentIndex) => {
+          const selected = filteredOptionsRef.current[currentIndex];
+          if (selected) {
+            onSelect(selected.id);
+          }
+          return currentIndex;
+        });
+        return;
+      }
 
-    if (goUp && filteredOptions.length > 0) {
-      setSelectedIndex((prev) =>
-        prev === 0 ? filteredOptions.length - 1 : prev - 1,
-      );
-      return;
-    }
+      // Navigation (vim keys only work when not searching)
+      const currentSearchQuery = searchQueryRef.current;
+      const goUp =
+        key.upArrow ||
+        (!currentSearchQuery && input === "k") ||
+        (key.ctrl && input === "p");
+      const goDown =
+        key.downArrow ||
+        (!currentSearchQuery && input === "j") ||
+        (key.ctrl && input === "n");
 
-    if (goDown && filteredOptions.length > 0) {
-      setSelectedIndex((prev) =>
-        prev === filteredOptions.length - 1 ? 0 : prev + 1,
-      );
-      return;
-    }
+      const optionsLength = filteredOptionsRef.current.length;
 
-    // Backspace to delete search character
-    if (key.backspace || key.delete) {
-      setSearchQuery((prev) => prev.slice(0, -1));
-      return;
-    }
+      if (goUp && optionsLength > 0) {
+        setSelectedIndex((prev) => (prev === 0 ? optionsLength - 1 : prev - 1));
+        return;
+      }
 
-    // Type to search (printable characters)
-    if (input && !key.ctrl && !key.meta) {
-      setSearchQuery((prev) => prev + input);
-    }
-  });
+      if (goDown && optionsLength > 0) {
+        setSelectedIndex((prev) => (prev === optionsLength - 1 ? 0 : prev + 1));
+        return;
+      }
+
+      // Backspace to delete search character
+      if (key.backspace || key.delete) {
+        setSearchQuery((prev) => prev.slice(0, -1));
+        return;
+      }
+
+      // Type to search (printable characters)
+      if (input && !key.ctrl && !key.meta) {
+        setSearchQuery((prev) => prev + input);
+      }
+    },
+    [onCancel, onSelect],
+  );
+
+  useInput(handleInput);
 
   return (
     <Box

--- a/packages/tui/components/settings-panel.tsx
+++ b/packages/tui/components/settings-panel.tsx
@@ -15,6 +15,7 @@ type SettingsPanelProps = {
   currentId: string;
   onSelect: (id: string) => void;
   onCancel: () => void;
+  maxVisible?: number;
 };
 
 export function SettingsPanel({
@@ -24,6 +25,7 @@ export function SettingsPanel({
   currentId,
   onSelect,
   onCancel,
+  maxVisible = 10,
 }: SettingsPanelProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -39,20 +41,37 @@ export function SettingsPanel({
     );
   }, [options, searchQuery]);
 
-  // Reset selection when filtered options change
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [filteredOptions.length]);
-
-  // Set initial selection to current value
+  // Update selection when filtered options change - prefer current value, fallback to 0
   useEffect(() => {
     const currentIndex = filteredOptions.findIndex(
       (opt) => opt.id === currentId,
     );
-    if (currentIndex !== -1) {
-      setSelectedIndex(currentIndex);
-    }
+    setSelectedIndex(currentIndex !== -1 ? currentIndex : 0);
   }, [currentId, filteredOptions]);
+
+  // Calculate visible window of options
+  const { visibleOptions, startIndex } = useMemo(() => {
+    const total = filteredOptions.length;
+    if (total <= maxVisible) {
+      return { visibleOptions: filteredOptions, startIndex: 0 };
+    }
+
+    // Calculate window to keep selected item visible with context
+    const halfWindow = Math.floor(maxVisible / 2);
+    let start = selectedIndex - halfWindow;
+
+    // Clamp to valid range
+    if (start < 0) {
+      start = 0;
+    } else if (start + maxVisible > total) {
+      start = total - maxVisible;
+    }
+
+    return {
+      visibleOptions: filteredOptions.slice(start, start + maxVisible),
+      startIndex: start,
+    };
+  }, [filteredOptions, selectedIndex, maxVisible]);
 
   useInput((input, key) => {
     // Escape to cancel
@@ -70,15 +89,15 @@ export function SettingsPanel({
       return;
     }
 
-    // Navigation
+    // Navigation (vim keys only work when not searching)
     const goUp =
       key.upArrow ||
-      input === "k" ||
+      (!searchQuery && input === "k") ||
       (key.ctrl && input === "p") ||
       (key.shift && key.tab);
     const goDown =
       key.downArrow ||
-      input === "j" ||
+      (!searchQuery && input === "j") ||
       (key.ctrl && input === "n") ||
       (!key.shift && key.tab);
 
@@ -146,40 +165,60 @@ export function SettingsPanel({
         {filteredOptions.length === 0 ? (
           <Text color="gray">No matching options</Text>
         ) : (
-          filteredOptions.map((option, index) => {
-            const isSelected = index === selectedIndex;
-            const isCurrent = option.id === currentId;
-
-            return (
-              <Box key={option.id} flexDirection="column">
-                <Box>
-                  {/* Selection indicator */}
-                  <Text color="yellow">{isSelected ? "› " : "  "}</Text>
-
-                  {/* Current indicator (checkmark) */}
-                  <Text color="green">{isCurrent ? "✓ " : "  "}</Text>
-
-                  {/* Option number and name */}
-                  <Text
-                    color={isSelected ? "yellow" : undefined}
-                    bold={isSelected}
-                  >
-                    {index + 1}. {option.name}
-                  </Text>
-
-                  {/* Meta info (e.g., pricing) */}
-                  {option.meta && <Text color="gray"> · {option.meta}</Text>}
-                </Box>
-
-                {/* Description on separate line */}
-                {option.description && (
-                  <Box marginLeft={6}>
-                    <Text color="gray">{option.description}</Text>
-                  </Box>
-                )}
+          <>
+            {/* Scroll up indicator */}
+            {startIndex > 0 && (
+              <Box marginBottom={0}>
+                <Text color="gray"> ↑ {startIndex} more above</Text>
               </Box>
-            );
-          })
+            )}
+
+            {visibleOptions.map((option, visibleIndex) => {
+              const actualIndex = startIndex + visibleIndex;
+              const isSelected = actualIndex === selectedIndex;
+              const isCurrent = option.id === currentId;
+
+              return (
+                <Box key={option.id} flexDirection="column">
+                  <Box>
+                    {/* Selection indicator */}
+                    <Text color="yellow">{isSelected ? "› " : "  "}</Text>
+
+                    {/* Current indicator (checkmark) */}
+                    <Text color="green">{isCurrent ? "✓ " : "  "}</Text>
+
+                    {/* Option number and name */}
+                    <Text
+                      color={isSelected ? "yellow" : undefined}
+                      bold={isSelected}
+                    >
+                      {actualIndex + 1}. {option.name}
+                    </Text>
+
+                    {/* Meta info (e.g., pricing) */}
+                    {option.meta && <Text color="gray"> · {option.meta}</Text>}
+                  </Box>
+
+                  {/* Description on separate line */}
+                  {option.description && (
+                    <Box marginLeft={6}>
+                      <Text color="gray">{option.description}</Text>
+                    </Box>
+                  )}
+                </Box>
+              );
+            })}
+
+            {/* Scroll down indicator */}
+            {startIndex + maxVisible < filteredOptions.length && (
+              <Box marginTop={0}>
+                <Text color="gray">
+                  {"    "}↓ {filteredOptions.length - startIndex - maxVisible}{" "}
+                  more below
+                </Text>
+              </Box>
+            )}
+          </>
         )}
       </Box>
 

--- a/packages/tui/components/settings-panel.tsx
+++ b/packages/tui/components/settings-panel.tsx
@@ -36,6 +36,7 @@ export function SettingsPanel({
     const query = searchQuery.toLowerCase();
     return options.filter(
       (opt) =>
+        opt.id.toLowerCase().includes(query) ||
         opt.name.toLowerCase().includes(query) ||
         opt.description?.toLowerCase().includes(query),
     );
@@ -93,13 +94,11 @@ export function SettingsPanel({
     const goUp =
       key.upArrow ||
       (!searchQuery && input === "k") ||
-      (key.ctrl && input === "p") ||
-      (key.shift && key.tab);
+      (key.ctrl && input === "p");
     const goDown =
       key.downArrow ||
       (!searchQuery && input === "j") ||
-      (key.ctrl && input === "n") ||
-      (!key.shift && key.tab);
+      (key.ctrl && input === "n");
 
     if (goUp && filteredOptions.length > 0) {
       setSelectedIndex((prev) =>

--- a/packages/tui/components/suggestions.tsx
+++ b/packages/tui/components/suggestions.tsx
@@ -5,6 +5,7 @@ export type Suggestion = {
   value: string;
   display: string;
   isDirectory?: boolean;
+  description?: string;
 };
 
 type SuggestionsProps = {
@@ -94,6 +95,10 @@ export const Suggestions = memo(function Suggestions({
             >
               {suggestion.display}
             </Text>
+            {/* Description (for commands) */}
+            {suggestion.description && (
+              <Text color="gray"> - {suggestion.description}</Text>
+            )}
           </Box>
         );
       })}

--- a/packages/tui/index.tsx
+++ b/packages/tui/index.tsx
@@ -11,9 +11,10 @@ import { defaultModelLabel } from "@open-harness/agent";
 import { createDefaultAgentOptions } from "./config";
 import type { TUIOptions } from "./types";
 
-export type { TUIOptions, AutoAcceptMode } from "./types";
+export type { TUIOptions, AutoAcceptMode, Settings } from "./types";
 export { useChatContext, ChatProvider } from "./chat-context";
 export { tuiAgent, createDefaultAgentOptions } from "./config";
+export { loadSettings, saveSettings } from "./lib/settings";
 
 /**
  * Create a Claude Code-style TUI.
@@ -55,6 +56,8 @@ export async function createTUI(options: TUIOptions): Promise<void> {
       model={options.header?.model ?? defaultModelLabel}
       workingDirectory={workingDirectory}
       initialAutoAcceptMode={options.initialAutoAcceptMode}
+      initialSettings={options.initialSettings}
+      onSettingsChange={options.onSettingsChange}
     >
       <ReasoningProvider>
         <ExpandedViewProvider>
@@ -90,6 +93,8 @@ export function renderTUI(options: TUIOptions) {
       model={options.header?.model ?? defaultModelLabel}
       workingDirectory={workingDirectory}
       initialAutoAcceptMode={options.initialAutoAcceptMode}
+      initialSettings={options.initialSettings}
+      onSettingsChange={options.onSettingsChange}
     >
       <ReasoningProvider>
         <ExpandedViewProvider>

--- a/packages/tui/index.tsx
+++ b/packages/tui/index.tsx
@@ -15,6 +15,8 @@ export type { TUIOptions, AutoAcceptMode, Settings } from "./types";
 export { useChatContext, ChatProvider } from "./chat-context";
 export { tuiAgent, createDefaultAgentOptions } from "./config";
 export { loadSettings, saveSettings } from "./lib/settings";
+export { fetchAvailableModels } from "./lib/fetch-models";
+export type { ModelInfo } from "./lib/models";
 
 /**
  * Create a Claude Code-style TUI.
@@ -58,6 +60,7 @@ export async function createTUI(options: TUIOptions): Promise<void> {
       initialAutoAcceptMode={options.initialAutoAcceptMode}
       initialSettings={options.initialSettings}
       onSettingsChange={options.onSettingsChange}
+      availableModels={options.availableModels}
     >
       <ReasoningProvider>
         <ExpandedViewProvider>
@@ -95,6 +98,7 @@ export function renderTUI(options: TUIOptions) {
       initialAutoAcceptMode={options.initialAutoAcceptMode}
       initialSettings={options.initialSettings}
       onSettingsChange={options.onSettingsChange}
+      availableModels={options.availableModels}
     >
       <ReasoningProvider>
         <ExpandedViewProvider>

--- a/packages/tui/lib/fetch-models.ts
+++ b/packages/tui/lib/fetch-models.ts
@@ -9,8 +9,11 @@ export type GatewayModel = Awaited<
 /**
  * Format price per token to price per million tokens
  */
-function formatPricing(pricePerToken: string): string {
+function formatPricing(pricePerToken: string): string | undefined {
   const price = parseFloat(pricePerToken);
+  if (Number.isNaN(price)) {
+    return undefined;
+  }
   const pricePerMillion = price * 1_000_000;
   return `$${pricePerMillion.toFixed(2)}/1M`;
 }
@@ -19,16 +22,20 @@ function formatPricing(pricePerToken: string): string {
  * Transform gateway model entry to ModelInfo format
  */
 export function transformToModelInfo(model: GatewayModel): ModelInfo {
+  let pricing: ModelInfo["pricing"];
+  if (model.pricing) {
+    const input = formatPricing(model.pricing.input);
+    const output = formatPricing(model.pricing.output);
+    if (input && output) {
+      pricing = { input, output };
+    }
+  }
+
   return {
     id: model.id,
     name: model.name ?? model.id,
     description: model.description ?? "",
-    pricing: model.pricing
-      ? {
-          input: formatPricing(model.pricing.input),
-          output: formatPricing(model.pricing.output),
-        }
-      : undefined,
+    pricing,
   };
 }
 

--- a/packages/tui/lib/fetch-models.ts
+++ b/packages/tui/lib/fetch-models.ts
@@ -1,0 +1,57 @@
+import { gateway } from "ai";
+import type { ModelInfo } from "./models";
+import { AVAILABLE_MODELS } from "./models";
+
+export type GatewayModel = Awaited<
+  ReturnType<typeof gateway.getAvailableModels>
+>["models"][number];
+
+/**
+ * Format price per token to price per million tokens
+ */
+function formatPricing(pricePerToken: string): string {
+  const price = parseFloat(pricePerToken);
+  const pricePerMillion = price * 1_000_000;
+  return `$${pricePerMillion.toFixed(2)}/1M`;
+}
+
+/**
+ * Transform gateway model entry to ModelInfo format
+ */
+export function transformToModelInfo(model: GatewayModel): ModelInfo {
+  return {
+    id: model.id,
+    name: model.name ?? model.id,
+    description: model.description ?? "",
+    pricing: model.pricing
+      ? {
+          input: formatPricing(model.pricing.input),
+          output: formatPricing(model.pricing.output),
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Fetch available models from the gateway provider.
+ * Falls back to hardcoded models on failure.
+ */
+export async function fetchAvailableModels(): Promise<ModelInfo[]> {
+  try {
+    const response = await gateway.getAvailableModels();
+
+    // Filter to only language models (not embeddings/image models)
+    const languageModels = response.models.filter(
+      (m) => !m.modelType || m.modelType === "language",
+    );
+
+    if (languageModels.length === 0) {
+      return AVAILABLE_MODELS;
+    }
+
+    return languageModels.map(transformToModelInfo);
+  } catch {
+    // Return fallback models on any error
+    return AVAILABLE_MODELS;
+  }
+}

--- a/packages/tui/lib/models.ts
+++ b/packages/tui/lib/models.ts
@@ -1,0 +1,52 @@
+import { gateway } from "@open-harness/agent";
+import type { GatewayModelId, LanguageModel } from "ai";
+
+export type ModelInfo = {
+  id: string;
+  name: string;
+  description: string;
+  pricing?: { input: string; output: string };
+};
+
+export const AVAILABLE_MODELS: ModelInfo[] = [
+  {
+    id: "anthropic/claude-opus-4.5",
+    name: "Opus 4.5",
+    description: "Most capable for complex work",
+    pricing: { input: "$15/1M", output: "$75/1M" },
+  },
+  {
+    id: "anthropic/claude-sonnet-4.5",
+    name: "Sonnet 4.5",
+    description: "Balanced performance and speed",
+    pricing: { input: "$3/1M", output: "$15/1M" },
+  },
+  {
+    id: "anthropic/claude-haiku-4.5",
+    name: "Haiku 4.5",
+    description: "Fastest for quick answers",
+    pricing: { input: "$0.80/1M", output: "$4/1M" },
+  },
+];
+
+export const DEFAULT_MODEL_ID = "anthropic/claude-haiku-4.5";
+
+/**
+ * Get a LanguageModel instance by ID
+ */
+export function getModelById(
+  id: string,
+  options: { devtools: boolean } = { devtools: false },
+): LanguageModel | undefined {
+  const model = AVAILABLE_MODELS.find((m) => m.id === id);
+  if (!model) return undefined;
+  return gateway(id as GatewayModelId, options);
+}
+
+/**
+ * Get display name for a model ID
+ */
+export function getModelDisplayName(modelId: string): string {
+  const model = AVAILABLE_MODELS.find((m) => m.id === modelId);
+  return model?.name ?? modelId;
+}

--- a/packages/tui/lib/models.ts
+++ b/packages/tui/lib/models.ts
@@ -29,17 +29,13 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
   },
 ];
 
-export const DEFAULT_MODEL_ID = "anthropic/claude-haiku-4.5";
-
 /**
  * Get a LanguageModel instance by ID
  */
 export function getModelById(
   id: string,
   options: { devtools: boolean } = { devtools: false },
-): LanguageModel | undefined {
-  const model = AVAILABLE_MODELS.find((m) => m.id === id);
-  if (!model) return undefined;
+): LanguageModel {
   return gateway(id as GatewayModelId, options);
 }
 

--- a/packages/tui/lib/models.ts
+++ b/packages/tui/lib/models.ts
@@ -38,11 +38,3 @@ export function getModelById(
 ): LanguageModel {
   return gateway(id as GatewayModelId, options);
 }
-
-/**
- * Get display name for a model ID
- */
-export function getModelDisplayName(modelId: string): string {
-  const model = AVAILABLE_MODELS.find((m) => m.id === modelId);
-  return model?.name ?? modelId;
-}

--- a/packages/tui/lib/settings.ts
+++ b/packages/tui/lib/settings.ts
@@ -1,18 +1,27 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { z } from "zod";
 
 const CONFIG_DIR = join(homedir(), ".config", "open-harness");
 const SETTINGS_FILE = join(CONFIG_DIR, "settings.json");
 
-export type Settings = {
-  modelId?: string;
-};
+export const settingsSchema = z.object({
+  modelId: z.string().optional(),
+});
+
+export type Settings = z.infer<typeof settingsSchema>;
 
 export async function loadSettings(): Promise<Settings> {
   try {
     const content = await readFile(SETTINGS_FILE, "utf-8");
-    return JSON.parse(content) as Settings;
+    const parsed = JSON.parse(content);
+    const result = settingsSchema.safeParse(parsed);
+    if (result.success) {
+      return result.data;
+    }
+    // Invalid schema - return empty settings
+    return {};
   } catch {
     return {};
   }

--- a/packages/tui/lib/settings.ts
+++ b/packages/tui/lib/settings.ts
@@ -1,0 +1,24 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+const CONFIG_DIR = join(homedir(), ".config", "open-harness");
+const SETTINGS_FILE = join(CONFIG_DIR, "settings.json");
+
+export type Settings = {
+  modelId?: string;
+};
+
+export async function loadSettings(): Promise<Settings> {
+  try {
+    const content = await readFile(SETTINGS_FILE, "utf-8");
+    return JSON.parse(content) as Settings;
+  } catch {
+    return {};
+  }
+}
+
+export async function saveSettings(settings: Settings): Promise<void> {
+  await mkdir(CONFIG_DIR, { recursive: true });
+  await writeFile(SETTINGS_FILE, JSON.stringify(settings, null, 2));
+}

--- a/packages/tui/lib/slash-commands.ts
+++ b/packages/tui/lib/slash-commands.ts
@@ -1,0 +1,73 @@
+import type { Suggestion } from "../components/suggestions";
+
+export type SlashCommandAction = "open-model-select";
+
+export type SlashCommand = {
+  name: string;
+  description: string;
+  action: SlashCommandAction;
+};
+
+export const slashCommands: SlashCommand[] = [
+  {
+    name: "model",
+    description: "Select the AI model",
+    action: "open-model-select",
+  },
+];
+
+/**
+ * Extract a slash command from input text.
+ * Only triggers when "/" is at the start of input.
+ * Returns the partial command being typed or null if not in a command.
+ */
+export function extractSlashCommand(
+  text: string,
+  cursorPosition: number,
+): { commandStart: number; partialCommand: string } | null {
+  // Only trigger at the start of input
+  if (!text.startsWith("/")) {
+    return null;
+  }
+
+  // Find end of command (first space or cursor position)
+  let commandEnd = text.indexOf(" ");
+  if (commandEnd === -1 || commandEnd > cursorPosition) {
+    commandEnd = cursorPosition;
+  }
+
+  // If cursor is past the command part, don't show suggestions
+  if (cursorPosition > commandEnd && text.indexOf(" ") !== -1) {
+    return null;
+  }
+
+  const partialCommand = text.slice(1, commandEnd);
+  return { commandStart: 0, partialCommand };
+}
+
+/**
+ * Get command suggestions matching a partial command.
+ */
+export function getCommandSuggestions(partialCommand: string): Suggestion[] {
+  const query = partialCommand.toLowerCase();
+
+  return slashCommands
+    .filter((cmd) => cmd.name.toLowerCase().includes(query))
+    .map((cmd) => ({
+      value: cmd.name,
+      display: `/${cmd.name}`,
+      description: cmd.description,
+    }));
+}
+
+/**
+ * Get the command action for a given command name.
+ */
+export function getCommandAction(
+  commandName: string,
+): SlashCommandAction | null {
+  const command = slashCommands.find(
+    (cmd) => cmd.name.toLowerCase() === commandName.toLowerCase(),
+  );
+  return command?.action ?? null;
+}

--- a/packages/tui/transport.ts
+++ b/packages/tui/transport.ts
@@ -52,7 +52,7 @@ export function createAgentTransport({
       const sessionRules = getApprovalRules ? getApprovalRules() : [];
       const settings = getSettings?.() ?? {};
       const model = settings.modelId
-        ? getModelById(settings.modelId, { devtools: false })
+        ? getModelById(settings.modelId, { devtools: true })
         : undefined;
 
       // Build the approval config based on the current base config type
@@ -76,7 +76,7 @@ export function createAgentTransport({
 
       const result = await agent.stream({
         messages: prunedMessages,
-        options: { ...agentOptions, model, approval },
+        options: { ...agentOptions, ...(model && { model }), approval },
         abortSignal: abortSignal ?? undefined,
         experimental_transform: smoothStream(),
       });

--- a/packages/tui/transport.ts
+++ b/packages/tui/transport.ts
@@ -12,12 +12,15 @@ import type {
   AutoAcceptMode,
   ApprovalRule,
 } from "./types";
+import type { Settings } from "./lib/settings";
+import { getModelById } from "./lib/models";
 
 export type AgentTransportOptions = {
   agent: TUIAgent;
   agentOptions: TUIAgentCallOptions;
   getAutoApprove?: () => AutoAcceptMode;
   getApprovalRules?: () => ApprovalRule[];
+  getSettings?: () => Settings;
   onUsageUpdate?: (usage: LanguageModelUsage) => void;
 };
 
@@ -26,6 +29,7 @@ export function createAgentTransport({
   agentOptions,
   getAutoApprove,
   getApprovalRules,
+  getSettings,
   onUsageUpdate,
 }: AgentTransportOptions): ChatTransport<TUIAgentUIMessage> {
   return {
@@ -46,6 +50,10 @@ export function createAgentTransport({
       // Get current settings at request time and build approval config
       const autoApprove = getAutoApprove ? getAutoApprove() : "off";
       const sessionRules = getApprovalRules ? getApprovalRules() : [];
+      const settings = getSettings?.() ?? {};
+      const model = settings.modelId
+        ? getModelById(settings.modelId, { devtools: false })
+        : undefined;
 
       // Build the approval config based on the current base config type
       const baseApproval = agentOptions.approval;
@@ -68,7 +76,7 @@ export function createAgentTransport({
 
       const result = await agent.stream({
         messages: prunedMessages,
-        options: { ...agentOptions, approval },
+        options: { ...agentOptions, model, approval },
         abortSignal: abortSignal ?? undefined,
         experimental_transform: smoothStream(),
       });

--- a/packages/tui/types.ts
+++ b/packages/tui/types.ts
@@ -59,4 +59,6 @@ export type TUIOptions = {
   initialSettings?: import("./lib/settings").Settings;
   /** Callback when settings change (for persistence) */
   onSettingsChange?: (settings: import("./lib/settings").Settings) => void;
+  /** Available models for model selection (fetched from gateway) */
+  availableModels?: import("./lib/models").ModelInfo[];
 };

--- a/packages/tui/types.ts
+++ b/packages/tui/types.ts
@@ -35,6 +35,9 @@ export type AutoAcceptMode = "off" | "edits" | "all";
 // Re-export ApprovalRule for client-side use
 export type { ApprovalRule } from "@open-harness/agent";
 
+// Re-export Settings for CLI use
+export type { Settings } from "./lib/settings";
+
 export type TUIOptions = {
   /** Initial prompt to run (for one-shot mode) */
   initialPrompt?: string;
@@ -52,4 +55,8 @@ export type TUIOptions = {
   };
   /** Initial auto-accept mode (defaults to "off") */
   initialAutoAcceptMode?: AutoAcceptMode;
+  /** Initial settings (loaded from config file) */
+  initialSettings?: import("./lib/settings").Settings;
+  /** Callback when settings change (for persistence) */
+  onSettingsChange?: (settings: import("./lib/settings").Settings) => void;
 };

--- a/packages/tui/types.ts
+++ b/packages/tui/types.ts
@@ -7,6 +7,8 @@ import type {
 } from "ai";
 import type { Sandbox } from "@open-harness/sandbox";
 import type { tuiAgent } from "./config";
+import type { Settings } from "./lib/settings";
+import type { ModelInfo } from "./lib/models";
 
 export type TUIAgent = typeof tuiAgent;
 export type TUIAgentCallOptions = Parameters<
@@ -38,6 +40,9 @@ export type { ApprovalRule } from "@open-harness/agent";
 // Re-export Settings for CLI use
 export type { Settings } from "./lib/settings";
 
+// Re-export ModelInfo for CLI use
+export type { ModelInfo } from "./lib/models";
+
 export type TUIOptions = {
   /** Initial prompt to run (for one-shot mode) */
   initialPrompt?: string;
@@ -56,9 +61,9 @@ export type TUIOptions = {
   /** Initial auto-accept mode (defaults to "off") */
   initialAutoAcceptMode?: AutoAcceptMode;
   /** Initial settings (loaded from config file) */
-  initialSettings?: import("./lib/settings").Settings;
+  initialSettings?: Settings;
   /** Callback when settings change (for persistence) */
-  onSettingsChange?: (settings: import("./lib/settings").Settings) => void;
+  onSettingsChange?: (settings: Settings) => void;
   /** Available models for model selection (fetched from gateway) */
-  availableModels?: import("./lib/models").ModelInfo[];
+  availableModels?: ModelInfo[];
 };

--- a/packages/tui/types.ts
+++ b/packages/tui/types.ts
@@ -37,11 +37,8 @@ export type AutoAcceptMode = "off" | "edits" | "all";
 // Re-export ApprovalRule for client-side use
 export type { ApprovalRule } from "@open-harness/agent";
 
-// Re-export Settings for CLI use
-export type { Settings } from "./lib/settings";
-
-// Re-export ModelInfo for CLI use
-export type { ModelInfo } from "./lib/models";
+// Re-export for external use (already imported above for TUIOptions)
+export type { Settings, ModelInfo };
 
 export type TUIOptions = {
   /** Initial prompt to run (for one-shot mode) */


### PR DESCRIPTION
Implement user-selectable AI models with settings persistence and slash command support.

- Add `/model` slash command to open model selection panel with search and pricing info
- Load and persist user settings (modelId) to `~/.config/open-harness/settings.json`
- Fetch available models from gateway provider with fallback to hardcoded defaults
- Create new SettingsPanel component for modal-style selection with keyboard navigation
- Thread settings through chat context and transport layer to override default model
- Suppress AI SDK warnings in CLI dev script with `AI_SDK_LOG_WARNINGS=false`