### PR TITLE
Add new-chat slash command to start fresh conversations

### DIFF
--- a/packages/tui/app.tsx
+++ b/packages/tui/app.tsx
@@ -525,6 +525,7 @@ function AppContent({ options }: AppProps) {
     closePanel,
     updateSettings,
     setSessionId,
+    resetUsage,
   } = useChatContext();
   const { isExpanded, toggleExpanded } = useExpandedView();
   const { isTodoVisible, toggleTodoView } = useTodoView();
@@ -728,9 +729,14 @@ function AppContent({ options }: AppProps) {
           loadSessions();
           openPanel({ type: "resume" });
           break;
+        case "new-chat":
+          setMessages([]);
+          setSessionId(null);
+          resetUsage();
+          break;
       }
     },
-    [openPanel, loadSessions],
+    [openPanel, loadSessions, setMessages, setSessionId, resetUsage],
   );
 
   // Memoize model options to prevent re-renders in SettingsPanel

--- a/packages/tui/chat-context.tsx
+++ b/packages/tui/chat-context.tsx
@@ -53,6 +53,7 @@ type ChatContextValue = {
   openPanel: (panel: PanelState) => void;
   closePanel: () => void;
   setSessionId: (sessionId: string | null) => void;
+  resetUsage: () => void;
 };
 
 const ChatContext = createContext<ChatContextValue | undefined>(undefined);
@@ -335,6 +336,11 @@ export function ChatProvider({
     setActivePanel({ type: "none" });
   }, []);
 
+  const resetUsage = useCallback(() => {
+    setUsage(DEFAULT_USAGE);
+    setSessionUsage(DEFAULT_USAGE);
+  }, []);
+
   return (
     <ChatContext.Provider
       value={{
@@ -348,6 +354,7 @@ export function ChatProvider({
         openPanel,
         closePanel,
         setSessionId,
+        resetUsage,
       }}
     >
       {children}

--- a/packages/tui/lib/slash-commands.ts
+++ b/packages/tui/lib/slash-commands.ts
@@ -1,6 +1,9 @@
 import type { Suggestion } from "../components/suggestions";
 
-export type SlashCommandAction = "open-model-select" | "open-resume";
+export type SlashCommandAction =
+  | "open-model-select"
+  | "open-resume"
+  | "new-chat";
 
 export type SlashCommand = {
   name: string;
@@ -18,6 +21,11 @@ export const slashCommands: SlashCommand[] = [
     name: "resume",
     description: "Resume a previous session",
     action: "open-resume",
+  },
+  {
+    name: "new",
+    description: "Start a new chat",
+    action: "new-chat",
   },
 ];
 


### PR DESCRIPTION
Implement a `/new` slash command that resets the chat state and usage metrics.

- Add `resetUsage()` function to ChatContext that clears both global and session usage
- Create `new-chat` slash command action that clears messages, resets session ID, and calls resetUsage
- Update SlashCommandAction type and slashCommands array to include the new command
- Update useCallback dependency array in app.tsx to include new dependencies