### PR TITLE
Improve GitHub repo selector search and cache refresh

### DIFF
--- a/apps/web/app/api/auth/signin/github/route.ts
+++ b/apps/web/app/api/auth/signin/github/route.ts
@@ -1,6 +1,6 @@
-import { type NextRequest } from "next/server";
-import { cookies } from "next/headers";
 import { generateState } from "arctic";
+import { cookies } from "next/headers";
+import { type NextRequest } from "next/server";
 
 export async function GET(req: NextRequest): Promise<Response> {
   const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID;
@@ -33,7 +33,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
-    scope: "repo,read:user,user:email",
+    scope: "repo,read:org,read:user,user:email",
     state: state,
   });
 

--- a/apps/web/app/api/github/repos/revalidate/route.ts
+++ b/apps/web/app/api/github/repos/revalidate/route.ts
@@ -1,0 +1,17 @@
+import { revalidateTag } from "next/cache";
+import { NextResponse } from "next/server";
+import { getGitHubReposCacheTag } from "@/lib/github/cached-api";
+import { getServerSession } from "@/lib/session/get-server-session";
+
+export async function POST() {
+  const session = await getServerSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const cacheTag = getGitHubReposCacheTag(session.user.id);
+  revalidateTag(cacheTag, { expire: 0 });
+
+  return NextResponse.json({ success: true, revalidated: cacheTag });
+}

--- a/apps/web/app/api/github/repos/route.ts
+++ b/apps/web/app/api/github/repos/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "@/lib/session/get-server-session";
-import { getUserGitHubToken } from "@/lib/github/user-token";
 import { getCachedGitHubRepos } from "@/lib/github/cached-api";
+import { getUserGitHubToken } from "@/lib/github/user-token";
+import { getServerSession } from "@/lib/session/get-server-session";
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession();
@@ -24,6 +24,8 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   const owner = searchParams.get("owner");
+  const limitParam = searchParams.get("limit");
+  const queryParam = searchParams.get("query");
 
   if (!owner) {
     return NextResponse.json(
@@ -32,8 +34,18 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+  const limit =
+    typeof parsedLimit === "number" && Number.isFinite(parsedLimit)
+      ? parsedLimit
+      : undefined;
+  const query = queryParam?.trim() || undefined;
+
   try {
-    const repos = await getCachedGitHubRepos(session.user.id, token, owner);
+    const repos = await getCachedGitHubRepos(session.user.id, token, owner, {
+      limit,
+      query,
+    });
 
     if (!repos) {
       return NextResponse.json(

--- a/apps/web/components/repo-selector-compact.tsx
+++ b/apps/web/components/repo-selector-compact.tsx
@@ -1,21 +1,15 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import useSWR from "swr";
 import {
-  Folder,
-  ChevronDown,
   CheckIcon,
-  LockIcon,
+  ChevronDown,
+  Folder,
   Loader2Icon,
+  LockIcon,
+  RefreshCw,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { fetcher } from "@/lib/swr";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import { useCallback, useEffect, useRef, useState } from "react";
+import useSWR, { useSWRConfig } from "swr";
 import {
   Command,
   CommandEmpty,
@@ -25,6 +19,13 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { fetcher } from "@/lib/swr";
+import { cn } from "@/lib/utils";
 
 interface Owner {
   login: string;
@@ -73,6 +74,10 @@ export function RepoSelectorCompact({
 }: RepoSelectorCompactProps) {
   const [open, setOpen] = useState(false);
   const [currentOwner, setCurrentOwner] = useState(selectedOwner);
+  const [repoSearch, setRepoSearch] = useState("");
+  const [debouncedRepoSearch, setDebouncedRepoSearch] = useState("");
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const { mutate } = useSWRConfig();
 
   // Track whether we've auto-selected an owner
   const hasAutoSelectedRef = useRef(false);
@@ -83,11 +88,40 @@ export function RepoSelectorCompact({
     fetchOwners,
   );
 
+  // Build the repos URL for current owner
+  const reposUrl = currentOwner
+    ? `/api/github/repos?${new URLSearchParams({
+        owner: currentOwner,
+        limit: "50",
+        ...(debouncedRepoSearch ? { query: debouncedRepoSearch } : {}),
+      }).toString()}`
+    : null;
+
   // Fetch repos for current owner (conditional fetch)
   const { data: repos = [], isLoading: reposLoading } = useSWR<Repo[]>(
-    currentOwner ? `/api/github/repos?owner=${currentOwner}` : null,
+    reposUrl,
     fetcher,
   );
+
+  // Revalidate cache and refetch repos
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      // Revalidate the server cache
+      await fetch("/api/github/repos/revalidate", { method: "POST" });
+      // Then refetch the data - use regex to match all repo URLs for this owner
+      await mutate(
+        (key) =>
+          typeof key === "string" &&
+          key.startsWith("/api/github/repos?") &&
+          key.includes(`owner=${currentOwner}`),
+        undefined,
+        { revalidate: true },
+      );
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [currentOwner, mutate]);
 
   // Auto-select first owner when data loads (only once)
   useEffect(() => {
@@ -103,6 +137,18 @@ export function RepoSelectorCompact({
       setCurrentOwner(selectedOwner);
     }
   }, [selectedOwner, currentOwner]);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedRepoSearch(repoSearch.trim());
+    }, 200);
+
+    return () => clearTimeout(timeoutId);
+  }, [repoSearch]);
+
+  useEffect(() => {
+    setRepoSearch("");
+  }, [currentOwner]);
 
   const handleRepoSelect = (repo: Repo) => {
     onSelect(currentOwner, repo.name);
@@ -137,7 +183,11 @@ export function RepoSelectorCompact({
       </PopoverTrigger>
       <PopoverContent className="w-80 p-0" align="start">
         <Command>
-          <CommandInput placeholder="Search repositories..." />
+          <CommandInput
+            placeholder="Search repositories..."
+            value={repoSearch}
+            onValueChange={setRepoSearch}
+          />
           <CommandList>
             <CommandEmpty>
               {ownersLoading || reposLoading
@@ -174,9 +224,26 @@ export function RepoSelectorCompact({
             </CommandGroup>
 
             <CommandSeparator />
+            <div className="flex items-center justify-between px-2 py-1.5 text-xs text-muted-foreground">
+              <span>
+                Showing repos for{" "}
+                <span className="text-foreground">{currentOwner}</span>
+              </span>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                disabled={isRefreshing}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+              >
+                <RefreshCw
+                  className={cn("size-3", isRefreshing && "animate-spin")}
+                />
+                {isRefreshing ? "Refreshing..." : "Refresh"}
+              </button>
+            </div>
 
             {/* Repos for current owner */}
-            <CommandGroup heading="Repositories">
+            <CommandGroup>
               {reposLoading ? (
                 <div className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground">
                   <Loader2Icon className="size-4 animate-spin" />
@@ -187,7 +254,7 @@ export function RepoSelectorCompact({
                   No repositories found.
                 </div>
               ) : (
-                repos.map((repo) => (
+                repos.slice(0, 50).map((repo) => (
                   <CommandItem
                     key={repo.full_name}
                     value={repo.name}
@@ -208,6 +275,11 @@ export function RepoSelectorCompact({
                     )}
                   </CommandItem>
                 ))
+              )}
+              {repos.length === 50 && !debouncedRepoSearch && (
+                <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                  Showing first 50 results. Use search to narrow.
+                </div>
               )}
             </CommandGroup>
           </CommandList>

--- a/apps/web/components/repo-selector.tsx
+++ b/apps/web/components/repo-selector.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import {
+  BookIcon,
   CheckIcon,
   ChevronsUpDownIcon,
-  UserIcon,
-  BookIcon,
   LockIcon,
+  RefreshCw,
+  UserIcon,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -23,6 +23,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 
 interface Owner {
   login: string;
@@ -50,6 +51,10 @@ export function RepoSelector({
   const [reposLoading, setReposLoading] = useState(false);
   const [ownerOpen, setOwnerOpen] = useState(false);
   const [repoOpen, setRepoOpen] = useState(false);
+  const [repoSearch, setRepoSearch] = useState("");
+  const [debouncedRepoSearch, setDebouncedRepoSearch] = useState("");
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [repoRefreshTrigger, setRepoRefreshTrigger] = useState(0);
 
   const [error, setError] = useState<string | null>(null);
 
@@ -92,24 +97,55 @@ export function RepoSelector({
     loadOwners();
   }, []);
 
-  useEffect(() => {
+  const loadRepos = useCallback(async () => {
     if (!selectedOwner) return;
 
-    const loadRepos = async () => {
-      setReposLoading(true);
-      setRepos([]);
-      try {
-        const res = await fetch(`/api/github/repos?owner=${selectedOwner}`);
-        const data = (await res.json()) as Repo[];
-        setRepos(data);
-      } catch (error) {
-        console.error("Failed to load repos:", error);
-      } finally {
-        setReposLoading(false);
+    setReposLoading(true);
+    setRepos([]);
+    try {
+      const params = new URLSearchParams({
+        owner: selectedOwner,
+        limit: "50",
+      });
+      if (debouncedRepoSearch) {
+        params.set("query", debouncedRepoSearch);
       }
-    };
+      const res = await fetch(`/api/github/repos?${params.toString()}`);
+      const data = (await res.json()) as Repo[];
+      setRepos(data);
+    } catch (error) {
+      console.error("Failed to load repos:", error);
+    } finally {
+      setReposLoading(false);
+    }
+  }, [selectedOwner, debouncedRepoSearch]);
 
+  useEffect(() => {
     loadRepos();
+  }, [loadRepos, repoRefreshTrigger]);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      // Revalidate the server cache
+      await fetch("/api/github/repos/revalidate", { method: "POST" });
+      // Trigger a refetch
+      setRepoRefreshTrigger((v) => v + 1);
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedRepoSearch(repoSearch.trim());
+    }, 200);
+
+    return () => clearTimeout(timeoutId);
+  }, [repoSearch]);
+
+  useEffect(() => {
+    setRepoSearch("");
   }, [selectedOwner]);
 
   const handleOwnerSelect = (ownerLogin: string) => {
@@ -215,14 +251,35 @@ export function RepoSelector({
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-64 p-0">
+          <div className="flex items-center justify-between border-b px-3 py-2 text-xs text-muted-foreground">
+            <span>
+              Showing repos for{" "}
+              <span className="text-foreground">{selectedOwner}</span>
+            </span>
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+            >
+              <RefreshCw
+                className={cn("size-3", isRefreshing && "animate-spin")}
+              />
+              {isRefreshing ? "Refreshing..." : "Refresh"}
+            </button>
+          </div>
           <Command>
-            <CommandInput placeholder="Search repositories..." />
+            <CommandInput
+              placeholder="Search repositories..."
+              value={repoSearch}
+              onValueChange={setRepoSearch}
+            />
             <CommandList>
               <CommandEmpty>
                 {reposLoading ? "Loading..." : "No repositories found."}
               </CommandEmpty>
               <CommandGroup>
-                {repos.map((repo) => (
+                {repos.slice(0, 50).map((repo) => (
                   <CommandItem
                     key={repo.full_name}
                     value={repo.name}
@@ -242,6 +299,11 @@ export function RepoSelector({
                     )}
                   </CommandItem>
                 ))}
+                {repos.length === 50 && !debouncedRepoSearch && (
+                  <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                    Showing first 50 results. Use search to narrow.
+                  </div>
+                )}
               </CommandGroup>
             </CommandList>
           </Command>

--- a/apps/web/lib/github/cached-api.ts
+++ b/apps/web/lib/github/cached-api.ts
@@ -32,6 +32,15 @@ interface GitHubRepoInfo {
   default_branch: string;
 }
 
+interface GitHubRepoOptions {
+  limit?: number;
+  query?: string;
+}
+
+interface GitHubSearchResponse {
+  items: GitHubRepo[];
+}
+
 async function fetchGitHubAPI<T>(
   endpoint: string,
   token: string,
@@ -80,68 +89,52 @@ export const getCachedGitHubOrgs = unstable_cache(
   { revalidate: CACHE_REVALIDATE_SECONDS },
 );
 
-export const getCachedGitHubRepos = unstable_cache(
-  async (userId: string, token: string, owner: string) => {
-    // Check if owner is the authenticated user
-    const currentUser = await fetchGitHubAPI<{ login: string }>("/user", token);
-    if (!currentUser) return null;
+// Helper to create user-scoped cache tags
+export function getGitHubReposCacheTag(userId: string): string {
+  return `github-repos-${userId}`;
+}
 
-    const isAuthenticatedUser = currentUser.login === owner;
+async function fetchGitHubReposInternal(
+  userId: string,
+  token: string,
+  owner: string,
+  options?: GitHubRepoOptions,
+) {
+  const normalizedLimit =
+    typeof options?.limit === "number" && Number.isFinite(options.limit)
+      ? Math.max(1, Math.min(options.limit, 100))
+      : undefined;
+  const normalizedQuery = options?.query?.trim() || undefined;
+  // Check if owner is the authenticated user
+  const currentUser = await fetchGitHubAPI<{ login: string }>("/user", token);
+  if (!currentUser) return null;
 
-    // Determine endpoint type
-    let apiEndpointType: "user" | "org" | "other" = "other";
-    if (isAuthenticatedUser) {
-      apiEndpointType = "user";
-    } else {
-      const orgResponse = await fetchGitHubAPI<unknown>(
-        `/orgs/${owner}`,
-        token,
-      );
-      if (orgResponse) {
-        apiEndpointType = "org";
-      }
+  const isAuthenticatedUser = currentUser.login === owner;
+
+  // Determine endpoint type
+  let apiEndpointType: "user" | "org" | "other" = "other";
+  if (isAuthenticatedUser) {
+    apiEndpointType = "user";
+  } else {
+    const orgResponse = await fetchGitHubAPI<unknown>(`/orgs/${owner}`, token);
+    if (orgResponse) {
+      apiEndpointType = "org";
     }
+  }
 
-    // Fetch all repos with pagination
-    const allRepos: GitHubRepo[] = [];
-    let page = 1;
-    const perPage = 100;
-    const maxPages = 50;
-
-    while (page <= maxPages) {
-      let endpoint: string;
-
-      if (apiEndpointType === "user") {
-        endpoint = `/user/repos?sort=name&direction=asc&per_page=${perPage}&page=${page}&visibility=all&affiliation=owner`;
-      } else if (apiEndpointType === "org") {
-        endpoint = `/orgs/${owner}/repos?sort=name&direction=asc&per_page=${perPage}&page=${page}`;
-      } else {
-        endpoint = `/users/${owner}/repos?sort=name&direction=asc&per_page=${perPage}&page=${page}`;
-      }
-
-      const repos = await fetchGitHubAPI<GitHubRepo[]>(endpoint, token);
-      if (!repos) {
-        // API error on first page means failure; on subsequent pages, return what we have
-        if (page === 1) return null;
-        break;
-      }
-      if (repos.length === 0) break;
-
-      allRepos.push(...repos);
-      if (repos.length < perPage) break;
-      page++;
-    }
-
-    // Dedupe and sort
-    const uniqueRepos = allRepos.filter(
-      (repo, index, self) =>
-        index === self.findIndex((r) => r.full_name === repo.full_name),
-    );
-    uniqueRepos.sort((a, b) =>
-      a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+  if (normalizedQuery) {
+    const perPage = normalizedLimit ?? 50;
+    const ownerQualifier = apiEndpointType === "org" ? "org" : "user";
+    const searchQuery = `${normalizedQuery} in:name ${ownerQualifier}:${owner}`;
+    const searchEndpoint = `/search/repositories?q=${encodeURIComponent(searchQuery)}&per_page=${perPage}`;
+    const searchResult = await fetchGitHubAPI<GitHubSearchResponse>(
+      searchEndpoint,
+      token,
     );
 
-    return uniqueRepos.map((repo) => ({
+    if (!searchResult) return null;
+
+    return searchResult.items.map((repo) => ({
       name: repo.name,
       full_name: repo.full_name,
       description: repo.description,
@@ -150,10 +143,78 @@ export const getCachedGitHubRepos = unstable_cache(
       updated_at: repo.updated_at,
       language: repo.language,
     }));
-  },
-  ["github-repos"],
-  { revalidate: CACHE_REVALIDATE_SECONDS },
-);
+  }
+
+  // Fetch all repos with pagination
+  const allRepos: GitHubRepo[] = [];
+  let page = 1;
+  const perPage = normalizedLimit ?? 100;
+  const maxPages = normalizedLimit ? 1 : 50;
+
+  while (page <= maxPages) {
+    let endpoint: string;
+
+    if (apiEndpointType === "user") {
+      endpoint = `/user/repos?sort=name&direction=asc&per_page=${perPage}&page=${page}&visibility=all&affiliation=owner`;
+    } else if (apiEndpointType === "org") {
+      endpoint = `/orgs/${owner}/repos?sort=name&direction=asc&per_page=${perPage}&page=${page}&type=all&visibility=all`;
+    } else {
+      endpoint = `/users/${owner}/repos?sort=name&direction=asc&per_page=${perPage}&page=${page}`;
+    }
+
+    const repos = await fetchGitHubAPI<GitHubRepo[]>(endpoint, token);
+    if (!repos) {
+      // API error on first page means failure; on subsequent pages, return what we have
+      if (page === 1) return null;
+      break;
+    }
+    if (repos.length === 0) break;
+
+    allRepos.push(...repos);
+    if (repos.length < perPage) break;
+    page++;
+  }
+
+  // Dedupe and sort
+  const uniqueRepos = allRepos.filter(
+    (repo, index, self) =>
+      index === self.findIndex((r) => r.full_name === repo.full_name),
+  );
+  uniqueRepos.sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+  );
+
+  const mappedRepos = uniqueRepos.map((repo) => ({
+    name: repo.name,
+    full_name: repo.full_name,
+    description: repo.description,
+    private: repo.private,
+    clone_url: repo.clone_url,
+    updated_at: repo.updated_at,
+    language: repo.language,
+  }));
+
+  if (normalizedLimit) {
+    return mappedRepos.slice(0, normalizedLimit);
+  }
+
+  return mappedRepos;
+}
+
+export function getCachedGitHubRepos(
+  userId: string,
+  token: string,
+  owner: string,
+  options?: GitHubRepoOptions,
+) {
+  // Create a cached version with user-specific tag for invalidation
+  const cachedFn = unstable_cache(fetchGitHubReposInternal, ["github-repos"], {
+    revalidate: CACHE_REVALIDATE_SECONDS,
+    tags: [getGitHubReposCacheTag(userId)],
+  });
+
+  return cachedFn(userId, token, owner, options);
+}
 
 export const getCachedGitHubBranches = unstable_cache(
   async (userId: string, token: string, owner: string, repo: string) => {


### PR DESCRIPTION
## Summary
- add repo API support for `limit` and `query` params and pass options to cached GitHub repo fetches
- add user-scoped repo cache tags and a revalidation endpoint at `/api/github/repos/revalidate`
- update both repo selector UIs to support debounced repo search, capped result lists, and manual refresh
- include `read:org` in GitHub OAuth scopes for org repo discovery

## Testing
- not run (not requested)