### PR TITLE
Add skill discovery and invocation system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,3 +206,8 @@ Use `catalog:` for shared external versions:
   }
 }
 ```
+
+## Lessons Learned
+
+- Skill discovery de-duplicates by first-seen name, so project skill directories must be scanned before user-level directories to allow project overrides.
+- The system prompt should list all model-invocable skills (including non-user-invocable ones), and reserve user-invocable filtering for the slash-command UI.

--- a/TODO-BEFORE-RELEASE.md
+++ b/TODO-BEFORE-RELEASE.md
@@ -42,6 +42,7 @@ To work through these todos, follow this pattern:
 - [ ] Move to workspace approach (multiple chats per workspace)
 - [x] Migrate from raw fetching to SWR
 - [ ] explore a new package with ai related utils (e.g. predicate for sendAutomaticallyWhen etc.)
+- [ ] Optimize skill discovery if it becomes a bottleneck (cache per task, parallelize reads, or HTTP caching)
 
 ### Cancelled
 

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -159,12 +159,13 @@ async function main() {
     // Base folder names that can contain skills (in both user home and project)
     const skillBaseFolders = [".claude", ".agents"];
     const skillDirs = [
-      // User-level skills (e.g., ~/.claude/skills, ~/.agents/skills)
-      ...skillBaseFolders.map((folder) => join(homedir(), folder, "skills")),
+      // Project-level skills should override user-level duplicates (first wins).
       // Project-level skills (e.g., .claude/skills, .agents/skills)
       ...skillBaseFolders.map((folder) =>
         join(workingDirectory, folder, "skills"),
       ),
+      // User-level skills (e.g., ~/.claude/skills, ~/.agents/skills)
+      ...skillBaseFolders.map((folder) => join(homedir(), folder, "skills")),
     ];
     const skills = await discoverSkills(sandbox, skillDirs);
 

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { execSync } from "node:child_process";
-import { defaultModelLabel } from "@open-harness/agent";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { defaultModelLabel, discoverSkills } from "@open-harness/agent";
 import {
   createTUI,
   loadSettings,
@@ -153,6 +155,19 @@ async function main() {
     // Load agents.md files from the working directory hierarchy
     const agentsMd = await loadAgentsMd(workingDirectory);
 
+    // Discover skills from standard locations
+    // Base folder names that can contain skills (in both user home and project)
+    const skillBaseFolders = [".claude", ".agents"];
+    const skillDirs = [
+      // User-level skills (e.g., ~/.claude/skills, ~/.agents/skills)
+      ...skillBaseFolders.map((folder) => join(homedir(), folder, "skills")),
+      // Project-level skills (e.g., .claude/skills, .agents/skills)
+      ...skillBaseFolders.map((folder) =>
+        join(workingDirectory, folder, "skills"),
+      ),
+    ];
+    const skills = await discoverSkills(sandbox, skillDirs);
+
     // Load user settings and available models in parallel
     const [settings, availableModels] = await Promise.all([
       loadSettings(),
@@ -190,6 +205,7 @@ async function main() {
         ...(agentsMd?.content && {
           customInstructions: agentsMd.content,
         }),
+        ...(skills.length > 0 && { skills }),
       },
       initialSettings: settings,
       onSettingsChange: handleSettingsChange,

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,3 +1,4 @@
+import { discoverSkills } from "@open-harness/agent";
 import { connectSandbox, type SandboxState } from "@open-harness/sandbox";
 import { convertToModelMessages, gateway, type LanguageModelUsage } from "ai";
 import { nanoid } from "nanoid";
@@ -70,6 +71,15 @@ export async function POST(req: Request) {
     env: githubToken ? { GITHUB_TOKEN: githubToken } : undefined,
   });
 
+  // Discover skills from the sandbox's working directory
+  // Only project-level skills (no user home directory in remote sandboxes)
+  // TODO: Optimize if this becomes a bottleneck (~20ms no skills, ~130ms with 5 skills)
+  const skillBaseFolders = [".claude", ".agents"];
+  const skillDirs = skillBaseFolders.map(
+    (folder) => `${sandbox.workingDirectory}/${folder}/skills`,
+  );
+  const skills = await discoverSkills(sandbox, skillDirs);
+
   // Save user message immediately (incremental persistence)
   // Only save if the message has an ID (non-empty string) and hasn't been persisted yet
   if (taskId && messages.length > 0) {
@@ -118,6 +128,7 @@ export async function POST(req: Request) {
         autoApprove: "all",
         sessionRules: [],
       },
+      ...(skills.length > 0 && { skills }),
     },
     abortSignal: req.signal,
   });

--- a/packages/agent/deep-agent.ts
+++ b/packages/agent/deep-agent.ts
@@ -17,7 +17,9 @@ import {
   bashTool,
   taskTool,
   askUserQuestionTool,
+  skillTool,
 } from "./tools";
+import type { SkillMetadata } from "./skills/types";
 import { buildSystemPrompt } from "./system-prompt";
 import type { TodoItem, ApprovalConfig } from "./types";
 import { approvalRuleSchema } from "./types";
@@ -39,6 +41,7 @@ const callOptionsSchema = z.object({
   approval: approvalConfigSchema,
   model: z.custom<LanguageModel>().optional(),
   customInstructions: z.string().optional(),
+  skills: z.custom<SkillMetadata[]>().optional(),
 });
 
 export type DeepAgentCallOptions = z.infer<typeof callOptionsSchema>;
@@ -56,6 +59,7 @@ const tools = {
   bash: bashTool(),
   task: taskTool,
   ask_user_question: askUserQuestionTool,
+  skill: skillTool,
 } satisfies ToolSet;
 
 export const deepAgent = new ToolLoopAgent({
@@ -80,6 +84,7 @@ export const deepAgent = new ToolLoopAgent({
     const callModel = options.model ?? model;
     const customInstructions = options.customInstructions;
     const sandbox = options.sandbox;
+    const skills = options.skills ?? [];
 
     // Derive mode for system prompt (interactive vs background)
     const mode = approval.type === "background" ? "background" : "interactive";
@@ -90,6 +95,7 @@ export const deepAgent = new ToolLoopAgent({
       currentBranch: sandbox.currentBranch,
       customInstructions,
       environmentDetails: sandbox.environmentDetails,
+      skills,
     });
 
     return {
@@ -100,7 +106,7 @@ export const deepAgent = new ToolLoopAgent({
         model: callModel,
       }),
       instructions,
-      experimental_context: { sandbox, approval },
+      experimental_context: { sandbox, approval, skills },
     };
   },
 });

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -34,3 +34,14 @@ export type {
   SubagentMessageMetadata,
   SubagentUIMessage,
 } from "./subagents/types";
+
+// Skills exports
+export { discoverSkills, parseSkillFrontmatter } from "./skills/discovery";
+export { extractSkillBody, substituteArguments } from "./skills/loader";
+export type {
+  SkillMetadata,
+  SkillOptions,
+  SkillFrontmatter,
+} from "./skills/types";
+export { skillFrontmatterSchema, frontmatterToOptions } from "./skills/types";
+export type { SkillToolInput } from "./tools/skill";

--- a/packages/agent/skills/discovery.ts
+++ b/packages/agent/skills/discovery.ts
@@ -47,21 +47,25 @@ export function parseSkillFrontmatter(
     if (colonIndex === -1) continue;
 
     const key = trimmed.slice(0, colonIndex).trim();
+    // Only split on the first colon to preserve colons in values (e.g., URLs)
     let value: string | boolean = trimmed.slice(colonIndex + 1).trim();
 
-    // Remove quotes if present
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-
-    // Parse booleans
-    if (value === "true") {
-      value = true;
-    } else if (value === "false") {
-      value = false;
+    // Handle quoted strings (including escaped quotes inside)
+    if (value.startsWith('"') && value.endsWith('"')) {
+      const inner = value.slice(1, -1);
+      // Unescape escaped quotes: \" -> "
+      value = inner.replace(/\\"/g, '"');
+    } else if (value.startsWith("'") && value.endsWith("'")) {
+      const inner = value.slice(1, -1);
+      // Unescape escaped quotes: \' -> '
+      value = inner.replace(/\\'/g, "'");
+    } else {
+      // Parse booleans only for unquoted values
+      if (value === "true") {
+        value = true;
+      } else if (value === "false") {
+        value = false;
+      }
     }
 
     parsed[key] = value;
@@ -157,11 +161,20 @@ export async function discoverSkills(
 
       const frontmatter = result.data;
 
-      // Skip duplicate skill names (first one wins)
-      if (seenNames.has(frontmatter.name)) {
+      // Skip skills that shadow built-in commands (they would be unreachable)
+      if (BUILTIN_COMMANDS.includes(frontmatter.name.toLowerCase())) {
+        console.warn(
+          `Warning: Skill "${frontmatter.name}" in ${skillDir} shadows built-in command /${frontmatter.name}. Skipping.`,
+        );
         continue;
       }
-      seenNames.add(frontmatter.name);
+
+      // Skip duplicate skill names (first one wins, case-insensitive)
+      const normalizedName = frontmatter.name.toLowerCase();
+      if (seenNames.has(normalizedName)) {
+        continue;
+      }
+      seenNames.add(normalizedName);
 
       skills.push({
         name: frontmatter.name,
@@ -170,15 +183,6 @@ export async function discoverSkills(
         filename: path.basename(skillFile),
         options: frontmatterToOptions(frontmatter),
       });
-    }
-  }
-
-  // Warn about skill names that shadow built-in commands
-  for (const skill of skills) {
-    if (BUILTIN_COMMANDS.includes(skill.name.toLowerCase())) {
-      console.warn(
-        `Warning: Skill "${skill.name}" shadows built-in command /${skill.name}. The skill will be unreachable via slash command.`,
-      );
     }
   }
 

--- a/packages/agent/skills/discovery.ts
+++ b/packages/agent/skills/discovery.ts
@@ -1,0 +1,170 @@
+import * as path from "path";
+import type { Sandbox } from "@open-harness/sandbox";
+import {
+  skillFrontmatterSchema,
+  frontmatterToOptions,
+  type SkillMetadata,
+} from "./types";
+
+/**
+ * Parse YAML frontmatter from SKILL.md content.
+ * Returns null if frontmatter is missing or invalid.
+ *
+ * Expected format:
+ * ---
+ * name: skill-name
+ * description: Short description
+ * ---
+ */
+export function parseSkillFrontmatter(
+  content: string,
+): ReturnType<typeof skillFrontmatterSchema.safeParse> {
+  // Match YAML frontmatter between --- markers
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match?.[1]) {
+    return {
+      success: false,
+      error: new Error("No frontmatter found") as never,
+    };
+  }
+
+  const yaml = match[1];
+  const parsed: Record<string, unknown> = {};
+
+  // Simple YAML parser for frontmatter
+  // Handles: key: value, key: "quoted value", multiline not supported
+  for (const line of yaml.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const colonIndex = trimmed.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const key = trimmed.slice(0, colonIndex).trim();
+    let value: string | boolean = trimmed.slice(colonIndex + 1).trim();
+
+    // Remove quotes if present
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    // Parse booleans
+    if (value === "true") {
+      value = true;
+    } else if (value === "false") {
+      value = false;
+    }
+
+    parsed[key] = value;
+  }
+
+  return skillFrontmatterSchema.safeParse(parsed);
+}
+
+/**
+ * Find the SKILL.md file in a directory.
+ * Prefers uppercase SKILL.md over lowercase skill.md.
+ * Returns null if neither exists.
+ */
+async function findSkillFile(
+  sandbox: Sandbox,
+  skillDir: string,
+): Promise<string | null> {
+  const uppercasePath = path.join(skillDir, "SKILL.md");
+  const lowercasePath = path.join(skillDir, "skill.md");
+
+  try {
+    await sandbox.access(uppercasePath);
+    return uppercasePath;
+  } catch {
+    // Uppercase not found, try lowercase
+  }
+
+  try {
+    await sandbox.access(lowercasePath);
+    return lowercasePath;
+  } catch {
+    // Neither found
+    return null;
+  }
+}
+
+/**
+ * Discover skills from the given directories using sandbox interface.
+ * Scans each directory for subdirectories containing SKILL.md files.
+ *
+ * @param sandbox - Sandbox interface for file operations
+ * @param directories - List of directories to scan for skills
+ * @returns Array of skill metadata (name, description, path, options)
+ */
+export async function discoverSkills(
+  sandbox: Sandbox,
+  directories: string[],
+): Promise<SkillMetadata[]> {
+  const skills: SkillMetadata[] = [];
+  const seenNames = new Set<string>();
+
+  for (const dir of directories) {
+    // Check if directory exists
+    try {
+      const stat = await sandbox.stat(dir);
+      if (!stat.isDirectory()) continue;
+    } catch {
+      // Directory doesn't exist, skip
+      continue;
+    }
+
+    // List subdirectories
+    let entries;
+    try {
+      entries = await sandbox.readdir(dir, { withFileTypes: true });
+    } catch {
+      // Can't read directory, skip
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      // Check for SKILL.md or skill.md
+      const skillDir = path.join(dir, entry.name);
+      const skillFile = await findSkillFile(sandbox, skillDir);
+      if (!skillFile) continue;
+
+      // Read and parse frontmatter only
+      let content: string;
+      try {
+        content = await sandbox.readFile(skillFile, "utf-8");
+      } catch {
+        // Can't read file, skip
+        continue;
+      }
+
+      const result = parseSkillFrontmatter(content);
+      if (!result.success) {
+        // Invalid frontmatter, skip
+        continue;
+      }
+
+      const frontmatter = result.data;
+
+      // Skip duplicate skill names (first one wins)
+      if (seenNames.has(frontmatter.name)) {
+        continue;
+      }
+      seenNames.add(frontmatter.name);
+
+      skills.push({
+        name: frontmatter.name,
+        description: frontmatter.description,
+        path: skillDir,
+        options: frontmatterToOptions(frontmatter),
+      });
+    }
+  }
+
+  return skills;
+}

--- a/packages/agent/skills/discovery.ts
+++ b/packages/agent/skills/discovery.ts
@@ -7,6 +7,12 @@ import {
 } from "./types";
 
 /**
+ * Built-in commands that skills cannot shadow.
+ * Skills with these names will be unreachable via slash command.
+ */
+const BUILTIN_COMMANDS = ["model", "resume", "new"];
+
+/**
  * Parse YAML frontmatter from SKILL.md content.
  * Returns null if frontmatter is missing or invalid.
  *
@@ -161,8 +167,18 @@ export async function discoverSkills(
         name: frontmatter.name,
         description: frontmatter.description,
         path: skillDir,
+        filename: path.basename(skillFile),
         options: frontmatterToOptions(frontmatter),
       });
+    }
+  }
+
+  // Warn about skill names that shadow built-in commands
+  for (const skill of skills) {
+    if (BUILTIN_COMMANDS.includes(skill.name.toLowerCase())) {
+      console.warn(
+        `Warning: Skill "${skill.name}" shadows built-in command /${skill.name}. The skill will be unreachable via slash command.`,
+      );
     }
   }
 

--- a/packages/agent/skills/index.ts
+++ b/packages/agent/skills/index.ts
@@ -1,0 +1,13 @@
+// Types
+export type {
+  SkillFrontmatter,
+  SkillOptions,
+  SkillMetadata,
+} from "./types";
+export { skillFrontmatterSchema, frontmatterToOptions } from "./types";
+
+// Discovery
+export { discoverSkills, parseSkillFrontmatter } from "./discovery";
+
+// Loader
+export { extractSkillBody, substituteArguments } from "./loader";

--- a/packages/agent/skills/loader.ts
+++ b/packages/agent/skills/loader.ts
@@ -1,0 +1,28 @@
+/**
+ * Extract the body content from a SKILL.md file.
+ * Strips the YAML frontmatter and returns only the markdown body.
+ *
+ * @param fileContent - Full content of SKILL.md file
+ * @returns The body content after frontmatter
+ */
+export function extractSkillBody(fileContent: string): string {
+  // Match and remove YAML frontmatter between --- markers
+  const match = fileContent.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  if (match) {
+    return fileContent.slice(match[0].length).trim();
+  }
+  // No frontmatter found, return entire content
+  return fileContent.trim();
+}
+
+/**
+ * Substitute $ARGUMENTS placeholder with actual arguments.
+ * Replaces all occurrences of $ARGUMENTS with the provided args.
+ *
+ * @param body - Skill body content with potential $ARGUMENTS placeholders
+ * @param args - Arguments to substitute, or undefined for empty string
+ * @returns Body with $ARGUMENTS replaced
+ */
+export function substituteArguments(body: string, args?: string): string {
+  return body.replace(/\$ARGUMENTS/g, args ?? "");
+}

--- a/packages/agent/skills/types.ts
+++ b/packages/agent/skills/types.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+/**
+ * Zod schema for skill frontmatter YAML validation.
+ * Defines the expected structure in SKILL.md files.
+ */
+export const skillFrontmatterSchema = z.object({
+  name: z.string().describe("Unique name of the skill"),
+  description: z.string().describe("Short description for the agent"),
+  version: z.string().optional().describe("Skill version"),
+  "disable-model-invocation": z
+    .boolean()
+    .optional()
+    .describe("If true, the model cannot invoke this skill automatically"),
+  "user-invocable": z
+    .boolean()
+    .optional()
+    .describe("If false, users cannot invoke this skill via slash command"),
+  "allowed-tools": z
+    .string()
+    .optional()
+    .describe("Comma-separated list of allowed tools when skill is active"),
+  context: z
+    .enum(["fork"])
+    .optional()
+    .describe("Execution context for the skill"),
+  agent: z.string().optional().describe("Agent type to use for execution"),
+});
+
+export type SkillFrontmatter = z.infer<typeof skillFrontmatterSchema>;
+
+/**
+ * Skill options derived from frontmatter.
+ * Normalized for easier access in code.
+ */
+export interface SkillOptions {
+  /** If true, the model cannot invoke this skill automatically */
+  disableModelInvocation?: boolean;
+  /** If false, users cannot invoke this skill via slash command */
+  userInvocable?: boolean;
+  /** List of allowed tools when skill is active */
+  allowedTools?: string[];
+  /** Execution context for the skill */
+  context?: "fork";
+  /** Agent type to use for execution */
+  agent?: string;
+}
+
+/**
+ * Skill metadata stored in agentOptions.
+ * Contains only what's needed for discovery and invocation.
+ */
+export interface SkillMetadata {
+  /** Unique name of the skill */
+  name: string;
+  /** Short description for the agent */
+  description: string;
+  /** Path to the skill directory */
+  path: string;
+  /** Skill options from frontmatter */
+  options: SkillOptions;
+}
+
+/**
+ * Normalize skill frontmatter to options.
+ * Converts kebab-case keys to camelCase.
+ */
+export function frontmatterToOptions(
+  frontmatter: SkillFrontmatter,
+): SkillOptions {
+  return {
+    disableModelInvocation: frontmatter["disable-model-invocation"],
+    userInvocable: frontmatter["user-invocable"],
+    allowedTools: frontmatter["allowed-tools"]
+      ?.split(",")
+      .map((t) => t.trim())
+      .filter(Boolean),
+    context: frontmatter.context,
+    agent: frontmatter.agent,
+  };
+}

--- a/packages/agent/skills/types.ts
+++ b/packages/agent/skills/types.ts
@@ -5,8 +5,14 @@ import { z } from "zod";
  * Defines the expected structure in SKILL.md files.
  */
 export const skillFrontmatterSchema = z.object({
-  name: z.string().describe("Unique name of the skill"),
-  description: z.string().describe("Short description for the agent"),
+  name: z
+    .string()
+    .min(1, "Skill name cannot be empty")
+    .describe("Unique name of the skill"),
+  description: z
+    .string()
+    .min(1, "Skill description cannot be empty")
+    .describe("Short description for the agent"),
   version: z.string().optional().describe("Skill version"),
   "disable-model-invocation": z
     .boolean()
@@ -57,6 +63,8 @@ export interface SkillMetadata {
   description: string;
   /** Path to the skill directory */
   path: string;
+  /** Filename of the skill file (SKILL.md or skill.md) */
+  filename: string;
   /** Skill options from frontmatter */
   options: SkillOptions;
 }

--- a/packages/agent/system-prompt.ts
+++ b/packages/agent/system-prompt.ts
@@ -205,17 +205,18 @@ function buildSkillsPrompt(skills: SkillMetadata[]): string {
   if (skills.length === 0) return "";
 
   // Filter to skills the model can actually invoke:
-  // - Must be user-invocable (for slash command display)
   // - Must NOT have model invocation disabled
   const invocableSkills = skills.filter(
-    (s) =>
-      s.options.userInvocable !== false && !s.options.disableModelInvocation,
+    (s) => !s.options.disableModelInvocation,
   );
 
   if (invocableSkills.length === 0) return "";
 
   const skillsList = invocableSkills
-    .map((s) => `- ${s.name}: ${s.description}`)
+    .map((s) => {
+      const suffix = s.options.userInvocable === false ? " (model-only)" : "";
+      return `- ${s.name}: ${s.description}${suffix}`;
+    })
     .join("\n");
 
   return `
@@ -223,6 +224,7 @@ function buildSkillsPrompt(skills: SkillMetadata[]): string {
 - \`skill\` - Execute a skill to extend your capabilities
 - Use the \`skill\` tool to invoke skills when relevant to the user's request
 - When a user references "/<skill-name>" (e.g., "/commit"), invoke the corresponding skill
+- Some skills may be model-only (not user-invocable) and should be invoked automatically when relevant
 
 Available skills:
 ${skillsList}

--- a/packages/agent/system-prompt.ts
+++ b/packages/agent/system-prompt.ts
@@ -1,3 +1,5 @@
+import type { SkillMetadata } from "./skills/types";
+
 export const DEEP_AGENT_SYSTEM_PROMPT = `You are a deep agent - an AI coding assistant capable of handling complex, multi-step tasks through planning, context management, and delegation.
 
 # Role & Agency
@@ -192,6 +194,38 @@ export interface BuildSystemPromptOptions {
   currentBranch?: string;
   customInstructions?: string;
   environmentDetails?: string;
+  skills?: SkillMetadata[];
+}
+
+/**
+ * Build the skills section for the system prompt.
+ * Lists available skills that the agent can invoke.
+ */
+function buildSkillsPrompt(skills: SkillMetadata[]): string {
+  if (skills.length === 0) return "";
+
+  // Filter to only user-invocable skills (unless explicitly disabled)
+  const invocableSkills = skills.filter(
+    (s) => s.options.userInvocable !== false,
+  );
+
+  if (invocableSkills.length === 0) return "";
+
+  const skillsList = invocableSkills
+    .map((s) => `- ${s.name}: ${s.description}`)
+    .join("\n");
+
+  return `
+## Skills
+- \`skill\` - Execute a skill to extend your capabilities
+- Use the \`skill\` tool to invoke skills when relevant to the user's request
+- When a user references "/<skill-name>" (e.g., "/commit"), invoke the corresponding skill
+
+Available skills:
+${skillsList}
+
+When a skill is relevant, invoke it IMMEDIATELY using the skill tool.
+If you see a <command-name> tag in the conversation, the skill is already loaded - follow its instructions directly.`;
 }
 
 export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
@@ -220,6 +254,14 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
     parts.push(
       `\n# Project-Specific Instructions\n\n${options.customInstructions}`,
     );
+  }
+
+  // Add skills section if skills are available
+  if (options.skills && options.skills.length > 0) {
+    const skillsPrompt = buildSkillsPrompt(options.skills);
+    if (skillsPrompt) {
+      parts.push(skillsPrompt);
+    }
   }
 
   return parts.join("\n");

--- a/packages/agent/system-prompt.ts
+++ b/packages/agent/system-prompt.ts
@@ -204,9 +204,12 @@ export interface BuildSystemPromptOptions {
 function buildSkillsPrompt(skills: SkillMetadata[]): string {
   if (skills.length === 0) return "";
 
-  // Filter to only user-invocable skills (unless explicitly disabled)
+  // Filter to skills the model can actually invoke:
+  // - Must be user-invocable (for slash command display)
+  // - Must NOT have model invocation disabled
   const invocableSkills = skills.filter(
-    (s) => s.options.userInvocable !== false,
+    (s) =>
+      s.options.userInvocable !== false && !s.options.disableModelInvocation,
   );
 
   if (invocableSkills.length === 0) return "";

--- a/packages/agent/tools/index.ts
+++ b/packages/agent/tools/index.ts
@@ -10,3 +10,4 @@ export {
   type AskUserQuestionToolUIPart,
   type AskUserQuestionInput,
 } from "./ask-user-question";
+export { skillTool, type SkillToolInput } from "./skill";

--- a/packages/agent/tools/skill.ts
+++ b/packages/agent/tools/skill.ts
@@ -23,14 +23,16 @@ function getSkills(experimental_context: unknown): SkillMetadata[] {
 
 /**
  * Check if a skill name matches any skill approval rules.
+ * Comparison is case-insensitive to match slash command behavior.
  */
 function skillMatchesApprovalRule(
   skillName: string,
   approvalRules: ApprovalRule[],
 ): boolean {
+  const normalizedName = skillName.toLowerCase();
   for (const rule of approvalRules) {
     if (rule.type === "skill" && rule.tool === "skill") {
-      if (rule.skillName === skillName) {
+      if (rule.skillName.toLowerCase() === normalizedName) {
         return true;
       }
     }
@@ -87,8 +89,11 @@ Important:
     const sandbox = getSandbox(experimental_context, "skill");
     const skills = getSkills(experimental_context);
 
-    // Find the skill by name
-    const foundSkill = skills.find((s) => s.name === skill);
+    // Find the skill by name (case-insensitive to match slash command behavior)
+    const normalizedSkillName = skill.toLowerCase();
+    const foundSkill = skills.find(
+      (s) => s.name.toLowerCase() === normalizedSkillName,
+    );
     if (!foundSkill) {
       const availableSkills = skills.map((s) => s.name).join(", ");
       return {

--- a/packages/agent/tools/skill.ts
+++ b/packages/agent/tools/skill.ts
@@ -1,0 +1,142 @@
+import * as path from "path";
+import { tool } from "ai";
+import { z } from "zod";
+import { getSandbox, getApprovalContext, shouldAutoApprove } from "./utils";
+import { extractSkillBody, substituteArguments } from "../skills/loader";
+import type { SkillMetadata } from "../skills/types";
+import type { ApprovalRule } from "../types";
+
+/**
+ * Extended agent context that includes skills.
+ */
+interface SkillAgentContext {
+  skills?: SkillMetadata[];
+}
+
+/**
+ * Get skills from experimental context.
+ */
+function getSkills(experimental_context: unknown): SkillMetadata[] {
+  const context = experimental_context as SkillAgentContext | undefined;
+  return context?.skills ?? [];
+}
+
+/**
+ * Check if a skill name matches any skill approval rules.
+ */
+function skillMatchesApprovalRule(
+  skillName: string,
+  approvalRules: ApprovalRule[],
+): boolean {
+  for (const rule of approvalRules) {
+    if (rule.type === "skill" && rule.tool === "skill") {
+      if (rule.skillName === skillName) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+const skillInputSchema = z.object({
+  skill: z.string().describe("The skill name to invoke"),
+  args: z.string().optional().describe("Optional arguments for the skill"),
+});
+
+export const skillTool = tool({
+  needsApproval: ({ skill }, { experimental_context }) => {
+    const ctx = getApprovalContext(experimental_context, "skill");
+    const { approval } = ctx;
+
+    // Background and delegated modes auto-approve
+    if (shouldAutoApprove(approval)) {
+      return false;
+    }
+
+    // Check if a session rule matches this skill
+    if (skillMatchesApprovalRule(skill, approval.sessionRules)) {
+      return false;
+    }
+
+    // Default: skills need approval
+    return true;
+  },
+  description: `Execute a skill within the main conversation.
+
+When users ask you to perform tasks, check if any of the available skills can help complete the task more effectively. Skills provide specialized capabilities and domain knowledge.
+
+When users ask you to run a "slash command" or reference "/<something>" (e.g., "/commit", "/review-pr"), they are referring to a skill. Use this tool to invoke the corresponding skill.
+
+Example:
+  User: "run /commit"
+  Assistant: [Calls skill tool with skill: "commit"]
+
+How to invoke:
+- Use this tool with the skill name and optional arguments
+- Examples:
+  - skill: "pdf" - invoke the pdf skill
+  - skill: "commit", args: "-m 'Fix bug'" - invoke with arguments
+
+Important:
+- When a skill is relevant, invoke this tool IMMEDIATELY as your first action
+- NEVER just announce or mention a skill without actually calling this tool
+- Only use skills listed in "Available skills" in your system prompt
+- If you see a <command-name> tag in the conversation, the skill is ALREADY loaded - follow its instructions directly`,
+  inputSchema: skillInputSchema,
+  execute: async ({ skill, args }, { experimental_context }) => {
+    const sandbox = getSandbox(experimental_context, "skill");
+    const skills = getSkills(experimental_context);
+
+    // Find the skill by name
+    const foundSkill = skills.find((s) => s.name === skill);
+    if (!foundSkill) {
+      const availableSkills = skills.map((s) => s.name).join(", ");
+      return {
+        success: false,
+        error: `Skill '${skill}' not found. Available skills: ${availableSkills || "none"}`,
+      };
+    }
+
+    // Check if skill disables model invocation
+    if (foundSkill.options.disableModelInvocation) {
+      return {
+        success: false,
+        error: `Skill '${skill}' cannot be invoked by the model (disable-model-invocation is set)`,
+      };
+    }
+
+    // Load skill content via sandbox
+    const skillFilePath = path.join(foundSkill.path, "SKILL.md");
+    let fileContent: string;
+    try {
+      fileContent = await sandbox.readFile(skillFilePath, "utf-8");
+    } catch {
+      // Try lowercase
+      try {
+        const lowercasePath = path.join(foundSkill.path, "skill.md");
+        fileContent = await sandbox.readFile(lowercasePath, "utf-8");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          success: false,
+          error: `Failed to read skill file: ${message}`,
+        };
+      }
+    }
+
+    // Parse and extract body (skip frontmatter)
+    const body = extractSkillBody(fileContent);
+
+    // Substitute arguments
+    const content = substituteArguments(body, args);
+
+    return {
+      success: true,
+      skillName: skill,
+      skillPath: foundSkill.path,
+      content,
+    };
+  },
+});
+
+export type SkillToolInput = z.infer<typeof skillInputSchema>;

--- a/packages/agent/tools/skill.ts
+++ b/packages/agent/tools/skill.ts
@@ -106,22 +106,16 @@ Important:
     }
 
     // Load skill content via sandbox
-    const skillFilePath = path.join(foundSkill.path, "SKILL.md");
+    const skillFilePath = path.join(foundSkill.path, foundSkill.filename);
     let fileContent: string;
     try {
       fileContent = await sandbox.readFile(skillFilePath, "utf-8");
-    } catch {
-      // Try lowercase
-      try {
-        const lowercasePath = path.join(foundSkill.path, "skill.md");
-        fileContent = await sandbox.readFile(lowercasePath, "utf-8");
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          success: false,
-          error: `Failed to read skill file: ${message}`,
-        };
-      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        error: `Failed to read skill file: ${message}`,
+      };
     }
 
     // Parse and extract body (skip frontmatter)

--- a/packages/agent/types.ts
+++ b/packages/agent/types.ts
@@ -29,9 +29,12 @@ export type ApprovalConfig =
   | { type: "background" }
   | { type: "delegated" };
 
+import type { SkillMetadata } from "./skills/types";
+
 export interface AgentContext {
   sandbox: Sandbox;
   approval: ApprovalConfig;
+  skills?: SkillMetadata[];
 }
 
 /**
@@ -56,6 +59,11 @@ export const approvalRuleSchema = z.discriminatedUnion("type", [
     type: z.literal("subagent-type"),
     tool: z.literal("task"),
     subagentType: z.enum(["explorer", "executor"]),
+  }),
+  z.object({
+    type: z.literal("skill"),
+    tool: z.literal("skill"),
+    skillName: z.string().min(1, "Skill name cannot be empty"),
   }),
 ]);
 

--- a/packages/tui/app.tsx
+++ b/packages/tui/app.tsx
@@ -721,6 +721,9 @@ function AppContent({ options }: AppProps) {
 
   const handleCommandSelect = useCallback(
     (action: SlashCommandAction) => {
+      // Skills are handled in InputBox by submitting as message, not here
+      if (typeof action === "object") return;
+
       switch (action) {
         case "open-model-select":
           openPanel({ type: "model-select" });

--- a/packages/tui/chat-context.tsx
+++ b/packages/tui/chat-context.tsx
@@ -277,7 +277,10 @@ export function ChatProvider({
     [transport],
   );
 
-  const skills = agentOptions.skills ?? [];
+  const skills = useMemo(
+    () => agentOptions.skills ?? [],
+    [agentOptions.skills],
+  );
 
   const state: ChatState = useMemo(
     () => ({

--- a/packages/tui/chat-context.tsx
+++ b/packages/tui/chat-context.tsx
@@ -19,7 +19,7 @@ import type {
 } from "./types";
 import type { Settings } from "./lib/settings";
 import { AVAILABLE_MODELS, type ModelInfo } from "./lib/models";
-import { getContextLimit } from "@open-harness/agent";
+import { getContextLimit, type SkillMetadata } from "@open-harness/agent";
 
 export type PanelState =
   | { type: "none" }
@@ -40,6 +40,7 @@ type ChatState = {
   sessionId: string | null;
   projectPath: string | null;
   currentBranch: string;
+  skills: SkillMetadata[];
 };
 
 type ChatContextValue = {
@@ -276,6 +277,8 @@ export function ChatProvider({
     [transport],
   );
 
+  const skills = agentOptions.skills ?? [];
+
   const state: ChatState = useMemo(
     () => ({
       model: effectiveModel,
@@ -291,6 +294,7 @@ export function ChatProvider({
       sessionId,
       projectPath: projectPath ?? null,
       currentBranch,
+      skills,
     }),
     [
       effectiveModel,
@@ -306,6 +310,7 @@ export function ChatProvider({
       sessionId,
       projectPath,
       currentBranch,
+      skills,
     ],
   );
 

--- a/packages/tui/components/approval-panel.tsx
+++ b/packages/tui/components/approval-panel.tsx
@@ -38,6 +38,18 @@ export function ApprovalPanel({
     if (!toolPart) return null;
     return inferApprovalRule(toolPart, state.workingDirectory);
   }, [toolPart, state.workingDirectory]);
+
+  // For skill tools, look up the actual skill description
+  const effectiveDescription = useMemo(() => {
+    if (toolPart?.type === "tool-skill") {
+      const skillName = String(toolPart.input?.skill ?? "");
+      const skill = state.skills.find((s) => s.name === skillName);
+      if (skill?.description) {
+        return skill.description;
+      }
+    }
+    return toolDescription;
+  }, [toolPart, state.skills, toolDescription]);
   // Determine available options based on whether a rule can be inferred
   const canSaveRule = inferredRule !== null;
 
@@ -156,7 +168,9 @@ export function ApprovalPanel({
       {/* Command and description */}
       <Box flexDirection="column" marginTop={1} marginLeft={2}>
         <Text>{toolCommand}</Text>
-        {toolDescription && <Text color="gray">{toolDescription}</Text>}
+        {effectiveDescription && (
+          <Text color="gray">{effectiveDescription}</Text>
+        )}
       </Box>
 
       {/* Code preview for new files */}

--- a/packages/tui/components/approval-panel.tsx
+++ b/packages/tui/components/approval-panel.tsx
@@ -50,6 +50,7 @@ export function ApprovalPanel({
     }
     return toolDescription;
   }, [toolPart, state.skills, toolDescription]);
+
   // Determine available options based on whether a rule can be inferred
   const canSaveRule = inferredRule !== null;
 

--- a/packages/tui/components/approval-panel.tsx
+++ b/packages/tui/components/approval-panel.tsx
@@ -43,7 +43,9 @@ export function ApprovalPanel({
   const effectiveDescription = useMemo(() => {
     if (toolPart?.type === "tool-skill") {
       const skillName = String(toolPart.input?.skill ?? "");
-      const skill = state.skills.find((s) => s.name === skillName);
+      const skill = state.skills.find(
+        (s) => s.name.toLowerCase() === skillName.toLowerCase(),
+      );
       if (skill?.description) {
         return skill.description;
       }

--- a/packages/tui/components/input-box.tsx
+++ b/packages/tui/components/input-box.tsx
@@ -17,6 +17,7 @@ import {
   getCommandAction,
   type SlashCommandAction,
 } from "../lib/slash-commands";
+import { useChatContext } from "../chat-context";
 import {
   countLines,
   createPasteToken,
@@ -125,6 +126,8 @@ export const InputBox = memo(function InputBox({
   contextLimit = 0,
   pasteCollapseLineThreshold = 5,
 }: InputBoxProps) {
+  const { state } = useChatContext();
+  const skills = state.skills;
   const [value, setValue] = useState("");
   const [cursorPosition, setCursorPosition] = useState(0);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
@@ -219,7 +222,7 @@ export const InputBox = memo(function InputBox({
     if (command) {
       setCommandInfo(command);
       setMentionInfo(null);
-      setSuggestions(getCommandSuggestions(command.partialCommand));
+      setSuggestions(getCommandSuggestions(command.partialCommand, skills));
       setSelectedIndex(0);
       return;
     }
@@ -254,7 +257,7 @@ export const InputBox = memo(function InputBox({
         clearTimeout(debounceRef.current);
       }
     };
-  }, [value, cursorPosition]);
+  }, [value, cursorPosition, skills]);
 
   const pasteBlocksByToken = useMemo(() => {
     return new Map(pasteBlocks.map((block) => [block.token, block]));
@@ -382,15 +385,26 @@ export const InputBox = memo(function InputBox({
 
     // Handle slash command selection
     if (commandInfo) {
-      const action = getCommandAction(selected.value);
-      if (action && onCommandSelect) {
-        // Clear input and close suggestions
+      const action = getCommandAction(selected.value, skills);
+      if (action) {
+        // Handle skill selection by autocompleting (not submitting)
+        if (typeof action === "object" && action.type === "invoke-skill") {
+          const newValue = `/${action.skillName} `;
+          updateValue(newValue);
+          setCursorPosition(newValue.length);
+          setSuggestions([]);
+          setCommandInfo(null);
+          return true;
+        }
+
+        // Handle built-in command actions (execute immediately)
         updateValue("");
         setCursorPosition(0);
         setSuggestions([]);
         setCommandInfo(null);
-        // Execute the command action
-        onCommandSelect(action);
+        if (onCommandSelect) {
+          onCommandSelect(action);
+        }
         return true;
       }
       return false;
@@ -423,6 +437,7 @@ export const InputBox = memo(function InputBox({
     cursorPosition,
     updateValue,
     onCommandSelect,
+    skills,
   ]);
 
   const handleTab = useCallback(() => {

--- a/packages/tui/components/suggestions.tsx
+++ b/packages/tui/components/suggestions.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from "react";
-import { Box, Text } from "ink";
+import { Box, Text, useStdout } from "ink";
 
 export type Suggestion = {
   value: string;
@@ -39,12 +39,24 @@ function calculateWindow(
   };
 }
 
+function truncateDescription(description: string, maxWidth: number): string {
+  if (description.length <= maxWidth) {
+    return description;
+  }
+  if (maxWidth <= 3) {
+    return description.slice(0, maxWidth);
+  }
+  return description.slice(0, maxWidth - 3) + "...";
+}
+
 export const Suggestions = memo(function Suggestions({
   suggestions,
   selectedIndex,
   visible,
 }: SuggestionsProps) {
   const maxDisplay = 10;
+  const { stdout } = useStdout();
+  const terminalWidth = stdout?.columns ?? 80;
 
   // Calculate window based on selected index (must be called before early return)
   const { windowStart, windowEnd } = useMemo(
@@ -68,6 +80,10 @@ export const Suggestions = memo(function Suggestions({
   );
   const columnWidth = maxDisplayWidth + 4; // Add padding between columns
 
+  // Calculate available width for description
+  // Account for: paddingLeft (1) + columnWidth + some margin
+  const descriptionMaxWidth = terminalWidth - columnWidth - 4;
+
   return (
     <Box flexDirection="column" paddingLeft={1} marginTop={1} marginBottom={1}>
       {/* Scroll indicator: items above */}
@@ -81,6 +97,9 @@ export const Suggestions = memo(function Suggestions({
         // Map display index back to actual suggestion index
         const actualIndex = windowStart + displayIndex;
         const isSelected = actualIndex === selectedIndex;
+        const truncatedDescription = suggestion.description
+          ? truncateDescription(suggestion.description, descriptionMaxWidth)
+          : undefined;
 
         return (
           <Box key={suggestion.value}>
@@ -92,9 +111,9 @@ export const Suggestions = memo(function Suggestions({
             >
               {suggestion.display.padEnd(columnWidth)}
             </Text>
-            {suggestion.description && (
+            {truncatedDescription && (
               <Text color={isSelected ? "yellow" : "gray"}>
-                {suggestion.description}
+                {truncatedDescription}
               </Text>
             )}
           </Box>

--- a/packages/tui/components/tool-renderers/default-renderer.tsx
+++ b/packages/tui/components/tool-renderers/default-renderer.tsx
@@ -22,7 +22,7 @@ export function DefaultRenderer({
   return (
     <ToolLayout
       name={name}
-      summary={JSON.stringify(part.input).slice(0, 40)}
+      summary={part.input ? JSON.stringify(part.input).slice(0, 40) : "..."}
       output={
         part.state === "output-available" && <Text color="white">Done</Text>
       }

--- a/packages/tui/lib/approval.ts
+++ b/packages/tui/lib/approval.ts
@@ -148,6 +148,17 @@ export function getToolApprovalInfo(
       };
     }
 
+    case "tool-skill": {
+      const skillName = String(part.input?.skill ?? "");
+      return {
+        toolType: `Use skill "${skillName}"`,
+        toolCommand: skillName,
+        toolDescription:
+          "Claude may use instructions, code, or files from this skill.",
+        dontAskAgainPattern: `${skillName} skill`,
+      };
+    }
+
     default: {
       const toolName = getToolName(part);
       return {
@@ -242,6 +253,17 @@ export function inferApprovalRule(
         type: "path-glob",
         tool: "grep",
         glob: getPathGlob(searchPath, cwd),
+      };
+    }
+
+    case "tool-skill": {
+      const skillName = String(part.input?.skill ?? "");
+      if (!skillName) return null;
+
+      return {
+        type: "skill",
+        tool: "skill",
+        skillName,
       };
     }
 

--- a/packages/tui/lib/render-tool.tsx
+++ b/packages/tui/lib/render-tool.tsx
@@ -91,6 +91,8 @@ export function renderToolPart(
           isExpanded={isExpanded}
         />
       );
+    case "tool-skill":
+      return <DefaultRenderer part={part} state={state} />;
     case "dynamic-tool":
       return <DefaultRenderer part={part} state={state} />;
   }

--- a/packages/tui/lib/slash-commands.ts
+++ b/packages/tui/lib/slash-commands.ts
@@ -1,9 +1,11 @@
+import type { SkillMetadata } from "@open-harness/agent";
 import type { Suggestion } from "../components/suggestions";
 
 export type SlashCommandAction =
   | "open-model-select"
   | "open-resume"
-  | "new-chat";
+  | "new-chat"
+  | { type: "invoke-skill"; skillName: string };
 
 export type SlashCommand = {
   name: string;
@@ -60,27 +62,71 @@ export function extractSlashCommand(
 
 /**
  * Get command suggestions matching a partial command.
+ * Merges built-in commands with user-invocable skills, sorted alphabetically.
  */
-export function getCommandSuggestions(partialCommand: string): Suggestion[] {
+export function getCommandSuggestions(
+  partialCommand: string,
+  skills: SkillMetadata[] = [],
+): Suggestion[] {
   const query = partialCommand.toLowerCase();
 
-  return slashCommands
+  // Filter built-in commands
+  const commandSuggestions = slashCommands
     .filter((cmd) => cmd.name.toLowerCase().includes(query))
     .map((cmd) => ({
       value: cmd.name,
       display: `/${cmd.name}`,
       description: cmd.description,
     }));
+
+  // Filter user-invocable skills
+  const skillSuggestions = skills
+    .filter((skill) => skill.options.userInvocable !== false)
+    .filter((skill) => skill.name.toLowerCase().includes(query))
+    .map((skill) => {
+      const maxLen = 50;
+      const truncated =
+        skill.description.length > maxLen
+          ? skill.description.slice(0, maxLen - 1) + "…"
+          : skill.description;
+      return {
+        value: skill.name,
+        display: `/${skill.name}`,
+        description: `(skill) ${truncated}`,
+      };
+    });
+
+  // Merge and sort alphabetically by value
+  return [...commandSuggestions, ...skillSuggestions].sort((a, b) =>
+    a.value.localeCompare(b.value),
+  );
 }
 
 /**
  * Get the command action for a given command name.
+ * Checks built-in commands first, then falls back to skills.
  */
 export function getCommandAction(
   commandName: string,
+  skills: SkillMetadata[] = [],
 ): SlashCommandAction | null {
+  // Check built-in commands first
   const command = slashCommands.find(
     (cmd) => cmd.name.toLowerCase() === commandName.toLowerCase(),
   );
-  return command?.action ?? null;
+  if (command) {
+    return command.action;
+  }
+
+  // Check skills
+  const skill = skills.find(
+    (s) =>
+      s.name.toLowerCase() === commandName.toLowerCase() &&
+      s.options.userInvocable !== false,
+  );
+  if (skill) {
+    return { type: "invoke-skill", skillName: skill.name };
+  }
+
+  return null;
 }

--- a/packages/tui/lib/slash-commands.ts
+++ b/packages/tui/lib/slash-commands.ts
@@ -90,7 +90,7 @@ export function getCommandSuggestions(
     }));
 
   // Merge and sort alphabetically by value
-  return [...commandSuggestions, ...skillSuggestions].sort((a, b) =>
+  return [...commandSuggestions, ...skillSuggestions].toSorted((a, b) =>
     a.value.localeCompare(b.value),
   );
 }

--- a/packages/tui/lib/slash-commands.ts
+++ b/packages/tui/lib/slash-commands.ts
@@ -83,18 +83,11 @@ export function getCommandSuggestions(
   const skillSuggestions = skills
     .filter((skill) => skill.options.userInvocable !== false)
     .filter((skill) => skill.name.toLowerCase().includes(query))
-    .map((skill) => {
-      const maxLen = 50;
-      const truncated =
-        skill.description.length > maxLen
-          ? skill.description.slice(0, maxLen - 1) + "…"
-          : skill.description;
-      return {
-        value: skill.name,
-        display: `/${skill.name}`,
-        description: `(skill) ${truncated}`,
-      };
-    });
+    .map((skill) => ({
+      value: skill.name,
+      display: `/${skill.name}`,
+      description: skill.description,
+    }));
 
   // Merge and sort alphabetically by value
   return [...commandSuggestions, ...skillSuggestions].sort((a, b) =>


### PR DESCRIPTION
Implement a complete skill system allowing the agent to discover, manage, and invoke custom skills from `.claude` and `.agents` directories.

- **Skill Discovery**: Scan project and user directories for `SKILL.md` files with YAML frontmatter containing name, description, and options
- **Skill Tool**: New `skill` tool enables the agent to invoke discovered skills with optional arguments, substituting `$ARGUMENTS` placeholders
- **System Prompt Integration**: Automatically list available model-invocable skills in system prompt; filter user-invocable skills for slash command UI
- **CLI & Web Support**: Integrated skill discovery in both CLI (scanning `~/.claude` and project directories) and web API (project-only scanning)
- **Approval Rules**: Added skill-specific approval rules to support auto-approval of trusted skills
- **Documentation**: Added lessons learned about directory scan order and skill invocation filtering