### PR TITLE
Run drizzle push before web build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "drizzle-kit push",
     "build": "next build",
     "start": "next start",
     "lint": "oxlint",

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["POSTGRES_URL"],
       "outputs": ["dist/**"]
     },
     "dev": {


### PR DESCRIPTION
## Summary
- run `drizzle-kit push` as a prebuild hook for the web app
- keep production schema in sync before `next build`