### PR TITLE
Add model to experimental context and normalize imports

### DIFF
--- a/packages/agent/deep-agent.ts
+++ b/packages/agent/deep-agent.ts
@@ -1,30 +1,30 @@
+import type { Sandbox } from "@open-harness/sandbox";
 import {
-  ToolLoopAgent,
-  stepCountIs,
+  gateway,
   type LanguageModel,
+  stepCountIs,
+  ToolLoopAgent,
   type ToolSet,
   type TypedToolResult,
-  gateway,
 } from "ai";
 import { z } from "zod";
-import {
-  todoWriteTool,
-  readFileTool,
-  writeFileTool,
-  editFileTool,
-  grepTool,
-  globTool,
-  bashTool,
-  taskTool,
-  askUserQuestionTool,
-  skillTool,
-} from "./tools";
+import { addCacheControl, compactContext } from "./context-management";
 import type { SkillMetadata } from "./skills/types";
 import { buildSystemPrompt } from "./system-prompt";
-import type { TodoItem, ApprovalConfig } from "./types";
+import {
+  askUserQuestionTool,
+  bashTool,
+  editFileTool,
+  globTool,
+  grepTool,
+  readFileTool,
+  skillTool,
+  taskTool,
+  todoWriteTool,
+  writeFileTool,
+} from "./tools";
+import type { ApprovalConfig, TodoItem } from "./types";
 import { approvalRuleSchema } from "./types";
-import { addCacheControl, compactContext } from "./context-management";
-import type { Sandbox } from "@open-harness/sandbox";
 
 const approvalConfigSchema = z.discriminatedUnion("type", [
   z.object({
@@ -106,7 +106,7 @@ export const deepAgent = new ToolLoopAgent({
         model: callModel,
       }),
       instructions,
-      experimental_context: { sandbox, approval, skills },
+      experimental_context: { sandbox, approval, skills, model: callModel },
     };
   },
 });

--- a/packages/agent/subagents/executor.ts
+++ b/packages/agent/subagents/executor.ts
@@ -1,11 +1,12 @@
-import { ToolLoopAgent, stepCountIs } from "ai";
-import { z } from "zod";
-import { readFileTool } from "../tools/read";
-import { writeFileTool, editFileTool } from "../tools/write";
-import { grepTool } from "../tools/grep";
-import { globTool } from "../tools/glob";
-import { bashTool } from "../tools/bash";
 import type { Sandbox } from "@open-harness/sandbox";
+import type { LanguageModel } from "ai";
+import { gateway, stepCountIs, ToolLoopAgent } from "ai";
+import { z } from "zod";
+import { bashTool } from "../tools/bash";
+import { globTool } from "../tools/glob";
+import { grepTool } from "../tools/grep";
+import { readFileTool } from "../tools/read";
+import { editFileTool, writeFileTool } from "../tools/write";
 
 const EXECUTOR_SYSTEM_PROMPT = `You are an executor agent - a fire-and-forget subagent that completes specific, well-defined implementation tasks autonomously.
 
@@ -49,12 +50,13 @@ const callOptionsSchema = z.object({
   sandbox: z
     .custom<Sandbox>()
     .describe("Sandbox for file system and shell operations"),
+  model: z.custom<LanguageModel>().describe("Language model for this subagent"),
 });
 
 export type ExecutorCallOptions = z.infer<typeof callOptionsSchema>;
 
 export const executorSubagent = new ToolLoopAgent({
-  model: "anthropic/claude-haiku-4.5",
+  model: gateway("anthropic/claude-haiku-4.5"),
   instructions: EXECUTOR_SYSTEM_PROMPT,
   tools: {
     // All tools auto-approve in delegated mode (set via prepareCall)
@@ -69,8 +71,10 @@ export const executorSubagent = new ToolLoopAgent({
   callOptionsSchema,
   prepareCall: ({ options, ...settings }) => {
     const sandbox = options.sandbox;
+    const model = options.model ?? settings.model;
     return {
       ...settings,
+      model,
       instructions: `${EXECUTOR_SYSTEM_PROMPT}
 
 Working directory: ${sandbox.workingDirectory}
@@ -88,6 +92,7 @@ ${options.instructions}
       experimental_context: {
         sandbox,
         approval: { type: "delegated" },
+        model,
       },
     };
   },

--- a/packages/agent/subagents/explorer.ts
+++ b/packages/agent/subagents/explorer.ts
@@ -1,10 +1,11 @@
-import { ToolLoopAgent, stepCountIs } from "ai";
-import { z } from "zod";
-import { readFileTool } from "../tools/read";
-import { grepTool } from "../tools/grep";
-import { globTool } from "../tools/glob";
-import { bashTool } from "../tools/bash";
 import type { Sandbox } from "@open-harness/sandbox";
+import type { LanguageModel } from "ai";
+import { gateway, stepCountIs, ToolLoopAgent } from "ai";
+import { z } from "zod";
+import { bashTool } from "../tools/bash";
+import { globTool } from "../tools/glob";
+import { grepTool } from "../tools/grep";
+import { readFileTool } from "../tools/read";
 
 const EXPLORER_SYSTEM_PROMPT = `You are an explorer agent - a fast, read-only subagent specialized for exploring codebases.
 
@@ -62,12 +63,13 @@ const callOptionsSchema = z.object({
   sandbox: z
     .custom<Sandbox>()
     .describe("Sandbox for file system and shell operations"),
+  model: z.custom<LanguageModel>().describe("Language model for this subagent"),
 });
 
 export type ExplorerCallOptions = z.infer<typeof callOptionsSchema>;
 
 export const explorerSubagent = new ToolLoopAgent({
-  model: "anthropic/claude-haiku-4.5",
+  model: gateway("anthropic/claude-haiku-4.5"),
   instructions: EXPLORER_SYSTEM_PROMPT,
   tools: {
     // All tools auto-approve in delegated mode (set via prepareCall)
@@ -80,8 +82,10 @@ export const explorerSubagent = new ToolLoopAgent({
   callOptionsSchema,
   prepareCall: ({ options, ...settings }) => {
     const sandbox = options.sandbox;
+    const model = options.model ?? settings.model;
     return {
       ...settings,
+      model,
       instructions: `${EXPLORER_SYSTEM_PROMPT}
 
 Working directory: ${sandbox.workingDirectory}
@@ -99,6 +103,7 @@ ${options.instructions}
       experimental_context: {
         sandbox,
         approval: { type: "delegated" },
+        model,
       },
     };
   },

--- a/packages/agent/system-prompt.ts
+++ b/packages/agent/system-prompt.ts
@@ -161,7 +161,7 @@ Prefer structured questions over open-ended chat when you need specific decision
 
 - Be concise and direct
 - No emojis, minimal exclamation points
-- Link to files when mentioning them using \`file://\` URLs
+- Link to files when mentioning them using repo-relative paths (no \`file://\` prefix)
 - After completing work, summarize: what changed, verification results, next action if any`;
 
 const BACKGROUND_MODE_INSTRUCTIONS = `# Background Mode - Ephemeral Sandbox

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -1,15 +1,20 @@
 import {
-  tool,
-  readUIMessageStream,
-  type UIToolInvocation,
   type LanguageModelUsage,
+  readUIMessageStream,
+  tool,
+  type UIToolInvocation,
 } from "ai";
 import { z } from "zod";
-import { explorerSubagent } from "../subagents/explorer";
 import { executorSubagent } from "../subagents/executor";
+import { explorerSubagent } from "../subagents/explorer";
 import type { SubagentUIMessage } from "../subagents/types";
-import { getSandbox, getApprovalContext, shouldAutoApprove } from "./utils";
 import type { ApprovalRule } from "../types";
+import {
+  getApprovalContext,
+  getModel,
+  getSandbox,
+  shouldAutoApprove,
+} from "./utils";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
 
@@ -126,6 +131,7 @@ NOTE: The executor subagent requires user approval before running because it has
     { experimental_context, abortSignal },
   ) {
     const sandbox = getSandbox(experimental_context, "task");
+    const model = getModel(experimental_context, "task");
 
     const subagent =
       subagentType === "explorer" ? explorerSubagent : executorSubagent;
@@ -133,7 +139,7 @@ NOTE: The executor subagent requires user approval before running because it has
     const result = await subagent.stream({
       prompt:
         "Complete this task and provide a summary of what you accomplished.",
-      options: { task, instructions, sandbox },
+      options: { task, instructions, sandbox, model },
       abortSignal,
     });
 

--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -1,7 +1,17 @@
+import type { Sandbox } from "@open-harness/sandbox";
+import type { LanguageModel, ModelMessage } from "ai";
 import * as path from "path";
 import type { AgentContext, ApprovalConfig, ApprovalRule } from "../types";
-import type { Sandbox } from "@open-harness/sandbox";
-import type { ModelMessage } from "ai";
+
+function isAgentContext(value: unknown): value is AgentContext {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "sandbox" in value &&
+    "approval" in value &&
+    "model" in value
+  );
+}
 
 /**
  * Check if a file path is within a given directory.
@@ -36,7 +46,9 @@ export function getSandbox(
   experimental_context: unknown,
   toolName?: string,
 ): Sandbox {
-  const context = experimental_context as AgentContext | undefined;
+  const context = isAgentContext(experimental_context)
+    ? experimental_context
+    : undefined;
   if (!context?.sandbox) {
     const toolInfo = toolName ? ` (tool: ${toolName})` : "";
     const contextInfo = context
@@ -81,7 +93,9 @@ export function getApprovalContext(
   workingDirectory: string;
   approval: ApprovalConfig;
 } {
-  const context = experimental_context as AgentContext | undefined;
+  const context = isAgentContext(experimental_context)
+    ? experimental_context
+    : undefined;
   if (!context?.sandbox) {
     const toolInfo = toolName ? ` (tool: ${toolName})` : "";
     const contextInfo = context
@@ -105,6 +119,30 @@ export function getApprovalContext(
     workingDirectory: context.sandbox.workingDirectory,
     approval: context.approval ?? defaultApproval,
   };
+}
+
+/**
+ * Get model from experimental context with null safety.
+ * Throws a descriptive error if model is not initialized.
+ */
+export function getModel(
+  experimental_context: unknown,
+  toolName?: string,
+): LanguageModel {
+  const context = isAgentContext(experimental_context)
+    ? experimental_context
+    : undefined;
+  if (!context?.model) {
+    const toolInfo = toolName ? ` (tool: ${toolName})` : "";
+    const contextInfo = context
+      ? `Context exists but model is missing. Context keys: ${Object.keys(context).join(", ")}`
+      : "Context is undefined or null";
+    throw new Error(
+      `Model not initialized in context${toolInfo}. ${contextInfo}. ` +
+        "Ensure the agent's prepareCall sets experimental_context: { model, ... }",
+    );
+  }
+  return context.model;
 }
 
 /**

--- a/packages/agent/types.ts
+++ b/packages/agent/types.ts
@@ -1,5 +1,6 @@
-import { z } from "zod";
 import type { Sandbox } from "@open-harness/sandbox";
+import type { LanguageModel } from "ai";
+import { z } from "zod";
 
 export const todoStatusSchema = z.enum(["pending", "in_progress", "completed"]);
 export type TodoStatus = z.infer<typeof todoStatusSchema>;
@@ -35,6 +36,7 @@ export interface AgentContext {
   sandbox: Sandbox;
   approval: ApprovalConfig;
   skills?: SkillMetadata[];
+  model: LanguageModel;
 }
 
 /**

--- a/packages/tui/components/task-group-view.tsx
+++ b/packages/tui/components/task-group-view.tsx
@@ -225,10 +225,9 @@ function TaskItem({
     nestedStatus = denialReason ? `Denied: ${denialReason}` : "Denied";
   } else if (approvalRequested) {
     nestedStatus = "Awaiting approval...";
-  } else if (
-    status === "pending" ||
-    (status === "running" && toolCount === 0)
-  ) {
+  } else if (status === "pending") {
+    nestedStatus = "Initializing...";
+  } else if (status === "running" && (!lastTool || toolCount === 0)) {
     nestedStatus = "Initializing...";
   } else if (lastTool) {
     nestedStatus = lastTool.summary

--- a/packages/tui/components/task-group-view.tsx
+++ b/packages/tui/components/task-group-view.tsx
@@ -110,11 +110,6 @@ function countTaskTools(part: TaskToolUIPart): number {
 function getTaskTokens(part: TaskToolUIPart): number | null {
   if (part.state !== "output-available") return null;
   const message = part.output;
-  // Use totalMessageUsage when complete, lastStepUsage when still running
-  const isComplete = !part.preliminary;
-  if (isComplete) {
-    return message?.metadata?.totalMessageUsage?.inputTokens ?? null;
-  }
   return message?.metadata?.lastStepUsage?.inputTokens ?? null;
 }
 

--- a/packages/tui/components/task-group-view.tsx
+++ b/packages/tui/components/task-group-view.tsx
@@ -4,8 +4,10 @@ import { TextAttributes } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
 import { getToolName, isToolUIPart } from "ai";
 import React, { useEffect, useRef, useState } from "react";
+import { useChatContext } from "../chat-context";
 import { PRIMARY_COLOR } from "../lib/colors";
 import { truncateText } from "../lib/truncate";
+import { toRelativePath } from "./tool-renderers/shared";
 
 type SubagentMessagePart = SubagentUIMessage["parts"][number];
 
@@ -116,12 +118,14 @@ function getTaskTokens(part: TaskToolUIPart): number | null {
   return message?.metadata?.lastStepUsage?.inputTokens ?? null;
 }
 
-function getToolSummary(part: SubagentMessagePart): string {
+function getToolSummary(part: SubagentMessagePart, cwd: string): string {
   switch (part.type) {
     case "tool-read":
     case "tool-write":
     case "tool-edit":
-      return part.input?.filePath ?? "";
+      return part.input?.filePath
+        ? toRelativePath(part.input.filePath, cwd)
+        : "";
     case "tool-grep":
     case "tool-glob":
       return part.input?.pattern ? `"${part.input.pattern}"` : "";
@@ -135,12 +139,16 @@ function getToolSummary(part: SubagentMessagePart): string {
 
 function getLastToolInfo(
   part: TaskToolUIPart,
+  cwd: string,
 ): { name: string; summary: string } | null {
   if (part.state !== "output-available") return null;
   const message = part.output;
   if (!message?.parts) return null;
 
-  const toolParts = message.parts.filter(isToolUIPart);
+  const toolParts = message.parts.filter(
+    (toolPart) =>
+      isToolUIPart(toolPart) && toolPart.state !== "input-streaming",
+  );
   if (toolParts.length === 0) return null;
 
   const lastTool = toolParts[toolParts.length - 1];
@@ -148,7 +156,7 @@ function getLastToolInfo(
   if (!lastTool || !isToolUIPart(lastTool)) return null;
 
   const toolName = getToolName(lastTool);
-  const summary = getToolSummary(lastTool);
+  const summary = getToolSummary(lastTool, cwd);
 
   const displayName = toolName.charAt(0).toUpperCase() + toolName.slice(1);
   return { name: displayName, summary };
@@ -189,7 +197,9 @@ function TaskItem({
   const elapsedSeconds = useTaskTiming(isRunning);
   const toolCount = countTaskTools(part);
   const tokenCount = getTaskTokens(part);
-  const lastTool = getLastToolInfo(part);
+  const { state: chatState } = useChatContext();
+  const cwd = chatState.workingDirectory ?? process.cwd();
+  const lastTool = getLastToolInfo(part, cwd);
   const { width } = useTerminalDimensions();
   const terminalWidth = width ?? 80;
 

--- a/packages/tui/components/tool-renderers/task-renderer.tsx
+++ b/packages/tui/components/tool-renderers/task-renderer.tsx
@@ -221,8 +221,8 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
           <text fg="gray">└ </text>
           <text fg="white">
             Complete ({toolParts.length} tool calls
-            {message?.metadata?.totalMessageUsage?.inputTokens
-              ? `, ${formatTokens(message.metadata.totalMessageUsage.inputTokens)} tokens`
+            {message?.metadata?.lastStepUsage?.inputTokens
+              ? `, ${formatTokens(message.metadata.lastStepUsage.inputTokens)} tokens`
               : ""}
             )
           </text>

--- a/packages/tui/components/tool-renderers/task-renderer.tsx
+++ b/packages/tui/components/tool-renderers/task-renderer.tsx
@@ -4,19 +4,22 @@ import { TextAttributes } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
 import { getToolName, isTextUIPart, isToolUIPart } from "ai";
 import React from "react";
+import { useChatContext } from "../../chat-context";
 import { PRIMARY_COLOR } from "../../lib/colors";
 import type { ToolRendererProps } from "../../lib/render-tool";
 import { truncateText } from "../../lib/truncate";
-import { ToolSpinner } from "./shared";
+import { ToolSpinner, toRelativePath } from "./shared";
 
 type SubagentMessagePart = SubagentUIMessage["parts"][number];
 
-function getToolSummary(part: SubagentMessagePart): string {
+function getToolSummary(part: SubagentMessagePart, cwd: string): string {
   switch (part.type) {
     case "tool-read":
     case "tool-write":
     case "tool-edit":
-      return part.input?.filePath ?? "";
+      return part.input?.filePath
+        ? toRelativePath(part.input.filePath, cwd)
+        : "";
     case "tool-grep":
     case "tool-glob":
       return part.input?.pattern ? `"${part.input.pattern}"` : "";
@@ -28,13 +31,15 @@ function getToolSummary(part: SubagentMessagePart): string {
 }
 
 function SubagentToolCall({ part }: { part: SubagentMessagePart }) {
+  const { state: chatState } = useChatContext();
+  const cwd = chatState.workingDirectory ?? process.cwd();
   const { width } = useTerminalDimensions();
   if (!isToolUIPart(part)) return null;
+  if (part.state === "input-streaming") return null;
   const toolName = getToolName(part);
-  const isRunning =
-    part.state === "input-streaming" || part.state === "input-available";
+  const isRunning = part.state === "input-available";
   const hasError = part.state === "output-error";
-  const summary = getToolSummary(part);
+  const summary = getToolSummary(part, cwd);
   const terminalWidth = width ?? 80;
 
   const dotColor = isRunning ? PRIMARY_COLOR : hasError ? "red" : "green";
@@ -88,9 +93,11 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
 
   // Get all parts in order, filter to text and tool parts
   const messageParts = message?.parts ?? [];
-  const relevantParts = messageParts.filter(
-    (p) => isToolUIPart(p) || isTextUIPart(p),
-  );
+  const relevantParts = messageParts.filter((p) => {
+    if (isTextUIPart(p)) return true;
+    if (!isToolUIPart(p)) return false;
+    return p.state !== "input-streaming";
+  });
   const toolParts = messageParts.filter(isToolUIPart);
 
   // Show only the last few parts to avoid too much output


### PR DESCRIPTION
This PR adds language model support to the experimental context across agents and subagents, and organizes imports alphabetically for consistency.

- **Model context propagation**: Pass `model` through `experimental_context` in deep agent, executor subagent, and explorer subagent to enable subagents to use the parent agent's language model
- **New `getModel()` utility**: Added type-safe model extraction from context with validation and type guards
- **Type safety improvements**: Added `isAgentContext()` type guard and updated `AgentContext` interface to require `model` field
- **UI refinements**: Fixed file path display to use repo-relative paths instead of `file://` URLs, improved task status display logic, and excluded input-streaming tool parts from rendering