### PR TITLE
Auto-extend sandbox timeout when time runs low

### DIFF
--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -40,7 +40,10 @@ import { useScrollToBottom } from "@/hooks/use-scroll-to-bottom";
 import { useImageAttachments } from "@/hooks/use-image-attachments";
 import { useAudioRecording } from "@/hooks/use-audio-recording";
 import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
-import { DEFAULT_SANDBOX_TIMEOUT_MS } from "@/lib/sandbox/config";
+import {
+  DEFAULT_SANDBOX_TIMEOUT_MS,
+  AUTO_EXTEND_THRESHOLD_MS,
+} from "@/lib/sandbox/config";
 import type { WebAgentUIToolPart, WebAgentUIMessagePart } from "@/app/types";
 import type { TaskToolUIPart, AskUserQuestionInput } from "@open-harness/agent";
 
@@ -136,8 +139,6 @@ function useSandboxTimeRemaining(sandboxInfo: SandboxInfo | null) {
 
   return timeRemaining;
 }
-
-const WARNING_THRESHOLD_MS = 60_000; // Show warning when < 1 minute remaining
 
 function formatTokens(tokens: number): string {
   if (tokens >= 1000) {
@@ -266,11 +267,23 @@ function SandboxHeaderBadge({
   const [isHovered, setIsHovered] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
   const hasAutoSavedRef = useRef(false);
+  const hasAutoExtendedRef = useRef(false);
 
   // Reset auto-save flag when sandbox changes
   useEffect(() => {
     hasAutoSavedRef.current = false;
   }, [sandboxInfo]);
+
+  // Reset auto-extend flag when sandbox changes or time goes back up (after successful extend)
+  useEffect(() => {
+    if (
+      !sandboxInfo ||
+      timeRemaining === null ||
+      timeRemaining > AUTO_EXTEND_THRESHOLD_MS
+    ) {
+      hasAutoExtendedRef.current = false;
+    }
+  }, [sandboxInfo, timeRemaining]);
 
   // Reset stopping state when sandbox becomes inactive
   useEffect(() => {
@@ -292,6 +305,38 @@ function SandboxHeaderBadge({
       onSaveAndKill();
     }
   }, [timeRemaining, isSavingSnapshot, onSaveAndKill]);
+
+  // Auto-extend when window is visible and time is low
+  useEffect(() => {
+    const tryAutoExtend = () => {
+      if (
+        timeRemaining !== null &&
+        timeRemaining > 0 &&
+        timeRemaining <= AUTO_EXTEND_THRESHOLD_MS &&
+        !hasAutoExtendedRef.current &&
+        !isExtending &&
+        document.visibilityState === "visible"
+      ) {
+        hasAutoExtendedRef.current = true;
+        onExtend();
+      }
+    };
+
+    // Check immediately
+    tryAutoExtend();
+
+    // Also check when visibility changes (user returns to tab)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        tryAutoExtend();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [timeRemaining, isExtending, onExtend]);
 
   const handleStop = () => {
     setIsStopping(true);
@@ -377,45 +422,7 @@ function SandboxHeaderBadge({
   // (we returned early for null timeout above, and the inactive check handles null/0 timeRemaining)
   if (timeRemaining === null) return null;
 
-  const isWarning = timeRemaining < WARNING_THRESHOLD_MS;
-  const secondsRemaining = Math.ceil(timeRemaining / 1000);
-
-  // Warning state - show message with extend and close buttons
-  if (isWarning) {
-    return (
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-orange-500">
-          Pausing in {secondsRemaining}s
-        </span>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onExtend}
-          disabled={isExtending}
-          className="h-6 px-2 text-xs"
-        >
-          {isExtending ? <Loader2 className="size-3 animate-spin" /> : "Extend"}
-        </Button>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={handleStop}
-              disabled={isSavingSnapshot}
-              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
-            >
-              <X className="size-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={8}>
-            Save and pause
-          </TooltipContent>
-        </Tooltip>
-      </div>
-    );
-  }
-
-  // Active - show green dot with X on hover
+  // Active - show green dot with X on hover (no countdown displayed, auto-extend handles it)
   return (
     <div
       className="flex items-center gap-1"
@@ -424,11 +431,8 @@ function SandboxHeaderBadge({
     >
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex items-center gap-1 p-1">
+          <div className="flex items-center p-1">
             <span className="size-2.5 rounded-full bg-green-500" />
-            <span className="text-xs text-muted-foreground">
-              {secondsRemaining}s
-            </span>
           </div>
         </TooltipTrigger>
         <TooltipContent side="bottom" sideOffset={8}>

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -261,13 +261,15 @@ function SandboxHeaderBadge({
   isRestoring: boolean;
   isExtending: boolean;
   timeRemaining: number | null;
-  onExtend: () => void;
+  onExtend: () => Promise<boolean>;
   onSaveAndKill: () => void;
 }) {
   const [isHovered, setIsHovered] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
   const hasAutoSavedRef = useRef(false);
   const hasAutoExtendedRef = useRef(false);
+  const autoExtendRetryCountRef = useRef(0);
+  const MAX_AUTO_EXTEND_RETRIES = 3;
 
   // Reset auto-save flag when sandbox changes
   useEffect(() => {
@@ -282,6 +284,7 @@ function SandboxHeaderBadge({
       timeRemaining > AUTO_EXTEND_THRESHOLD_MS
     ) {
       hasAutoExtendedRef.current = false;
+      autoExtendRetryCountRef.current = 0;
     }
   }, [sandboxInfo, timeRemaining]);
 
@@ -308,7 +311,7 @@ function SandboxHeaderBadge({
 
   // Auto-extend when window is visible and time is low
   useEffect(() => {
-    const tryAutoExtend = () => {
+    const tryAutoExtend = async () => {
       if (
         timeRemaining !== null &&
         timeRemaining > 0 &&
@@ -318,7 +321,14 @@ function SandboxHeaderBadge({
         document.visibilityState === "visible"
       ) {
         hasAutoExtendedRef.current = true;
-        onExtend();
+        const success = await onExtend();
+        // Allow retry on failure, up to max retries
+        if (!success) {
+          autoExtendRetryCountRef.current += 1;
+          if (autoExtendRetryCountRef.current < MAX_AUTO_EXTEND_RETRIES) {
+            hasAutoExtendedRef.current = false;
+          }
+        }
       }
     };
 
@@ -744,8 +754,8 @@ export function TaskDetailContent() {
     saveSnapshot,
   ]);
 
-  const handleExtendSandbox = useCallback(async () => {
-    if (!sandboxInfo) return;
+  const handleExtendSandbox = useCallback(async (): Promise<boolean> => {
+    if (!sandboxInfo) return false;
     setIsExtendingSandbox(true);
     try {
       const response = await fetch("/api/sandbox/extend", {
@@ -759,7 +769,7 @@ export function TaskDetailContent() {
       if (!response.ok) {
         const error = (await response.json()) as { error?: string };
         console.error("Failed to extend sandbox:", error.error);
-        return;
+        return false;
       }
 
       const data = (await response.json()) as {
@@ -775,12 +785,14 @@ export function TaskDetailContent() {
         createdAt: now,
         timeout: data.expiresAt - now,
       });
+      return true;
     } catch (err) {
       console.error("Failed to extend sandbox:", err);
+      return false;
     } finally {
       setIsExtendingSandbox(false);
     }
-  }, [sandboxInfo, task.id, setSandboxInfo, setIsExtendingSandbox]);
+  }, [sandboxInfo, task.id, setSandboxInfo]);
 
   const [restoreError, setRestoreError] = useState<string | null>(null);
   const isSavingSnapshotRef = useRef(false);

--- a/apps/web/app/tasks/[id]/task-detail-content.tsx
+++ b/apps/web/app/tasks/[id]/task-detail-content.tsx
@@ -744,7 +744,7 @@ export function TaskDetailContent() {
     saveSnapshot,
   ]);
 
-  const handleExtendSandbox = async () => {
+  const handleExtendSandbox = useCallback(async () => {
     if (!sandboxInfo) return;
     setIsExtendingSandbox(true);
     try {
@@ -780,7 +780,7 @@ export function TaskDetailContent() {
     } finally {
       setIsExtendingSandbox(false);
     }
-  };
+  }, [sandboxInfo, task.id, setSandboxInfo, setIsExtendingSandbox]);
 
   const [restoreError, setRestoreError] = useState<string | null>(null);
   const isSavingSnapshotRef = useRef(false);

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -8,3 +8,6 @@ export const DEFAULT_SANDBOX_TIMEOUT_MS = 300_000;
 
 /** Duration to extend timeout by when user requests more time (5 minutes) */
 export const EXTEND_TIMEOUT_DURATION_MS = 300_000;
+
+/** Threshold for auto-extending sandbox when window is focused (60 seconds before expiry) */
+export const AUTO_EXTEND_THRESHOLD_MS = 60_000;


### PR DESCRIPTION
Automatically extends the sandbox session when time remaining drops below 60 seconds and the window is visible, eliminating the need for manual extension.

- Added `AUTO_EXTEND_THRESHOLD_MS` constant to `sandbox/config.ts` for the auto-extend trigger point
- Implemented auto-extend logic that triggers when time is low, window is focused, and hasn't already extended for current timeout
- Removed the countdown warning UI and associated `WARNING_THRESHOLD_MS` constant in favor of silent auto-extension
- Simplified the sandbox badge to show only the green status indicator without the countdown timer