### PR TITLE
Improve CLI release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 1.2.3)"
+        required: true
+        type: string
+      publish_latest:
+        description: "Update latest pointer"
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  build-and-upload:
+    name: Build & Upload (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: darwin-arm64
+            opentui: "@opentui/core-darwin-arm64"
+          - os: macos-13
+            target: darwin-x64
+            opentui: "@opentui/core-darwin-x64"
+          - os: ubuntu-latest
+            target: linux-x64
+            opentui: "@opentui/core-linux-x64"
+          - os: ubuntu-24.04-arm64
+            target: linux-arm64
+            opentui: "@opentui/core-linux-arm64"
+          - os: windows-latest
+            target: windows-x64
+            opentui: "@opentui/core-win32-x64"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.14"
+
+      - name: Install dependencies
+        shell: bash
+        run: bun install
+
+      - name: Install platform OpenTUI package
+        shell: bash
+        run: bun add -D ${{ matrix.opentui }}
+
+      - name: Build release artifact
+        shell: bash
+        run: bun run build:release-artifacts --targets ${{ matrix.target }} --dir dist
+
+      - name: Upload artifact to Blob
+        shell: bash
+        env:
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+        run: bun run upload:release --version ${{ inputs.version }} --dir dist --targets ${{ matrix.target }} --skip-latest
+
+  publish-latest:
+    name: Publish Latest Pointer
+    runs-on: ubuntu-latest
+    needs: build-and-upload
+    if: ${{ inputs.publish_latest }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.14"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Write latest pointer
+        env:
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+        run: bun run upload:release --version ${{ inputs.version }} --only-latest

--- a/README.md
+++ b/README.md
@@ -12,4 +12,14 @@ To run:
 bun run index.ts
 ```
 
+Releasing the CLI:
+
+See `docs/release.md`.
+
+Release checklist (quick):
+
+- Pick a unique version (can be multiple per day)
+- Run the **Release CLI** GitHub Action with that version
+- Verify install: `curl -fsSL https://openharness.dev/install | bash`
+
 This project was created using `bun init` in bun v1.2.23. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/apps/cli/auth/commands.ts
+++ b/apps/cli/auth/commands.ts
@@ -18,7 +18,7 @@ export async function handleLogin(): Promise<void> {
   const existing = await loadCredentials();
   if (existing) {
     console.log(`Already logged in as ${existing.username}`);
-    console.log('Run "open-harness auth logout" to sign out first.');
+    console.log('Run "openharness auth logout" to sign out first.');
     return;
   }
 
@@ -99,7 +99,7 @@ export async function handleStatus(): Promise<void> {
 
   if (!credentials) {
     console.log("Not logged in");
-    console.log('Run "open-harness auth login" to authenticate.');
+    console.log('Run "openharness auth login" to authenticate.');
     return;
   }
 
@@ -139,7 +139,7 @@ export async function handleWhoami(): Promise<void> {
  * Print auth help
  */
 export function printAuthHelp(): void {
-  console.log("Usage: open-harness auth <command>");
+  console.log("Usage: openharness auth <command>");
   console.log("");
   console.log("Commands:");
   console.log("  login   Authenticate with the Open Harness web app");
@@ -148,8 +148,8 @@ export function printAuthHelp(): void {
   console.log("  whoami  Print the current user's username");
   console.log("");
   console.log("Examples:");
-  console.log("  open-harness auth login");
-  console.log("  open-harness auth status");
+  console.log("  openharness auth login");
+  console.log("  openharness auth status");
 }
 
 /**

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -48,9 +48,9 @@ function printHelp() {
   console.log("Open Harness CLI");
   console.log("");
   console.log("Usage:");
-  console.log("  open-harness [options]              Start interactive REPL");
-  console.log("  open-harness [options] <prompt>     Run a one-shot prompt");
-  console.log("  open-harness auth <command>         Authentication commands");
+  console.log("  openharness [options]              Start interactive REPL");
+  console.log("  openharness [options] <prompt>     Run a one-shot prompt");
+  console.log("  openharness auth <command>         Authentication commands");
   console.log("");
   console.log("Options:");
   console.log(
@@ -76,11 +76,11 @@ function printHelp() {
   console.log("  SANDBOX_NEW_BRANCH  New branch to create (optional)");
   console.log("");
   console.log("Examples:");
-  console.log('  open-harness "Explain the structure of this codebase"');
-  console.log("  open-harness --sandbox=vercel");
-  console.log("  open-harness --sandbox=vercel --repo=vercel/ai");
-  console.log('  open-harness --sandbox=vercel --repo=vercel/ai "Fix the bug"');
-  console.log("  open-harness auth login");
+  console.log('  openharness "Explain the structure of this codebase"');
+  console.log("  openharness --sandbox=vercel");
+  console.log("  openharness --sandbox=vercel --repo=vercel/ai");
+  console.log('  openharness --sandbox=vercel --repo=vercel/ai "Fix the bug"');
+  console.log("  openharness auth login");
   console.log("");
   console.log("Keyboard shortcuts:");
   console.log("  esc           Abort current operation / exit");
@@ -157,7 +157,7 @@ async function main() {
 
   if (!credentials) {
     console.log("You must be logged in to use Open Harness.\n");
-    console.log("Run `open-harness auth login` to authenticate.\n");
+    console.log("Run `openharness auth login` to authenticate.\n");
     process.exit(1);
   }
 
@@ -171,7 +171,7 @@ async function main() {
       console.log("Continuing with cached credentials...\n");
     } else {
       console.log(`Authentication failed: ${validation.error}\n`);
-      console.log("Run `open-harness auth login` to re-authenticate.\n");
+      console.log("Run `openharness auth login` to re-authenticate.\n");
       process.exit(1);
     }
   }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "bin": {
-    "open-harness": "./index.ts"
+    "openharness": "./index.ts"
   },
   "scripts": {
     "dev": "NODE_ENV=development bun run index.ts",

--- a/apps/web/app/cli/auth/cli-auth-page.tsx
+++ b/apps/web/app/cli/auth/cli-auth-page.tsx
@@ -102,7 +102,7 @@ function CLIAuthSignedOut() {
             </div>
             <div className="ml-4 flex-1 text-center">
               <span className="font-mono text-xs text-white/30">
-                open-harness auth
+                openharness auth
               </span>
             </div>
             <div className="w-[52px]" />
@@ -114,7 +114,7 @@ function CLIAuthSignedOut() {
             <div className="mb-6 font-mono text-sm">
               <div className="flex items-center gap-2 text-white/40">
                 <span className="text-emerald-400">$</span>
-                <span>open-harness auth login</span>
+                <span>openharness auth login</span>
                 <span className="inline-block h-4 w-2 animate-pulse bg-emerald-400/80" />
               </div>
               <div className="mt-2 text-white/30">

--- a/apps/web/docs/design-system.md
+++ b/apps/web/docs/design-system.md
@@ -134,7 +134,7 @@ Animated terminal prompt with blinking cursor:
 <div className="font-mono text-sm">
   <div className="flex items-center gap-2 text-white/40">
     <span className="text-emerald-400">$</span>
-    <span>open-harness auth login</span>
+    <span>openharness auth login</span>
     <span className="inline-block h-4 w-2 animate-pulse bg-emerald-400/80" />
   </div>
   <div className="mt-2 text-white/30">

--- a/apps/web/public/install
+++ b/apps/web/public/install
@@ -2,13 +2,15 @@
 set -euo pipefail
 
 APP_NAME="Open Harness"
-BIN_NAME="open-harness"
+BIN_NAME="openharness"
 REPO_OWNER="vercel-labs"
 REPO_NAME="open-harness"
-INSTALL_DIR="$HOME/.open-harness/bin"
+INSTALL_DIR="$HOME/.openharness/bin"
 INSTALL_DOMAIN="openharness.dev"
 INSTALL_PATH="/install"
 INSTALL_URL="https://${INSTALL_DOMAIN}${INSTALL_PATH}"
+BLOB_PUBLIC_BASE_URL="${OPEN_HARNESS_BLOB_BASE_URL:-https://jalsc4d6nyeispea.public.blob.vercel-storage.com/open-harness}"
+BLOB_PUBLIC_BASE_URL="${BLOB_PUBLIC_BASE_URL%/}"
 
 MUTED='\033[0;2m'
 RED='\033[0;31m'
@@ -141,22 +143,25 @@ else
   fi
 
   if [ -z "$requested_version" ]; then
-    url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download/$filename"
-    specific_version=$(curl -fsSL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | sed -n 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/p')
+    specific_version=$(curl -fsSL "${BLOB_PUBLIC_BASE_URL}/latest" | tr -d '[:space:]')
+    specific_version="${specific_version#v}"
 
     if [[ $? -ne 0 || -z "$specific_version" ]]; then
-      echo -e "${RED}Failed to fetch version information${NC}"
+      echo -e "${RED}Failed to fetch latest version${NC}"
       exit 1
     fi
   else
     requested_version="${requested_version#v}"
-    url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/v${requested_version}/$filename"
     specific_version=$requested_version
+  fi
 
-    http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/v${requested_version}")
+  url="${BLOB_PUBLIC_BASE_URL}/${specific_version}/${filename}"
+
+  if [ -n "$requested_version" ]; then
+    http_status=$(curl -sI -o /dev/null -w "%{http_code}" "$url")
     if [ "$http_status" = "404" ]; then
       echo -e "${RED}Error: Release v${requested_version} not found${NC}"
-      echo -e "${MUTED}Available releases: https://github.com/${REPO_OWNER}/${REPO_NAME}/releases${NC}"
+      echo -e "${MUTED}Available releases: ${BLOB_PUBLIC_BASE_URL}${NC}"
       exit 1
     fi
   fi
@@ -197,6 +202,14 @@ download_and_install() {
 
   mv "$tmp_dir/$binary_name" "$INSTALL_DIR/$binary_name"
   chmod 755 "${INSTALL_DIR}/$binary_name"
+  if [ -f "$tmp_dir/parser.worker.js" ]; then
+    mv "$tmp_dir/parser.worker.js" "$INSTALL_DIR/parser.worker.js"
+  fi
+  if [ -d "$tmp_dir/node_modules/web-tree-sitter" ]; then
+    mkdir -p "$INSTALL_DIR/node_modules"
+    rm -rf "$INSTALL_DIR/node_modules/web-tree-sitter"
+    mv "$tmp_dir/node_modules/web-tree-sitter" "$INSTALL_DIR/node_modules/"
+  fi
   rm -rf "$tmp_dir"
 }
 
@@ -204,6 +217,16 @@ install_from_binary() {
   print_message info "${MUTED}Installing ${NC}${BIN_NAME}${MUTED} from: ${NC}$binary_path"
   cp "$binary_path" "${INSTALL_DIR}/${BIN_NAME}"
   chmod 755 "${INSTALL_DIR}/${BIN_NAME}"
+  worker_source="$(dirname "$binary_path")/parser.worker.js"
+  if [ -f "$worker_source" ]; then
+    cp "$worker_source" "${INSTALL_DIR}/parser.worker.js"
+  fi
+  module_source="$(dirname "$binary_path")/node_modules/web-tree-sitter"
+  if [ -d "$module_source" ]; then
+    mkdir -p "$INSTALL_DIR/node_modules"
+    rm -rf "$INSTALL_DIR/node_modules/web-tree-sitter"
+    cp -R "$module_source" "$INSTALL_DIR/node_modules/"
+  fi
 }
 
 if [ -n "$binary_path" ]; then

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,12 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
+        "@opentui/core-darwin-arm64": "^0.1.75",
+        "@opentui/core-darwin-x64": "^0.1.75",
+        "@opentui/core-linux-arm64": "^0.1.75",
+        "@opentui/core-linux-x64": "^0.1.75",
+        "@opentui/core-win32-x64": "^0.1.75",
+        "@vercel/blob": "^0.27.0",
         "turbo": "^2.5.4",
         "typescript": "^5",
       },
@@ -17,7 +23,7 @@
       "name": "@open-harness/cli",
       "version": "0.0.0",
       "bin": {
-        "deep-agent": "./index.ts",
+        "open-harness": "./index.ts",
       },
       "dependencies": {
         "@open-harness/agent": "workspace:*",
@@ -300,6 +306,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
 
@@ -765,6 +773,8 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
+    "@vercel/blob": ["@vercel/blob@0.27.3", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^5.28.4" } }, "sha512-WizeAxzOTmv0JL7wOaxvLIU/KdBcrclM1ZUOdSlIZAxsTTTe1jsyBthStLby0Ueh7FnmKYAjLz26qRJTk5SDkQ=="],
+
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
     "@vercel/sandbox": ["@vercel/sandbox@1.2.0", "", { "dependencies": { "@vercel/oidc": "^3.1.0", "async-retry": "1.3.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.16.0", "xdg-app-paths": "5.1.0", "zod": "3.24.4" } }, "sha512-oq0d2xQuiDq8LyoZOZW+i+QmNkMQ0/ddEGHMukBsF+cxX7ohBEXOV/a0+SopBwEsKCjq9j55QFP56G3MU/iEjA=="],
@@ -1079,6 +1089,8 @@
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
+    "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
+
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
@@ -1086,6 +1098,8 @@
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
+
+    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
@@ -1499,7 +1513,7 @@
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
-    "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -1686,6 +1700,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@vercel/sandbox/undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
     "bun-types/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,21 +9,23 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
+        "@vercel/blob": "^0.27.0",
+        "turbo": "^2.5.4",
+        "typescript": "^5",
+      },
+      "optionalDependencies": {
         "@opentui/core-darwin-arm64": "^0.1.75",
         "@opentui/core-darwin-x64": "^0.1.75",
         "@opentui/core-linux-arm64": "^0.1.75",
         "@opentui/core-linux-x64": "^0.1.75",
         "@opentui/core-win32-x64": "^0.1.75",
-        "@vercel/blob": "^0.27.0",
-        "turbo": "^2.5.4",
-        "typescript": "^5",
       },
     },
     "apps/cli": {
       "name": "@open-harness/cli",
       "version": "0.0.0",
       "bin": {
-        "open-harness": "./index.ts",
+        "openharness": "./index.ts",
       },
       "dependencies": {
         "@open-harness/agent": "workspace:*",

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,78 @@
+# CLI Releases (Simple)
+
+This is the easy, repeatable way to ship the CLI and keep the one-command install working.
+
+## One-command install (what users run)
+
+```bash
+curl -fsSL https://openharness.dev/install | bash
+```
+
+The installer script downloads a prebuilt binary from the Blob URL in `installer.config.json` and uses the `latest` pointer to pick a version.
+
+## The release flow (CI does all distros)
+
+1) Pick a unique version string. You can release multiple times per day as long as the version changes.
+
+Examples:
+- `0.2.0-20260131.1`
+- `2026.01.31.1`
+
+2) Run the GitHub Actions workflow **Release CLI** (manual trigger).
+- Input: `version`
+- This builds on macOS (arm64 + x64), Linux (arm64 + x64), and Windows (x64)
+- It uploads artifacts to Blob and optionally updates `latest`
+
+That's it - the curl install command will now install the new version.
+
+## Local testing (no CI)
+
+This builds your host target only, then installs from the local binary without editing your PATH:
+
+```bash
+bun run release:local
+```
+
+This command wipes `~/.openharness/bin` first so you always test a clean install.
+
+Run the CLI:
+
+```bash
+~/.openharness/bin/openharness --help
+```
+
+## Optional: end-to-end curl test before CI
+
+If you want to test the real curl install flow before running CI:
+
+1) Upload a local build to a temporary Blob prefix:
+
+```bash
+BLOB_READ_WRITE_TOKEN=... bun run upload:release --version 0.0.0-local --dir dist --targets <your-host-target> --prefix <your-name>/local
+```
+
+2) Run the installer with the Blob override (no deploy needed):
+
+```bash
+curl -fsSL https://openharness.dev/install | OPEN_HARNESS_BLOB_BASE_URL="https://<your-blob-domain>/<your-name>/local" bash
+```
+
+Note: the Blob override env var only affects the install source, not the public website.
+
+## Troubleshooting
+
+If you see:
+
+```
+TreeSitter worker error: BuildMessage: ModuleNotFound resolving "/$bunfs/root/parser.worker.ts"
+```
+
+Run a new build using `bun run build:release-artifacts` (or `bun run release:local`). The release artifacts must include `parser.worker.js` alongside the CLI binary.
+
+If you see:
+
+```
+TreeSitter worker error: error: Cannot find package 'web-tree-sitter'
+```
+
+Rebuild and reinstall. The release artifacts must include `node_modules/web-tree-sitter` next to the CLI binary.

--- a/installer.config.json
+++ b/installer.config.json
@@ -1,9 +1,10 @@
 {
   "appName": "Open Harness",
-  "binName": "open-harness",
+  "binName": "openharness",
   "repoOwner": "vercel-labs",
   "repoName": "open-harness",
-  "installDir": ".open-harness/bin",
+  "installDir": ".openharness/bin",
   "installDomain": "openharness.dev",
-  "installPath": "/install"
+  "installPath": "/install",
+  "blobPublicBaseUrl": "https://jalsc4d6nyeispea.public.blob.vercel-storage.com/open-harness"
 }

--- a/package.json
+++ b/package.json
@@ -34,14 +34,16 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
+    "@vercel/blob": "^0.27.0",
+    "turbo": "^2.5.4",
+    "typescript": "^5"
+  },
+  "optionalDependencies": {
     "@opentui/core-darwin-arm64": "^0.1.75",
     "@opentui/core-darwin-x64": "^0.1.75",
     "@opentui/core-linux-arm64": "^0.1.75",
     "@opentui/core-linux-x64": "^0.1.75",
-    "@opentui/core-win32-x64": "^0.1.75",
-    "@vercel/blob": "^0.27.0",
-    "turbo": "^2.5.4",
-    "typescript": "^5"
+    "@opentui/core-win32-x64": "^0.1.75"
   },
   "packageManager": "bun@1.2.14",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,19 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "ci": "bun run format:check && bun run lint && bun run typecheck",
-    "build:installer": "bun run scripts/build-installer.ts"
+    "build:installer": "bun run scripts/build-installer.ts",
+    "build:release-artifacts": "bun run scripts/build-release-artifacts.ts",
+    "release:local": "bun run scripts/release-local.ts",
+    "upload:release": "bun run scripts/upload-release-to-blob.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
+    "@opentui/core-darwin-arm64": "^0.1.75",
+    "@opentui/core-darwin-x64": "^0.1.75",
+    "@opentui/core-linux-arm64": "^0.1.75",
+    "@opentui/core-linux-x64": "^0.1.75",
+    "@opentui/core-win32-x64": "^0.1.75",
+    "@vercel/blob": "^0.27.0",
     "turbo": "^2.5.4",
     "typescript": "^5"
   },

--- a/packages/tui/lib/code-theme.ts
+++ b/packages/tui/lib/code-theme.ts
@@ -1,6 +1,10 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { getTreeSitterClient, SyntaxStyle, type ThemeTokenStyle } from "@opentui/core";
+import {
+  getTreeSitterClient,
+  SyntaxStyle,
+  type ThemeTokenStyle,
+} from "@opentui/core";
 
 const workerEnvVar = "OTUI_TREE_SITTER_WORKER_PATH";
 

--- a/packages/tui/lib/code-theme.ts
+++ b/packages/tui/lib/code-theme.ts
@@ -1,8 +1,16 @@
-import {
-  getTreeSitterClient,
-  SyntaxStyle,
-  type ThemeTokenStyle,
-} from "@opentui/core";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getTreeSitterClient, SyntaxStyle, type ThemeTokenStyle } from "@opentui/core";
+
+const workerEnvVar = "OTUI_TREE_SITTER_WORKER_PATH";
+
+if (!process.env[workerEnvVar]) {
+  const execDir = dirname(process.execPath);
+  const workerPath = join(execDir, "parser.worker.js");
+  if (existsSync(workerPath)) {
+    process.env[workerEnvVar] = workerPath;
+  }
+}
 
 const CODE_THEME: ThemeTokenStyle[] = [
   { scope: ["default"], style: { foreground: "#d7d7d7" } },

--- a/scripts/build-installer.ts
+++ b/scripts/build-installer.ts
@@ -9,6 +9,7 @@ const configSchema = z.object({
   installDir: z.string().min(1),
   installDomain: z.string().min(1),
   installPath: z.string().min(1),
+  blobPublicBaseUrl: z.string().min(1),
 });
 
 const rootDir = process.cwd();
@@ -31,6 +32,7 @@ async function main() {
     __INSTALL_DIR__: config.installDir,
     __INSTALL_DOMAIN__: config.installDomain,
     __INSTALL_PATH__: config.installPath,
+    __BLOB_PUBLIC_BASE_URL__: config.blobPublicBaseUrl,
   };
 
   let output = template;

--- a/scripts/build-release-artifacts.ts
+++ b/scripts/build-release-artifacts.ts
@@ -1,0 +1,248 @@
+import { mkdir, cp, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { z } from "zod";
+
+const configSchema = z.object({
+  binName: z.string().min(1),
+});
+
+type TargetSpec = {
+  os: "darwin" | "linux" | "windows";
+  arch: "x64" | "arm64";
+  bunTarget: string;
+  archiveExt: ".zip" | ".tar.gz";
+  exeSuffix: "" | ".exe";
+  opentuiPackage: string;
+};
+
+type CliOptions = {
+  dir: string;
+  entry: string;
+  targets: string[];
+};
+
+const DEFAULT_TARGETS = [
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-arm64",
+  "linux-x64",
+  "windows-x64",
+];
+
+const TARGETS: Record<string, TargetSpec> = {
+  "darwin-arm64": {
+    os: "darwin",
+    arch: "arm64",
+    bunTarget: "bun-darwin-arm64",
+    archiveExt: ".zip",
+    exeSuffix: "",
+    opentuiPackage: "@opentui/core-darwin-arm64",
+  },
+  "darwin-x64": {
+    os: "darwin",
+    arch: "x64",
+    bunTarget: "bun-darwin-x64",
+    archiveExt: ".zip",
+    exeSuffix: "",
+    opentuiPackage: "@opentui/core-darwin-x64",
+  },
+  "linux-arm64": {
+    os: "linux",
+    arch: "arm64",
+    bunTarget: "bun-linux-arm64",
+    archiveExt: ".tar.gz",
+    exeSuffix: "",
+    opentuiPackage: "@opentui/core-linux-arm64",
+  },
+  "linux-x64": {
+    os: "linux",
+    arch: "x64",
+    bunTarget: "bun-linux-x64",
+    archiveExt: ".tar.gz",
+    exeSuffix: "",
+    opentuiPackage: "@opentui/core-linux-x64",
+  },
+  "windows-x64": {
+    os: "windows",
+    arch: "x64",
+    bunTarget: "bun-windows-x64",
+    archiveExt: ".zip",
+    exeSuffix: ".exe",
+    opentuiPackage: "@opentui/core-win32-x64",
+  },
+};
+
+const usage = () => {
+  console.log(`Usage:
+  bun run scripts/build-release-artifacts.ts [options]
+
+Options:
+  -d, --dir <path>       Output directory (default: dist)
+  -e, --entry <path>     CLI entrypoint (default: apps/cli/index.ts)
+  -t, --targets <list>   Comma-separated targets (default: ${DEFAULT_TARGETS.join(", ")})
+  -h, --help             Show this help message\n`);
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: Partial<CliOptions> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "-h":
+      case "--help":
+        usage();
+        process.exit(0);
+      case "-d":
+      case "--dir": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --dir");
+        }
+        options.dir = value;
+        i += 1;
+        break;
+      }
+      case "-e":
+      case "--entry": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --entry");
+        }
+        options.entry = value;
+        i += 1;
+        break;
+      }
+      case "-t":
+      case "--targets": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --targets");
+        }
+        options.targets = value.split(",").map((target) => target.trim());
+        i += 1;
+        break;
+      }
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return {
+    dir: options.dir ?? "dist",
+    entry: options.entry ?? "apps/cli/index.ts",
+    targets: options.targets ?? DEFAULT_TARGETS,
+  };
+}
+
+async function ensureCommand(command: string) {
+  try {
+    await Bun.$`command -v ${command}`;
+  } catch {
+    throw new Error(`Missing required tool: ${command}`);
+  }
+}
+
+async function ensureOpentuiPackage(packageName: string) {
+  const packagePath = join("node_modules", packageName, "package.json");
+  const exists = await Bun.file(packagePath).exists();
+  if (exists) {
+    return;
+  }
+  throw new Error(
+    `Missing ${packageName}. Install it with: bun add -D ${packageName}`,
+  );
+}
+
+async function copyTreeSitterWorker(stageDir: string) {
+  const sourcePath = join("node_modules", "@opentui", "core", "parser.worker.js");
+  const exists = await Bun.file(sourcePath).exists();
+  if (!exists) {
+    throw new Error(
+      "Missing @opentui/core/parser.worker.js. Run bun install before building release artifacts.",
+    );
+  }
+
+  const destinationPath = join(stageDir, "parser.worker.js");
+  await Bun.write(destinationPath, Bun.file(sourcePath));
+}
+
+async function copyWebTreeSitter(stageDir: string) {
+  const sourceDir = join("node_modules", "web-tree-sitter");
+  const exists = await Bun.file(join(sourceDir, "package.json")).exists();
+  if (!exists) {
+    throw new Error(
+      "Missing web-tree-sitter. Run bun install before building release artifacts.",
+    );
+  }
+
+  const destinationRoot = join(stageDir, "node_modules");
+  const destinationDir = join(destinationRoot, "web-tree-sitter");
+  await mkdir(destinationRoot, { recursive: true });
+  await cp(sourceDir, destinationDir, { recursive: true, force: true });
+}
+
+async function main() {
+  const options = parseArgs(Bun.argv.slice(2));
+  const isWindows = process.platform === "win32";
+
+  const configText = await Bun.file("installer.config.json").text();
+  const parsedConfig: unknown = JSON.parse(configText);
+  const config = configSchema.parse(parsedConfig);
+
+  const invalidTargets = options.targets.filter((target) => !(target in TARGETS));
+  if (invalidTargets.length > 0) {
+    throw new Error(`Unknown targets: ${invalidTargets.join(", ")}`);
+  }
+
+  const needsZip = options.targets.some((target) => TARGETS[target]?.archiveExt === ".zip");
+  const needsTar = options.targets.some(
+    (target) => TARGETS[target]?.archiveExt === ".tar.gz",
+  );
+
+  if (needsZip && !isWindows) {
+    await ensureCommand("zip");
+  }
+  if (needsTar) {
+    await ensureCommand("tar");
+  }
+
+  const outputDir = resolve(options.dir);
+  const stageRoot = join(outputDir, "stage");
+
+  await Bun.$`mkdir -p ${stageRoot}`;
+
+  for (const targetKey of options.targets) {
+    const target = TARGETS[targetKey];
+    await ensureOpentuiPackage(target.opentuiPackage);
+    const stageDir = join(stageRoot, `${target.os}-${target.arch}`);
+    const binaryName = `${config.binName}${target.exeSuffix}`;
+    const outputBinary = join(stageDir, binaryName);
+
+    await rm(stageDir, { recursive: true, force: true });
+    await Bun.$`mkdir -p ${stageDir}`;
+    await Bun.$`bun build ${options.entry} --compile --target=${target.bunTarget} --outfile ${outputBinary}`;
+    await copyTreeSitterWorker(stageDir);
+    await copyWebTreeSitter(stageDir);
+
+    const archiveName = `${config.binName}-${target.os}-${target.arch}${target.archiveExt}`;
+    const archivePath = join(outputDir, archiveName);
+
+    if (target.archiveExt === ".tar.gz") {
+      await Bun.$`tar -czf ${archivePath} -C ${stageDir} .`;
+    } else {
+      if (isWindows) {
+        await Bun.$`powershell -NoProfile -Command Compress-Archive -Path "${stageDir}\\*" -DestinationPath "${archivePath}" -Force`;
+      } else {
+        await Bun.$`bash -c ${`cd "${stageDir}" && zip -r "${archivePath}" . -x "*.DS_Store"`}`;
+      }
+    }
+
+    console.log(`Built ${archivePath}`);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/scripts/build-release-artifacts.ts
+++ b/scripts/build-release-artifacts.ts
@@ -154,7 +154,12 @@ async function ensureOpentuiPackage(packageName: string) {
 }
 
 async function copyTreeSitterWorker(stageDir: string) {
-  const sourcePath = join("node_modules", "@opentui", "core", "parser.worker.js");
+  const sourcePath = join(
+    "node_modules",
+    "@opentui",
+    "core",
+    "parser.worker.js",
+  );
   const exists = await Bun.file(sourcePath).exists();
   if (!exists) {
     throw new Error(
@@ -189,12 +194,16 @@ async function main() {
   const parsedConfig: unknown = JSON.parse(configText);
   const config = configSchema.parse(parsedConfig);
 
-  const invalidTargets = options.targets.filter((target) => !(target in TARGETS));
+  const invalidTargets = options.targets.filter(
+    (target) => !(target in TARGETS),
+  );
   if (invalidTargets.length > 0) {
     throw new Error(`Unknown targets: ${invalidTargets.join(", ")}`);
   }
 
-  const needsZip = options.targets.some((target) => TARGETS[target]?.archiveExt === ".zip");
+  const needsZip = options.targets.some(
+    (target) => TARGETS[target]?.archiveExt === ".zip",
+  );
   const needsTar = options.targets.some(
     (target) => TARGETS[target]?.archiveExt === ".tar.gz",
   );

--- a/scripts/install.template.sh
+++ b/scripts/install.template.sh
@@ -9,6 +9,8 @@ INSTALL_DIR="$HOME/__INSTALL_DIR__"
 INSTALL_DOMAIN="__INSTALL_DOMAIN__"
 INSTALL_PATH="__INSTALL_PATH__"
 INSTALL_URL="https://${INSTALL_DOMAIN}${INSTALL_PATH}"
+BLOB_PUBLIC_BASE_URL="${OPEN_HARNESS_BLOB_BASE_URL:-__BLOB_PUBLIC_BASE_URL__}"
+BLOB_PUBLIC_BASE_URL="${BLOB_PUBLIC_BASE_URL%/}"
 
 MUTED='\033[0;2m'
 RED='\033[0;31m'
@@ -141,22 +143,25 @@ else
   fi
 
   if [ -z "$requested_version" ]; then
-    url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download/$filename"
-    specific_version=$(curl -fsSL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | sed -n 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/p')
+    specific_version=$(curl -fsSL "${BLOB_PUBLIC_BASE_URL}/latest" | tr -d '[:space:]')
+    specific_version="${specific_version#v}"
 
     if [[ $? -ne 0 || -z "$specific_version" ]]; then
-      echo -e "${RED}Failed to fetch version information${NC}"
+      echo -e "${RED}Failed to fetch latest version${NC}"
       exit 1
     fi
   else
     requested_version="${requested_version#v}"
-    url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/v${requested_version}/$filename"
     specific_version=$requested_version
+  fi
 
-    http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/v${requested_version}")
+  url="${BLOB_PUBLIC_BASE_URL}/${specific_version}/${filename}"
+
+  if [ -n "$requested_version" ]; then
+    http_status=$(curl -sI -o /dev/null -w "%{http_code}" "$url")
     if [ "$http_status" = "404" ]; then
       echo -e "${RED}Error: Release v${requested_version} not found${NC}"
-      echo -e "${MUTED}Available releases: https://github.com/${REPO_OWNER}/${REPO_NAME}/releases${NC}"
+      echo -e "${MUTED}Available releases: ${BLOB_PUBLIC_BASE_URL}${NC}"
       exit 1
     fi
   fi
@@ -197,6 +202,14 @@ download_and_install() {
 
   mv "$tmp_dir/$binary_name" "$INSTALL_DIR/$binary_name"
   chmod 755 "${INSTALL_DIR}/$binary_name"
+  if [ -f "$tmp_dir/parser.worker.js" ]; then
+    mv "$tmp_dir/parser.worker.js" "$INSTALL_DIR/parser.worker.js"
+  fi
+  if [ -d "$tmp_dir/node_modules/web-tree-sitter" ]; then
+    mkdir -p "$INSTALL_DIR/node_modules"
+    rm -rf "$INSTALL_DIR/node_modules/web-tree-sitter"
+    mv "$tmp_dir/node_modules/web-tree-sitter" "$INSTALL_DIR/node_modules/"
+  fi
   rm -rf "$tmp_dir"
 }
 
@@ -204,6 +217,16 @@ install_from_binary() {
   print_message info "${MUTED}Installing ${NC}${BIN_NAME}${MUTED} from: ${NC}$binary_path"
   cp "$binary_path" "${INSTALL_DIR}/${BIN_NAME}"
   chmod 755 "${INSTALL_DIR}/${BIN_NAME}"
+  worker_source="$(dirname "$binary_path")/parser.worker.js"
+  if [ -f "$worker_source" ]; then
+    cp "$worker_source" "${INSTALL_DIR}/parser.worker.js"
+  fi
+  module_source="$(dirname "$binary_path")/node_modules/web-tree-sitter"
+  if [ -d "$module_source" ]; then
+    mkdir -p "$INSTALL_DIR/node_modules"
+    rm -rf "$INSTALL_DIR/node_modules/web-tree-sitter"
+    cp -R "$module_source" "$INSTALL_DIR/node_modules/"
+  fi
 }
 
 if [ -n "$binary_path" ]; then

--- a/scripts/release-local.ts
+++ b/scripts/release-local.ts
@@ -1,0 +1,98 @@
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+
+const configSchema = z.object({
+  binName: z.string().min(1),
+  installDir: z.string().min(1),
+});
+
+type HostTarget = {
+  os: "darwin" | "linux" | "windows";
+  arch: "x64" | "arm64";
+  target: string;
+};
+
+function resolveHostTarget(): HostTarget {
+  let os: HostTarget["os"];
+  switch (process.platform) {
+    case "darwin":
+      os = "darwin";
+      break;
+    case "linux":
+      os = "linux";
+      break;
+    case "win32":
+      os = "windows";
+      break;
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+
+  let arch: HostTarget["arch"];
+  switch (process.arch) {
+    case "x64":
+      arch = "x64";
+      break;
+    case "arm64":
+      arch = "arm64";
+      break;
+    default:
+      throw new Error(`Unsupported architecture: ${process.arch}`);
+  }
+
+  return { os, arch, target: `${os}-${arch}` };
+}
+
+async function main() {
+  const configText = await Bun.file("installer.config.json").text();
+  const parsedConfig: unknown = JSON.parse(configText);
+  const config = configSchema.parse(parsedConfig);
+
+  const host = resolveHostTarget();
+  const distDir = "dist";
+  const stageDir = join(distDir, "stage", `${host.os}-${host.arch}`);
+  const binaryName = `${config.binName}${host.os === "windows" ? ".exe" : ""}`;
+  const binaryPath = join(stageDir, binaryName);
+
+  console.log(`Building ${host.target} release artifact...`);
+  await Bun.$`bun run scripts/build-release-artifacts.ts --targets ${host.target} --dir ${distDir}`;
+
+  const binaryExists = await Bun.file(binaryPath).exists();
+  if (!binaryExists) {
+    throw new Error(`Expected binary not found: ${binaryPath}`);
+  }
+
+  await Bun.$`bun run scripts/build-installer.ts`;
+
+  if (host.os === "windows") {
+    console.log("Local install script uses bash. Run in WSL or Git Bash.");
+    console.log(`Binary is at: ${binaryPath}`);
+    return;
+  }
+
+  const homeDir = process.env.HOME;
+  const resolvedInstallDir = homeDir
+    ? join(homeDir, config.installDir)
+    : `$HOME/${config.installDir}`;
+  if (homeDir) {
+    console.log(`Wiping local install dir: ${resolvedInstallDir}`);
+    await rm(resolvedInstallDir, { recursive: true, force: true });
+  } else {
+    console.warn("HOME is not set. Skipping local install dir cleanup.");
+  }
+
+  console.log("Installing from local binary (no PATH changes)...");
+  await Bun.$`bash apps/web/public/install --binary ${binaryPath} --no-modify-path`;
+
+  const installDir = resolvedInstallDir;
+
+  console.log("Done.");
+  console.log(`Run: ${join(installDir, config.binName)} --help`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/scripts/upload-release-to-blob.ts
+++ b/scripts/upload-release-to-blob.ts
@@ -152,7 +152,9 @@ async function main() {
     "windows-x64": { os: "windows", arch: "x64", ext: ".zip" },
   };
 
-  const invalidTargets = options.targets.filter((target) => !(target in combos));
+  const invalidTargets = options.targets.filter(
+    (target) => !(target in combos),
+  );
   if (invalidTargets.length > 0) {
     throw new Error(`Unknown targets: ${invalidTargets.join(", ")}`);
   }

--- a/scripts/upload-release-to-blob.ts
+++ b/scripts/upload-release-to-blob.ts
@@ -1,0 +1,223 @@
+import { join } from "node:path";
+import { put } from "@vercel/blob";
+import { z } from "zod";
+
+const configSchema = z.object({
+  binName: z.string().min(1),
+  blobPublicBaseUrl: z.string().min(1),
+});
+
+type CliOptions = {
+  version: string;
+  dir: string;
+  prefix?: string;
+  targets: string[];
+  skipLatest: boolean;
+  onlyLatest: boolean;
+};
+
+const usage = () => {
+  console.log(`Usage:
+  bun run scripts/upload-release-to-blob.ts --version <version> [--dir <path>] [--prefix <path>] [--targets <list>] [--skip-latest] [--only-latest]
+
+Options:
+  -v, --version    Release version (e.g. 1.2.3 or v1.2.3)
+  -d, --dir        Directory containing built archives (default: dist)
+  -p, --prefix     Optional blob path prefix (overrides base URL path)
+  -t, --targets    Comma-separated targets (default: all)
+      --skip-latest  Skip writing the latest pointer
+      --only-latest  Only write the latest pointer (skip artifacts)
+  -h, --help       Show this help message`);
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: Partial<CliOptions> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "-h":
+      case "--help":
+        usage();
+        process.exit(0);
+      case "-v":
+      case "--version": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --version");
+        }
+        options.version = value;
+        i += 1;
+        break;
+      }
+      case "-d":
+      case "--dir": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --dir");
+        }
+        options.dir = value;
+        i += 1;
+        break;
+      }
+      case "-p":
+      case "--prefix": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --prefix");
+        }
+        options.prefix = value;
+        i += 1;
+        break;
+      }
+      case "-t":
+      case "--targets": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --targets");
+        }
+        options.targets = value.split(",").map((target) => target.trim());
+        i += 1;
+        break;
+      }
+      case "--skip-latest":
+        options.skipLatest = true;
+        break;
+      case "--only-latest":
+        options.onlyLatest = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.version) {
+    throw new Error("--version is required");
+  }
+
+  return {
+    version: options.version,
+    dir: options.dir ?? "dist",
+    prefix: options.prefix,
+    targets: options.targets ?? [
+      "linux-x64",
+      "linux-arm64",
+      "darwin-x64",
+      "darwin-arm64",
+      "windows-x64",
+    ],
+    skipLatest: options.skipLatest ?? false,
+    onlyLatest: options.onlyLatest ?? false,
+  };
+}
+
+function normalizePath(input: string): string {
+  return input.replace(/^\/+|\/+$/g, "");
+}
+
+function contentTypeFor(filename: string): string {
+  if (filename.endsWith(".tar.gz")) {
+    return "application/gzip";
+  }
+  if (filename.endsWith(".zip")) {
+    return "application/zip";
+  }
+  return "application/octet-stream";
+}
+
+async function main() {
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    throw new Error("BLOB_READ_WRITE_TOKEN is required to upload releases.");
+  }
+
+  const options = parseArgs(Bun.argv.slice(2));
+  const version = options.version.replace(/^v/, "");
+  if (!version) {
+    throw new Error("Version must be non-empty.");
+  }
+
+  const configText = await Bun.file("installer.config.json").text();
+  const parsedConfig: unknown = JSON.parse(configText);
+  const config = configSchema.parse(parsedConfig);
+
+  const baseUrl = new URL(config.blobPublicBaseUrl);
+  const basePath = normalizePath(baseUrl.pathname);
+  const prefix = normalizePath(options.prefix ?? basePath);
+
+  const combos: Record<string, { os: string; arch: string; ext: string }> = {
+    "linux-x64": { os: "linux", arch: "x64", ext: ".tar.gz" },
+    "linux-arm64": { os: "linux", arch: "arm64", ext: ".tar.gz" },
+    "darwin-x64": { os: "darwin", arch: "x64", ext: ".zip" },
+    "darwin-arm64": { os: "darwin", arch: "arm64", ext: ".zip" },
+    "windows-x64": { os: "windows", arch: "x64", ext: ".zip" },
+  };
+
+  const invalidTargets = options.targets.filter((target) => !(target in combos));
+  if (invalidTargets.length > 0) {
+    throw new Error(`Unknown targets: ${invalidTargets.join(", ")}`);
+  }
+
+  const uploads = options.targets.map((target) => {
+    const { os, arch, ext } = combos[target];
+    const filename = `${config.binName}-${os}-${arch}${ext}`;
+    const localPath = join(options.dir, filename);
+    return { filename, localPath };
+  });
+
+  if (!options.onlyLatest) {
+    const missing: string[] = [];
+    for (const upload of uploads) {
+      const exists = await Bun.file(upload.localPath).exists();
+      if (!exists) {
+        missing.push(upload.localPath);
+      }
+    }
+
+    if (missing.length > 0) {
+      throw new Error(`Missing release artifacts:\n${missing.join("\n")}`);
+    }
+  }
+
+  const uploadedUrls: string[] = [];
+  if (!options.onlyLatest) {
+    for (const upload of uploads) {
+      const blobPath = [prefix, version, upload.filename]
+        .filter(Boolean)
+        .join("/");
+      const result = await put(blobPath, Bun.file(upload.localPath), {
+        access: "public",
+        addRandomSuffix: false,
+        contentType: contentTypeFor(upload.filename),
+        token,
+      });
+      uploadedUrls.push(result.url);
+    }
+  }
+
+  let latestResult: { url: string } | null = null;
+  if (!options.skipLatest) {
+    const latestPath = [prefix, "latest"].filter(Boolean).join("/");
+    latestResult = await put(latestPath, `${version}\n`, {
+      access: "public",
+      addRandomSuffix: false,
+      contentType: "text/plain; charset=utf-8",
+      token,
+    });
+  }
+
+  if (uploadedUrls.length > 0) {
+    console.log("Uploaded release artifacts:");
+    for (const url of uploadedUrls) {
+      console.log(`- ${url}`);
+    }
+  }
+  if (latestResult) {
+    console.log(`Latest pointer: ${latestResult.url}`);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
  - Bundle TreeSitter worker + web-tree-sitter into release artifacts
  - Update installer to install those assets alongside the CLI
  - Add local release/test script and release docs
  - Rename CLI binary to `openharness` and switch install dir to
  `~/.openharness/bin`

  ## Testing
  - `bun run release:local`
  - `/Users/nicoalbanese/.openharness/bin/openharness --help`

  ## Notes
  - Release artifacts now include `parser.worker.js` and `node_modules/web-
  tree-sitter`
  - Install command remains: `curl -fsSL https://openharness.dev/install |
  bash`