### PR TITLE
Improve user message styling with better contrast

### DIFF
--- a/packages/tui/app.tsx
+++ b/packages/tui/app.tsx
@@ -215,10 +215,13 @@ const UserMessage = memo(function UserMessage({
   return (
     <Box flexDirection="column" marginTop={1} marginBottom={1}>
       {imageCount > 0 && (
-        <Box>
-          <Text color="magenta" bold>
-            &gt;{" "}
-          </Text>
+        <Box
+          backgroundColor="#333333"
+          paddingLeft={1}
+          paddingRight={1}
+          alignSelf="flex-start"
+        >
+          <Text color="#666666">❯ </Text>
           <Text color="blue">
             {imageCount === 1
               ? "[1 image attached]"
@@ -227,10 +230,13 @@ const UserMessage = memo(function UserMessage({
         </Box>
       )}
       {text && (
-        <Box>
-          <Text color="magenta" bold>
-            &gt;{" "}
-          </Text>
+        <Box
+          backgroundColor="#333333"
+          paddingLeft={1}
+          paddingRight={1}
+          alignSelf="flex-start"
+        >
+          <Text color="#666666">❯ </Text>
           <Text color="white" bold>
             {text}
           </Text>


### PR DESCRIPTION
Updates the UserMessage component styling to enhance visual hierarchy and readability.

- Replace magenta `>` prefix with gray `❯` character for better visual consistency
- Add dark background container with padding to make message prefixes stand out
- Use absolute colors (#333333, #666666) instead of terminal color names for improved rendering
- Apply to both image count and text message blocks for uniform styling