### PR TITLE
Hide context usage indicator when input box is disabled

### DIFF
--- a/packages/tui/components/input-box.tsx
+++ b/packages/tui/components/input-box.tsx
@@ -556,10 +556,12 @@ export const InputBox = memo(function InputBox({
       {/* Bottom row: auto-accept (left) and context usage (right) */}
       <Box justifyContent="space-between">
         <AutoAcceptIndicator mode={autoAcceptMode} />
-        <ContextUsageIndicator
-          inputTokens={inputTokens}
-          contextLimit={contextLimit}
-        />
+        {!disabled && (
+          <ContextUsageIndicator
+            inputTokens={inputTokens}
+            contextLimit={contextLimit}
+          />
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Prevents the ContextUsageIndicator from rendering when the InputBox is disabled.

- Wrapped ContextUsageIndicator in a conditional check using the `disabled` prop
- Improves UX by not showing token information when user input is not accepted
- Aligns with the auto-accept indicator behavior which is also conditionally displayed