### PR TITLE
Add --dangerously-skip-all flag to auto-accept tool calls

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -45,9 +45,16 @@ function printHelp() {
   console.log("  deep-agent [options] <prompt>     Run a one-shot prompt");
   console.log("");
   console.log("Options:");
-  console.log("  --sandbox=<type>  Sandbox to use: local (default), vercel");
-  console.log("  --repo=<repo>     GitHub repo to clone (e.g., vercel/ai)");
-  console.log("  --help, -h        Show this help message");
+  console.log(
+    "  --sandbox=<type>        Sandbox to use: local (default), vercel",
+  );
+  console.log(
+    "  --repo=<repo>           GitHub repo to clone (e.g., vercel/ai)",
+  );
+  console.log(
+    "  --dangerously-skip-all  Auto-accept all tool calls (YOLO mode)",
+  );
+  console.log("  --help, -h              Show this help message");
   console.log("");
   console.log("Environment variables (for --sandbox=vercel):");
   console.log("  GITHUB_TOKEN        GitHub PAT for private repos (optional)");
@@ -72,17 +79,21 @@ interface ParsedArgs {
   repo?: string;
   initialPrompt?: string;
   showHelp: boolean;
+  dangerouslySkipAll: boolean;
 }
 
 function parseArgs(args: string[]): ParsedArgs {
   let sandboxType: SandboxType = "local";
   let repo: string | undefined;
   let showHelp = false;
+  let dangerouslySkipAll = false;
   const promptParts: string[] = [];
 
   for (const arg of args) {
     if (arg === "--help" || arg === "-h") {
       showHelp = true;
+    } else if (arg === "--dangerously-skip-all") {
+      dangerouslySkipAll = true;
     } else if (arg.startsWith("--sandbox=")) {
       const value = arg.slice("--sandbox=".length);
       sandboxType = parseSandboxType(value);
@@ -101,6 +112,7 @@ function parseArgs(args: string[]): ParsedArgs {
     repo,
     initialPrompt: promptParts.length > 0 ? promptParts.join(" ") : undefined,
     showHelp,
+    dangerouslySkipAll,
   };
 }
 
@@ -211,8 +223,10 @@ async function main() {
       initialSettings: settings,
       onSettingsChange: handleSettingsChange,
       availableModels,
-      // Auto-accept all tools in sandbox mode since it's an isolated environment
-      ...(isRemoteSandbox && { initialAutoAcceptMode: "all" }),
+      // Auto-accept all tools in sandbox mode or when --dangerously-skip-all is set
+      ...((isRemoteSandbox || parsed.dangerouslySkipAll) && {
+        initialAutoAcceptMode: "all" as const,
+      }),
     });
   } catch (error) {
     // Ignore abort errors from ESC key interrupts


### PR DESCRIPTION
Adds a new CLI flag `--dangerously-skip-all` that enables auto-accepting all tool calls in local sandbox mode, previously only available for remote sandboxes.

- New `--dangerously-skip-all` flag parses and enables "YOLO mode" for tool execution
- Updated help text with aligned formatting and new flag documentation
- Extends auto-accept logic to trigger for either remote sandbox or explicit flag
- Maintains existing behavior for remote sandboxes while offering opt-in local control