### PR TITLE
Display token counts in task and tool renderers

### DIFF
--- a/apps/web/components/task-group-view.tsx
+++ b/apps/web/components/task-group-view.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Loader2 } from "lucide-react";
 import { isToolUIPart, getToolName } from "ai";
 import type { TaskToolUIPart } from "@open-harness/agent";
+import { formatTokens } from "@open-harness/shared";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "./tool-call/approval-buttons";
 
@@ -43,13 +44,6 @@ function getTaskTokens(part: TaskToolUIPart): number | null {
   if (part.state !== "output-available") return null;
   const message = part.output;
   return message?.metadata?.inputTokens ?? null;
-}
-
-function formatTokens(tokens: number): string {
-  if (tokens >= 1000) {
-    return `${(tokens / 1000).toFixed(1)}k`;
-  }
-  return tokens.toString();
 }
 
 function getLastToolInfo(

--- a/apps/web/components/task-group-view.tsx
+++ b/apps/web/components/task-group-view.tsx
@@ -39,6 +39,19 @@ function countTaskTools(part: TaskToolUIPart): number {
   return message.parts.filter(isToolUIPart).length;
 }
 
+function getTaskTokens(part: TaskToolUIPart): number | null {
+  if (part.state !== "output-available") return null;
+  const message = part.output;
+  return message?.metadata?.inputTokens ?? null;
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  return tokens.toString();
+}
+
 function getLastToolInfo(
   part: TaskToolUIPart,
 ): { name: string; summary: string } | null {
@@ -149,6 +162,7 @@ function TaskItem({
   const isRunning = status === "running" || status === "pending";
   const elapsedSeconds = useTaskTiming(isRunning);
   const toolCount = countTaskTools(part);
+  const tokenCount = getTaskTokens(part);
   const lastTool = getLastToolInfo(part);
 
   const desc = part.input?.task ?? "Task";
@@ -208,6 +222,7 @@ function TaskItem({
           </span>
           <span className="text-xs text-muted-foreground">
             - {toolCount} tool{toolCount !== 1 ? "s" : ""}
+            {tokenCount !== null && ` - ${formatTokens(tokenCount)} tokens`}
           </span>
           {approvalRequested && (
             <span className="text-xs text-yellow-500">[NEEDS APPROVAL]</span>

--- a/apps/web/components/task-group-view.tsx
+++ b/apps/web/components/task-group-view.tsx
@@ -57,7 +57,8 @@ function getLastToolInfo(
   if (toolParts.length === 0) return null;
 
   const lastTool = toolParts[toolParts.length - 1];
-  if (!lastTool) return null;
+  // Double-check needed for TypeScript narrowing with union types
+  if (!lastTool || !isToolUIPart(lastTool)) return null;
 
   const toolName = getToolName(lastTool);
   const input = lastTool.input as Record<string, unknown> | undefined;

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -5,18 +5,12 @@ import type React from "react";
 import { useState } from "react";
 import { isToolUIPart, isTextUIPart, getToolName } from "ai";
 import type { ToolRenderState } from "@open-harness/shared/lib/tool-state";
+import { formatTokens } from "@open-harness/shared";
 import type { TaskToolUIPart, SubagentUIMessage } from "@open-harness/agent";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "../approval-buttons";
 
 type SubagentMessagePart = SubagentUIMessage["parts"][number];
-
-function formatTokens(tokens: number): string {
-  if (tokens >= 1000) {
-    return `${(tokens / 1000).toFixed(1)}k`;
-  }
-  return tokens.toString();
-}
 
 function getToolSummary(part: SubagentMessagePart): string {
   switch (part.type) {
@@ -346,10 +340,9 @@ export function TaskRenderer({
       {!isExpanded && isComplete && (
         <div className="mt-2 pl-5 text-sm text-muted-foreground">
           Complete ({toolParts.length} tool calls
-          {(() => {
-            const inputTokens = message?.metadata?.inputTokens;
-            return inputTokens ? `, ${formatTokens(inputTokens)} tokens` : "";
-          })()}
+          {message?.metadata?.inputTokens
+            ? `, ${formatTokens(message.metadata.inputTokens)} tokens`
+            : ""}
           )
         </div>
       )}

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -3,81 +3,50 @@
 import { Loader2 } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
+import { isToolUIPart, isTextUIPart, getToolName } from "ai";
 import type { ToolRenderState } from "@open-harness/shared/lib/tool-state";
+import type { TaskToolUIPart, SubagentUIMessage } from "@open-harness/agent";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "../approval-buttons";
 
-type TaskInput = {
-  prompt?: string;
-  description?: string;
-  subagent_type?: string;
-};
+type SubagentMessagePart = SubagentUIMessage["parts"][number];
 
-type MessagePart = {
-  type: string;
-  text?: string;
-  toolName?: string;
-  toolCallId?: string;
-  state?: string;
-  input?: Record<string, unknown>;
-  output?: unknown;
-  [key: string]: unknown;
-};
-
-type UIMessage = {
-  parts?: MessagePart[];
-};
-
-/**
- * Check if a part is a tool UI part.
- */
-function isToolPart(part: MessagePart): boolean {
-  return part.type.startsWith("tool-") || part.type === "dynamic-tool";
+function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  return tokens.toString();
 }
 
-/**
- * Check if a part is a text UI part.
- */
-function isTextPart(part: MessagePart): boolean {
-  return part.type === "text";
-}
-
-/**
- * Get tool name from a message part.
- */
-function getToolName(part: MessagePart): string {
-  if (part.toolName) {
-    return part.toolName;
+function getToolSummary(part: SubagentMessagePart): string {
+  switch (part.type) {
+    case "tool-read":
+      return part.input?.filePath ?? "";
+    case "tool-grep":
+    case "tool-glob":
+      return part.input?.pattern ? `"${part.input.pattern}"` : "";
+    case "tool-bash":
+      return part.input?.command ?? "";
+    default:
+      return "";
   }
-  if (part.type.startsWith("tool-")) {
-    return part.type.slice(5);
-  }
-  return "unknown";
 }
 
 function SubagentToolCall({
   part,
   expanded = false,
 }: {
-  part: MessagePart;
+  part: SubagentMessagePart;
   expanded?: boolean;
 }) {
+  if (!isToolUIPart(part)) return null;
+
   const toolName = getToolName(part);
   const isRunning =
     part.state === "input-streaming" || part.state === "input-available";
   const hasError = part.state === "output-error";
 
-  const input = part.input;
-  let summary = "";
-  if (input?.filePath) {
-    summary = String(input.filePath);
-  } else if (input?.pattern) {
-    summary = `"${input.pattern}"`;
-  } else if (input?.command) {
-    summary = String(input.command);
-  } else if (input) {
-    summary = JSON.stringify(input).slice(0, 40);
-  }
+  const summary = getToolSummary(part);
 
   const dotColor = isRunning
     ? "bg-yellow-500"
@@ -121,9 +90,9 @@ function SubagentToolCall({
         {hasError && <span className="text-sm text-red-500"> - error</span>}
       </div>
       {/* Show full input in expanded mode */}
-      {expanded && input && Object.keys(input).length > 0 && (
+      {expanded && (
         <pre className="ml-4 mt-1 max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-xs text-foreground">
-          {JSON.stringify(input, null, 2)}
+          {JSON.stringify(part.input, null, 2)}
         </pre>
       )}
     </div>
@@ -136,36 +105,30 @@ export function TaskRenderer({
   onApprove,
   onDeny,
 }: {
-  part: {
-    input?: unknown;
-    state: string;
-    output?: unknown;
-    approval?: { reason?: string; id?: string };
-    preliminary?: boolean;
-  };
+  part: TaskToolUIPart;
   state: ToolRenderState;
   onApprove?: (id: string) => void;
   onDeny?: (id: string, reason?: string) => void;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const input = part.input as TaskInput | undefined;
-  const desc = input?.description ?? input?.prompt ?? "Spawning subagent";
-  const fullPrompt = input?.prompt;
-  const subagentType = input?.subagent_type;
+  const input = part.input;
+  const desc = input?.task ?? "Spawning subagent";
+  const fullPrompt = input?.instructions;
+  const subagentType = input?.subagentType;
   const taskApprovalRequested = part.state === "approval-requested";
   const taskDenied = part.state === "output-denied";
   const taskDenialReason = taskDenied ? part.approval?.reason : undefined;
 
   const hasOutput = part.state === "output-available";
   const isPreliminary = hasOutput && part.preliminary === true;
-  const message = hasOutput ? (part.output as UIMessage) : undefined;
+  const message = hasOutput ? part.output : undefined;
 
   const messageParts = message?.parts ?? [];
   const relevantParts = messageParts.filter(
-    (p) => isToolPart(p) || isTextPart(p),
+    (p) => isToolUIPart(p) || isTextUIPart(p),
   );
-  const toolParts = messageParts.filter(isToolPart);
-  const textParts = messageParts.filter(isTextPart);
+  const toolParts = messageParts.filter(isToolUIPart);
+  const textParts = messageParts.filter(isTextUIPart);
 
   const maxVisible = 4;
   const hiddenCount = Math.max(0, relevantParts.length - maxVisible);
@@ -296,10 +259,10 @@ export function TaskRenderer({
             </div>
           )}
           {visibleParts.map((p, i) => {
-            if (isToolPart(p)) {
+            if (isToolUIPart(p)) {
               return <SubagentToolCall key={p.toolCallId ?? i} part={p} />;
             }
-            if (isTextPart(p)) {
+            if (isTextUIPart(p)) {
               const text = p.text?.trim() ?? "";
               if (!text) return null;
               const truncated =
@@ -351,7 +314,7 @@ export function TaskRenderer({
               </div>
               <div className="max-h-96 space-y-1 overflow-auto">
                 {relevantParts.map((p, i) => {
-                  if (isToolPart(p)) {
+                  if (isToolUIPart(p)) {
                     return (
                       <SubagentToolCall
                         key={p.toolCallId ?? i}
@@ -360,7 +323,7 @@ export function TaskRenderer({
                       />
                     );
                   }
-                  if (isTextPart(p)) {
+                  if (isTextUIPart(p)) {
                     const text = p.text?.trim() ?? "";
                     if (!text) return null;
                     return (
@@ -382,7 +345,12 @@ export function TaskRenderer({
 
       {!isExpanded && isComplete && (
         <div className="mt-2 pl-5 text-sm text-muted-foreground">
-          Complete ({toolParts.length} tool calls)
+          Complete ({toolParts.length} tool calls
+          {(() => {
+            const inputTokens = message?.metadata?.inputTokens;
+            return inputTokens ? `, ${formatTokens(inputTokens)} tokens` : "";
+          })()}
+          )
         </div>
       )}
 

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -15,6 +15,8 @@ type SubagentMessagePart = SubagentUIMessage["parts"][number];
 function getToolSummary(part: SubagentMessagePart): string {
   switch (part.type) {
     case "tool-read":
+    case "tool-write":
+    case "tool-edit":
       return part.input?.filePath ?? "";
     case "tool-grep":
     case "tool-glob":

--- a/apps/web/components/tool-call/tool-call.tsx
+++ b/apps/web/components/tool-call/tool-call.tsx
@@ -40,31 +40,30 @@ export function ToolCall({
   onDeny,
 }: ToolCallProps) {
   const state = extractRenderState(part, activeApprovalId, isStreaming);
-  const toolName = getToolName(part);
   const approvalProps = { onApprove, onDeny };
 
-  switch (toolName) {
-    case "bash":
+  switch (part.type) {
+    case "tool-bash":
       return <BashRenderer part={part} state={state} {...approvalProps} />;
-    case "read":
+    case "tool-read":
       return (
         <ReadRenderer part={part} state={state} cwd={cwd} {...approvalProps} />
       );
-    case "write":
+    case "tool-write":
       return (
         <WriteRenderer part={part} state={state} cwd={cwd} {...approvalProps} />
       );
-    case "edit":
+    case "tool-edit":
       return (
         <EditRenderer part={part} state={state} cwd={cwd} {...approvalProps} />
       );
-    case "glob":
+    case "tool-glob":
       return <GlobRenderer part={part} state={state} {...approvalProps} />;
-    case "grep":
+    case "tool-grep":
       return <GrepRenderer part={part} state={state} {...approvalProps} />;
-    case "task":
+    case "tool-task":
       return <TaskRenderer part={part} state={state} {...approvalProps} />;
-    case "todo_write":
+    case "tool-todo_write":
       // Todo tool doesn't require approval, so approvalProps are intentionally omitted
       return <TodoRenderer part={part} state={state} />;
     default:
@@ -72,7 +71,7 @@ export function ToolCall({
         <DefaultRenderer
           part={part}
           state={state}
-          toolName={toolName}
+          toolName={getToolName(part)}
           {...approvalProps}
         />
       );

--- a/docs/plans/completed/type-narrowing-over-casting.md
+++ b/docs/plans/completed/type-narrowing-over-casting.md
@@ -1,0 +1,99 @@
+# Type Narrowing Over Casting
+
+This document describes a refactoring pattern applied to improve type safety by replacing casts with proper type narrowing and derived types.
+
+## Problem
+
+Code was using loose inline types and `as` casts instead of leveraging TypeScript's type system properly. This leads to:
+
+- Lost type safety (casts bypass type checking)
+- Duplicated type definitions that drift from source
+- Missed opportunities for TypeScript to catch errors
+
+## Anti-patterns identified
+
+### 1. Loose inline types instead of derived types
+
+**Bad:**
+```typescript
+function TaskRenderer({ part }: {
+  part: { input?: unknown; state: string; output?: unknown };
+}) {
+  const input = part.input as TaskInput;  // cast required
+```
+
+**Good:**
+```typescript
+function TaskRenderer({ part }: {
+  part: TaskToolUIPart;  // derived from tool definition
+}) {
+  const input = part.input;  // properly typed, no cast
+```
+
+### 2. Switching on derived strings instead of discriminants
+
+**Bad:**
+```typescript
+const toolName = getToolName(part);  // returns string
+switch (toolName) {
+  case "task":
+    return <TaskRenderer part={part} />;  // part not narrowed
+```
+
+**Good:**
+```typescript
+switch (part.type) {  // discriminant field
+  case "tool-task":
+    return <TaskRenderer part={part} />;  // part narrowed to TaskToolUIPart
+```
+
+### 3. Local type definitions instead of deriving from source
+
+**Bad:**
+```typescript
+type MessagePart = {
+  type: string;
+  toolCallId?: string;
+  input?: Record<string, unknown>;
+};
+```
+
+**Good:**
+```typescript
+type SubagentMessagePart = SubagentUIMessage["parts"][number];
+```
+
+### 4. Casts instead of type narrowing
+
+**Bad:**
+```typescript
+const input = part.input as Record<string, unknown>;
+if (input?.filePath) { ... }
+```
+
+**Good:**
+```typescript
+switch (part.type) {
+  case "tool-read":
+    return part.input?.filePath;  // TypeScript knows input shape
+  case "tool-bash":
+    return part.input?.command;
+```
+
+## Files refactored
+
+- `apps/web/components/tool-call/renderers/task-renderer.tsx` - Used `TaskToolUIPart` and `SubagentMessagePart` instead of loose types
+- `apps/web/components/tool-call/tool-call.tsx` - Switch on `part.type` instead of derived `toolName`
+- `packages/tui/components/task-group-view.tsx` - Removed cast, types flow from `TaskToolUIPart`
+- `apps/web/components/task-group-view.tsx` - Same fix
+
+## Prompt for finding similar issues
+
+> Look for patterns where we cast with `as` instead of using type narrowing. Also find places where we define local types (like `type MessagePart = {...}`) instead of deriving them from source types. Check for switches on string values derived from objects (like `getToolName(part)`) instead of switching on discriminant fields (like `part.type`). The fix is to use properly typed imports, derive types with indexed access (`Type["field"][number]`), and narrow with discriminants or type guards.
+
+## Key principles
+
+1. **Derive types from source** - Use indexed access types (`Type["field"]`) rather than redefining
+2. **Switch on discriminants** - Use `part.type` not `getToolName(part)` for proper narrowing
+3. **Avoid casts** - If you need `as`, the types aren't flowing properly
+4. **Use type guards** - `isToolUIPart(part)` narrows the type for subsequent code

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -23,3 +23,9 @@ export {
 
 // Tool exports
 export { type TaskToolUIPart } from "./tools/task";
+
+// Subagent type exports
+export type {
+  SubagentMessageMetadata,
+  SubagentUIMessage,
+} from "./subagents/types";

--- a/packages/agent/subagents/index.ts
+++ b/packages/agent/subagents/index.ts
@@ -1,2 +1,3 @@
 export { explorerSubagent, type ExplorerCallOptions } from "./explorer";
 export { executorSubagent, type ExecutorCallOptions } from "./executor";
+export type { SubagentMessageMetadata, SubagentUIMessage } from "./types";

--- a/packages/agent/subagents/types.ts
+++ b/packages/agent/subagents/types.ts
@@ -1,0 +1,12 @@
+import type { InferAgentUIMessage } from "ai";
+import type { explorerSubagent } from "./explorer";
+
+export type SubagentMessageMetadata = {
+  inputTokens?: number;
+};
+
+// Both subagents have compatible tools, so one type works
+export type SubagentUIMessage = InferAgentUIMessage<
+  typeof explorerSubagent,
+  SubagentMessageMetadata
+>;

--- a/packages/agent/subagents/types.ts
+++ b/packages/agent/subagents/types.ts
@@ -1,12 +1,12 @@
 import type { InferAgentUIMessage } from "ai";
 import type { explorerSubagent } from "./explorer";
+import type { executorSubagent } from "./executor";
 
 export type SubagentMessageMetadata = {
   inputTokens?: number;
 };
 
-// Both subagents have compatible tools, so one type works
-export type SubagentUIMessage = InferAgentUIMessage<
-  typeof explorerSubagent,
-  SubagentMessageMetadata
->;
+// Union of both subagent types to support all tool types at runtime
+export type SubagentUIMessage =
+  | InferAgentUIMessage<typeof explorerSubagent, SubagentMessageMetadata>
+  | InferAgentUIMessage<typeof executorSubagent, SubagentMessageMetadata>;

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -2,6 +2,7 @@ import { tool, readUIMessageStream, type UIToolInvocation } from "ai";
 import { z } from "zod";
 import { explorerSubagent } from "../subagents/explorer";
 import { executorSubagent } from "../subagents/executor";
+import type { SubagentUIMessage } from "../subagents/types";
 import { getSandbox, getApprovalContext, shouldAutoApprove } from "./utils";
 import type { ApprovalRule } from "../types";
 
@@ -131,8 +132,14 @@ NOTE: The executor subagent requires user approval before running because it has
       abortSignal,
     });
 
-    for await (const message of readUIMessageStream({
-      stream: result.toUIMessageStream(),
+    for await (const message of readUIMessageStream<SubagentUIMessage>({
+      stream: result.toUIMessageStream<SubagentUIMessage>({
+        messageMetadata: ({ part }) => {
+          if (part.type === "finish-step") {
+            return { inputTokens: part.usage?.inputTokens };
+          }
+        },
+      }),
     })) {
       yield message;
     }

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -47,4 +47,5 @@ export {
   getStatusColor,
   getStatusLabel,
   toRelativePath,
+  formatTokens,
 } from "./lib/tool-state";

--- a/packages/shared/lib/tool-state.ts
+++ b/packages/shared/lib/tool-state.ts
@@ -127,3 +127,14 @@ export function toRelativePath(filePath: string, cwd: string): string {
   }
   return filePath;
 }
+
+/**
+ * Format token count for display.
+ * Shows "1.2k" for numbers >= 1000, otherwise raw number.
+ */
+export function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  return tokens.toString();
+}

--- a/packages/tui/components/suggestions.tsx
+++ b/packages/tui/components/suggestions.tsx
@@ -62,8 +62,14 @@ export const Suggestions = memo(function Suggestions({
   const itemsAbove = windowStart;
   const itemsBelow = suggestions.length - windowEnd;
 
+  // Calculate max width for column alignment
+  const maxDisplayWidth = Math.max(
+    ...displayedSuggestions.map((s) => s.display.length),
+  );
+  const columnWidth = maxDisplayWidth + 4; // Add padding between columns
+
   return (
-    <Box flexDirection="column" paddingLeft={1} paddingRight={1} marginTop={0}>
+    <Box flexDirection="column" paddingLeft={1} marginTop={1} marginBottom={1}>
       {/* Scroll indicator: items above */}
       {hasItemsAbove && (
         <Text color="gray" dimColor>
@@ -78,26 +84,18 @@ export const Suggestions = memo(function Suggestions({
 
         return (
           <Box key={suggestion.value}>
-            {/* Selection indicator */}
-            <Text color={isSelected ? "yellow" : "gray"}>
-              {isSelected ? "> " : "  "}
-            </Text>
-            {/* Suggestion text */}
             <Text
               color={
-                isSelected
-                  ? "yellow"
-                  : suggestion.isDirectory
-                    ? "cyan"
-                    : "white"
+                isSelected ? "yellow" : suggestion.isDirectory ? "cyan" : "gray"
               }
               bold={isSelected}
             >
-              {suggestion.display}
+              {suggestion.display.padEnd(columnWidth)}
             </Text>
-            {/* Description (for commands) */}
             {suggestion.description && (
-              <Text color="gray"> - {suggestion.description}</Text>
+              <Text color={isSelected ? "yellow" : "gray"}>
+                {suggestion.description}
+              </Text>
             )}
           </Box>
         );

--- a/packages/tui/components/task-group-view.tsx
+++ b/packages/tui/components/task-group-view.tsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect, useRef } from "react";
 import { Box, Text } from "ink";
 import { getToolName, isToolUIPart } from "ai";
 import type { TaskToolUIPart, SubagentUIMessage } from "@open-harness/agent";
+import { formatTokens } from "@open-harness/shared";
+
+type SubagentMessagePart = SubagentUIMessage["parts"][number];
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -105,11 +108,20 @@ function getTaskTokens(part: TaskToolUIPart): number | null {
   return message?.metadata?.inputTokens ?? null;
 }
 
-function formatTokens(tokens: number): string {
-  if (tokens >= 1000) {
-    return `${(tokens / 1000).toFixed(1)}k`;
+function getToolSummary(part: SubagentMessagePart): string {
+  switch (part.type) {
+    case "tool-read":
+      return part.input?.filePath ?? "";
+    case "tool-grep":
+    case "tool-glob":
+      return part.input?.pattern ? `"${part.input.pattern}"` : "";
+    case "tool-bash": {
+      const cmd = part.input?.command ?? "";
+      return cmd.length > 40 ? cmd.slice(0, 40) + "..." : cmd;
+    }
+    default:
+      return "";
   }
-  return tokens.toString();
 }
 
 function getLastToolInfo(
@@ -126,17 +138,7 @@ function getLastToolInfo(
   if (!lastTool) return null;
 
   const toolName = getToolName(lastTool);
-  const input = lastTool.input as Record<string, unknown> | undefined;
-
-  let summary = "";
-  if (input?.filePath) {
-    summary = String(input.filePath);
-  } else if (input?.pattern) {
-    summary = `"${input.pattern}"`;
-  } else if (input?.command) {
-    const cmd = String(input.command);
-    summary = cmd.length > 40 ? cmd.slice(0, 40) + "..." : cmd;
-  }
+  const summary = getToolSummary(lastTool);
 
   const displayName = toolName.charAt(0).toUpperCase() + toolName.slice(1);
   return { name: displayName, summary };

--- a/packages/tui/components/task-group-view.tsx
+++ b/packages/tui/components/task-group-view.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Box, Text } from "ink";
 import { getToolName, isToolUIPart } from "ai";
-import type { TaskToolUIPart } from "../../agent/tools/task";
+import type { TaskToolUIPart, SubagentUIMessage } from "@open-harness/agent";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -99,6 +99,19 @@ function countTaskTools(part: TaskToolUIPart): number {
   return message.parts.filter(isToolUIPart).length;
 }
 
+function getTaskTokens(part: TaskToolUIPart): number | null {
+  if (part.state !== "output-available") return null;
+  const message = part.output;
+  return message?.metadata?.inputTokens ?? null;
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  return tokens.toString();
+}
+
 function getLastToolInfo(
   part: TaskToolUIPart,
 ): { name: string; summary: string } | null {
@@ -163,6 +176,7 @@ function TaskItem({
   const isRunning = status === "running" || status === "pending";
   const elapsedSeconds = useTaskTiming(isRunning);
   const toolCount = countTaskTools(part);
+  const tokenCount = getTaskTokens(part);
   const lastTool = getLastToolInfo(part);
 
   const desc = part.input?.task ?? "Task";
@@ -213,6 +227,7 @@ function TaskItem({
         <Text color="gray">
           {" "}
           - {toolCount} tool{toolCount !== 1 ? "s" : ""}
+          {tokenCount !== null && ` - ${formatTokens(tokenCount)} tokens`}
         </Text>
         {approvalRequested && <Text color="yellow"> [NEEDS APPROVAL]</Text>}
         {isRunning && elapsedSeconds > 0 && (

--- a/packages/tui/components/task-group-view.tsx
+++ b/packages/tui/components/task-group-view.tsx
@@ -111,6 +111,8 @@ function getTaskTokens(part: TaskToolUIPart): number | null {
 function getToolSummary(part: SubagentMessagePart): string {
   switch (part.type) {
     case "tool-read":
+    case "tool-write":
+    case "tool-edit":
       return part.input?.filePath ?? "";
     case "tool-grep":
     case "tool-glob":
@@ -135,7 +137,8 @@ function getLastToolInfo(
   if (toolParts.length === 0) return null;
 
   const lastTool = toolParts[toolParts.length - 1];
-  if (!lastTool) return null;
+  // Double-check needed for TypeScript narrowing with union types
+  if (!lastTool || !isToolUIPart(lastTool)) return null;
 
   const toolName = getToolName(lastTool);
   const summary = getToolSummary(lastTool);

--- a/packages/tui/components/tool-renderers/task-renderer.tsx
+++ b/packages/tui/components/tool-renderers/task-renderer.tsx
@@ -1,15 +1,9 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { getToolName, isTextUIPart, isToolUIPart } from "ai";
+import { formatTokens } from "@open-harness/shared";
 import type { ToolRendererProps } from "../../lib/render-tool";
 import { ToolSpinner } from "./shared";
-
-function formatTokens(tokens: number): string {
-  if (tokens >= 1000) {
-    return `${(tokens / 1000).toFixed(1)}k`;
-  }
-  return tokens.toString();
-}
 
 /**
  * Simplified tool call renderer for subagent tool parts.
@@ -183,10 +177,10 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
           <Text color="gray">└ </Text>
           <Text color="white">
             Complete ({toolParts.length} tool calls
-            {(() => {
-              const inputTokens = message?.metadata?.inputTokens;
-              return inputTokens ? `, ${formatTokens(inputTokens)} tokens` : "";
-            })()})
+            {message?.metadata?.inputTokens
+              ? `, ${formatTokens(message.metadata.inputTokens)} tokens`
+              : ""}
+            )
           </Text>
         </Box>
       )}

--- a/packages/tui/components/tool-renderers/task-renderer.tsx
+++ b/packages/tui/components/tool-renderers/task-renderer.tsx
@@ -4,6 +4,13 @@ import { getToolName, isTextUIPart, isToolUIPart } from "ai";
 import type { ToolRendererProps } from "../../lib/render-tool";
 import { ToolSpinner } from "./shared";
 
+function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  return tokens.toString();
+}
+
 /**
  * Simplified tool call renderer for subagent tool parts.
  * Uses a looser type since these come from a different agent's tool set.
@@ -174,7 +181,13 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
       {isComplete && (
         <Box paddingLeft={2}>
           <Text color="gray">└ </Text>
-          <Text color="white">Complete ({toolParts.length} tool calls)</Text>
+          <Text color="white">
+            Complete ({toolParts.length} tool calls
+            {(() => {
+              const inputTokens = message?.metadata?.inputTokens;
+              return inputTokens ? `, ${formatTokens(inputTokens)} tokens` : "";
+            })()})
+          </Text>
         </Box>
       )}
 


### PR DESCRIPTION
Add token usage metrics to task completion summaries across web and TUI interfaces.

- Import `formatTokens` utility and token metadata from shared packages
- Extract token count from task output metadata and display alongside tool call count
- Refactor type definitions to use proper derived types (`TaskToolUIPart`, `SubagentUIMessage`) instead of loose inline types
- Replace string-based tool name switching with discriminant-based type narrowing on `part.type`
- Remove unnecessary type casts by leveraging TypeScript's type system properly
- Update subagent type exports to make UI message types available to consumers