### PR TITLE
web: replace custom diff rendering with @pierre/diffs

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/diff-viewer.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/diff-viewer.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 import { ChevronDown, ChevronRight, X, FileText, Loader2 } from "lucide-react";
+import { PatchDiff } from "@pierre/diffs/react";
 import { cn } from "@/lib/utils";
+import { defaultDiffOptions } from "@/lib/diffs-config";
 import { Button } from "@/components/ui/button";
 import type { DiffFile } from "@/app/api/sessions/[sessionId]/diff/route";
 import { useSessionChatContext } from "./session-chat-context";
@@ -10,62 +12,6 @@ import { useSessionChatContext } from "./session-chat-context";
 type DiffViewerProps = {
   onClose: () => void;
 };
-
-type DiffLineType = "context" | "addition" | "deletion" | "header" | "info";
-
-type ParsedDiffLine = {
-  type: DiffLineType;
-  content: string;
-  oldLineNum?: number;
-  newLineNum?: number;
-};
-
-function parseDiffContent(diff: string): ParsedDiffLine[] {
-  const lines: ParsedDiffLine[] = [];
-  let oldLine = 0;
-  let newLine = 0;
-
-  for (const line of diff.split("\n")) {
-    if (line.startsWith("diff --git")) {
-      lines.push({ type: "header", content: line });
-    } else if (
-      line.startsWith("index ") ||
-      line.startsWith("---") ||
-      line.startsWith("+++")
-    ) {
-      lines.push({ type: "info", content: line });
-    } else if (line.startsWith("@@")) {
-      // Parse hunk header: @@ -start,count +start,count @@
-      const match = line.match(/@@ -(\d+),?\d* \+(\d+),?\d* @@/);
-      if (match) {
-        oldLine = parseInt(match[1] ?? "1", 10);
-        newLine = parseInt(match[2] ?? "1", 10);
-      }
-      lines.push({ type: "info", content: line });
-    } else if (line.startsWith("+")) {
-      lines.push({
-        type: "addition",
-        content: line.slice(1),
-        newLineNum: newLine++,
-      });
-    } else if (line.startsWith("-")) {
-      lines.push({
-        type: "deletion",
-        content: line.slice(1),
-        oldLineNum: oldLine++,
-      });
-    } else if (line.startsWith(" ") || line === "") {
-      lines.push({
-        type: "context",
-        content: line.slice(1) || "",
-        oldLineNum: oldLine++,
-        newLineNum: newLine++,
-      });
-    }
-  }
-
-  return lines;
-}
 
 function formatTimestamp(date: Date) {
   return date.toLocaleString("en-US", {
@@ -129,7 +75,6 @@ function FileEntry({
   isExpanded: boolean;
   onToggle: () => void;
 }) {
-  const parsedLines = parseDiffContent(file.diff);
   const fileName = file.path.split("/").pop() ?? file.path;
   const dirPath = file.path.slice(0, -fileName.length);
 
@@ -165,57 +110,9 @@ function FileEntry({
         </div>
       </button>
 
-      {isExpanded && parsedLines.length > 0 && (
-        <div className="overflow-x-auto border-t border-border bg-muted/30">
-          <div className="min-w-max font-mono text-xs">
-            {parsedLines.map((line, i) => {
-              if (line.type === "header" || line.type === "info") {
-                return (
-                  <div
-                    key={i}
-                    className="flex bg-muted/50 px-2 py-0.5 text-muted-foreground"
-                  >
-                    <span className="w-16 shrink-0" />
-                    <span className="truncate">{line.content}</span>
-                  </div>
-                );
-              }
-
-              return (
-                <div
-                  key={i}
-                  className={cn(
-                    "flex",
-                    line.type === "addition" && "bg-green-950/40",
-                    line.type === "deletion" && "bg-red-950/40",
-                  )}
-                >
-                  <span className="w-8 shrink-0 select-none border-r border-border px-1 py-0.5 text-right text-muted-foreground">
-                    {line.oldLineNum ?? ""}
-                  </span>
-                  <span className="w-8 shrink-0 select-none border-r border-border px-1 py-0.5 text-right text-muted-foreground">
-                    {line.newLineNum ?? ""}
-                  </span>
-                  <span
-                    className={cn(
-                      "w-4 shrink-0 select-none py-0.5 text-center",
-                      line.type === "addition" && "text-green-500",
-                      line.type === "deletion" && "text-red-400",
-                    )}
-                  >
-                    {line.type === "addition"
-                      ? "+"
-                      : line.type === "deletion"
-                        ? "-"
-                        : " "}
-                  </span>
-                  <span className="flex-1 whitespace-pre py-0.5 pr-2">
-                    {line.content}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
+      {isExpanded && file.diff && (
+        <div className="border-t border-border">
+          <PatchDiff patch={file.diff} options={defaultDiffOptions} />
         </div>
       )}
     </div>
@@ -253,7 +150,7 @@ export function DiffViewer({ onClose }: DiffViewerProps) {
   };
 
   return (
-    <div className="flex h-full w-[500px] flex-col border-l border-border bg-card">
+    <div className="flex h-full w-[500px] min-w-0 flex-col overflow-hidden border-l border-border bg-card">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <div className="flex items-center gap-3">

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
@@ -7,6 +7,7 @@ import {
   getSessionById,
 } from "@/lib/db/sessions";
 import { getServerSession } from "@/lib/session/get-server-session";
+import { DiffsProvider } from "@/components/diffs-provider";
 import { SessionChatProvider } from "./session-chat-context";
 import { SessionChatContent } from "./session-chat-content";
 
@@ -57,12 +58,14 @@ export default async function SessionChatPage({
   const initialMessages = dbMessages.map((m) => m.parts as WebAgentUIMessage);
 
   return (
-    <SessionChatProvider
-      session={sessionRecord}
-      chat={chat}
-      initialMessages={initialMessages}
-    >
-      <SessionChatContent />
-    </SessionChatProvider>
+    <DiffsProvider>
+      <SessionChatProvider
+        session={sessionRecord}
+        chat={chat}
+        initialMessages={initialMessages}
+      >
+        <SessionChatContent />
+      </SessionChatProvider>
+    </DiffsProvider>
   );
 }

--- a/apps/web/components/diffs-provider.tsx
+++ b/apps/web/components/diffs-provider.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { WorkerPoolContextProvider } from "@pierre/diffs/react";
+
+export function DiffsProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <WorkerPoolContextProvider
+      poolOptions={{
+        poolSize: 2,
+        workerFactory: () =>
+          new Worker(
+            new URL("@pierre/diffs/worker/worker.js", import.meta.url),
+          ),
+      }}
+      highlighterOptions={{
+        theme: "github-dark",
+        langs: [],
+      }}
+    >
+      {children}
+    </WorkerPoolContextProvider>
+  );
+}

--- a/apps/web/components/tool-call/renderers/edit-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/edit-renderer.tsx
@@ -3,9 +3,10 @@
 import { Loader2 } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
+import { MultiFileDiff } from "@pierre/diffs/react";
 import { toRelativePath } from "@open-harness/shared/lib/tool-state";
-import { createEditDiffLines } from "@open-harness/shared/lib/diff";
 import type { ToolRendererProps } from "@/app/lib/render-tool";
+import { defaultDiffOptions } from "@/lib/diffs-config";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "../approval-buttons";
 
@@ -24,16 +25,10 @@ export function EditRenderer({
   const oldString = input?.oldString ?? "";
   const newString = input?.newString ?? "";
 
-  // Collapsed view: limited to 10 lines
-  const { lines, additions, removals } = createEditDiffLines(
-    oldString,
-    newString,
-    1,
-    10,
-  );
-
-  // Expanded view: show all lines (up to 500)
-  const fullDiff = createEditDiffLines(oldString, newString, 3, 500);
+  const oldLines = oldString.split("\n");
+  const newLines = newString.split("\n");
+  const additions = newLines.filter((l) => !oldLines.includes(l)).length;
+  const removals = oldLines.filter((l) => !newLines.includes(l)).length;
 
   const output = part.state === "output-available" ? part.output : undefined;
   const outputError =
@@ -57,11 +52,8 @@ export function EditRenderer({
           ? "bg-red-500"
           : "bg-green-500";
 
-  // Has expandable content if the diff is large
-  const hasExpandableContent =
-    fullDiff.lines.length > lines.length ||
-    oldString.length > 200 ||
-    newString.length > 200;
+  // Has expandable content if strings are substantial
+  const hasExpandableContent = oldString.length > 200 || newString.length > 200;
 
   const handleClick = () => {
     if (hasExpandableContent) {
@@ -77,51 +69,6 @@ export function EditRenderer({
       }
     }
   };
-
-  const renderDiffLines = (
-    diffLines: ReturnType<typeof createEditDiffLines>["lines"],
-  ) => (
-    <div className="overflow-hidden rounded border border-border bg-muted font-mono text-xs">
-      {diffLines.map((line, i) => (
-        <div
-          key={i}
-          className={cn(
-            "flex",
-            line.type === "addition" && "bg-green-950/50",
-            line.type === "removal" && "bg-red-950/50",
-          )}
-        >
-          {line.type === "separator" ? (
-            <span className="px-2 py-0.5 text-muted-foreground">
-              {line.content}
-            </span>
-          ) : (
-            <>
-              <span className="w-10 shrink-0 px-2 py-0.5 text-right text-muted-foreground">
-                {line.lineNumber ?? ""}
-              </span>
-              <span
-                className={cn(
-                  "w-4 shrink-0 py-0.5 text-center",
-                  line.type === "addition" && "text-green-500",
-                  line.type === "removal" && "text-red-500",
-                )}
-              >
-                {line.type === "addition"
-                  ? "+"
-                  : line.type === "removal"
-                    ? "-"
-                    : " "}
-              </span>
-              <span className="truncate py-0.5 pr-2 text-foreground">
-                {isExpanded ? line.content : line.content.slice(0, 80)}
-              </span>
-            </>
-          )}
-        </div>
-      ))}
-    </div>
-  );
 
   return (
     <div
@@ -192,9 +139,13 @@ export function EditRenderer({
               </span>
             </div>
 
-            {lines.length > 0 && (
-              <div className="ml-5 mt-2">{renderDiffLines(lines)}</div>
-            )}
+            <div className="ml-5 mt-2 max-h-40 overflow-hidden">
+              <MultiFileDiff
+                oldFile={{ name: rawFilePath, contents: oldString }}
+                newFile={{ name: rawFilePath, contents: newString }}
+                options={defaultDiffOptions}
+              />
+            </div>
           </>
         )}
 
@@ -206,22 +157,21 @@ export function EditRenderer({
             <span className="font-medium">{filePath}</span>
             <span> with </span>
             <span className="text-green-500">
-              {fullDiff.additions} addition{fullDiff.additions !== 1 ? "s" : ""}
+              {additions} addition{additions !== 1 ? "s" : ""}
             </span>
             <span> and </span>
             <span className="text-red-500">
-              {fullDiff.removals} removal{fullDiff.removals !== 1 ? "s" : ""}
+              {removals} removal{removals !== 1 ? "s" : ""}
             </span>
           </div>
 
           {/* Full diff view */}
-          <div>
-            <div className="mb-1 text-xs font-medium text-muted-foreground">
-              Full Diff
-            </div>
-            <div className="max-h-96 overflow-auto">
-              {renderDiffLines(fullDiff.lines)}
-            </div>
+          <div className="max-h-96 overflow-auto">
+            <MultiFileDiff
+              oldFile={{ name: rawFilePath, contents: oldString }}
+              newFile={{ name: rawFilePath, contents: newString }}
+              options={defaultDiffOptions}
+            />
           </div>
 
           {/* Raw old/new strings for debugging */}

--- a/apps/web/components/tool-call/renderers/edit-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/edit-renderer.tsx
@@ -27,8 +27,21 @@ export function EditRenderer({
 
   const oldLines = oldString.split("\n");
   const newLines = newString.split("\n");
-  const additions = newLines.filter((l) => !oldLines.includes(l)).length;
-  const removals = oldLines.filter((l) => !newLines.includes(l)).length;
+
+  // Count additions and removals using multiset comparison to handle duplicate lines
+  const oldCounts = new Map<string, number>();
+  for (const l of oldLines) oldCounts.set(l, (oldCounts.get(l) ?? 0) + 1);
+  const newCounts = new Map<string, number>();
+  for (const l of newLines) newCounts.set(l, (newCounts.get(l) ?? 0) + 1);
+
+  let additions = 0;
+  for (const [line, count] of newCounts) {
+    additions += Math.max(0, count - (oldCounts.get(line) ?? 0));
+  }
+  let removals = 0;
+  for (const [line, count] of oldCounts) {
+    removals += Math.max(0, count - (newCounts.get(line) ?? 0));
+  }
 
   const output = part.state === "output-available" ? part.output : undefined;
   const outputError =

--- a/apps/web/components/tool-call/renderers/write-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/write-renderer.tsx
@@ -3,9 +3,10 @@
 import { Loader2 } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
+import { File as DiffsFile } from "@pierre/diffs/react";
 import { toRelativePath } from "@open-harness/shared/lib/tool-state";
-import { createNewFileCodeLines } from "@open-harness/shared/lib/diff";
 import type { ToolRendererProps } from "@/app/lib/render-tool";
+import { defaultFileOptions } from "@/lib/diffs-config";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "../approval-buttons";
 
@@ -23,12 +24,8 @@ export function WriteRenderer({
     rawFilePath === "..." ? rawFilePath : toRelativePath(rawFilePath, cwd);
   const content = input?.content ?? "";
 
-  const { lines, totalLines, hiddenLines } = createNewFileCodeLines(
-    content,
-    rawFilePath,
-    undefined,
-    10,
-  );
+  const totalLines = content.split("\n").length;
+  const hiddenLines = Math.max(0, totalLines - 10);
 
   const output = part.state === "output-available" ? part.output : undefined;
   const outputError =
@@ -135,20 +132,12 @@ export function WriteRenderer({
               </span>
             </div>
 
-            {lines.length > 0 && (
-              <div className="ml-5 mt-2 overflow-hidden rounded border border-border bg-muted p-2 font-mono text-xs">
-                {lines.map((line, i) => (
-                  <div key={i} className="truncate text-foreground">
-                    {line.content}
-                  </div>
-                ))}
-                {hiddenLines > 0 && (
-                  <div className="text-muted-foreground">
-                    ... {hiddenLines} more line{hiddenLines !== 1 ? "s" : ""}
-                  </div>
-                )}
-              </div>
-            )}
+            <div className="ml-5 mt-2 max-h-40 overflow-hidden">
+              <DiffsFile
+                file={{ name: rawFilePath, contents: content }}
+                options={defaultFileOptions}
+              />
+            </div>
           </>
         )}
 
@@ -164,13 +153,11 @@ export function WriteRenderer({
             </span>
           </div>
 
-          <div>
-            <div className="mb-1 text-xs font-medium text-muted-foreground">
-              Full Content
-            </div>
-            <pre className="max-h-96 overflow-auto whitespace-pre-wrap rounded border border-border bg-muted p-2 font-mono text-xs text-foreground">
-              {content}
-            </pre>
+          <div className="max-h-96 overflow-auto">
+            <DiffsFile
+              file={{ name: rawFilePath, contents: content }}
+              options={defaultFileOptions}
+            />
           </div>
         </div>
       )}

--- a/apps/web/lib/diffs-config.ts
+++ b/apps/web/lib/diffs-config.ts
@@ -1,0 +1,30 @@
+import type { BaseCodeOptions, BaseDiffOptions } from "@pierre/diffs/react";
+
+const unsafeCSS = `
+  :host {
+    display: block;
+    max-width: 100%;
+    --diffs-bg: var(--background);
+    --diffs-fg: var(--foreground);
+    --diffs-font-family: var(--font-geist-mono);
+    --diffs-tab-size: 2;
+    --diffs-gap-inline: 8px;
+    --diffs-gap-block: 0px;
+  }
+`;
+
+export const defaultDiffOptions = {
+  theme: "github-dark",
+  diffStyle: "unified",
+  diffIndicators: "classic",
+  overflow: "scroll",
+  disableFileHeader: true,
+  unsafeCSS,
+} satisfies BaseDiffOptions;
+
+export const defaultFileOptions = {
+  theme: "github-dark",
+  overflow: "scroll",
+  disableFileHeader: true,
+  unsafeCSS,
+} satisfies BaseCodeOptions;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@open-harness/agent": "workspace:*",
     "@open-harness/sandbox": "workspace:*",
     "@open-harness/shared": "workspace:*",
+    "@pierre/diffs": "^1.0.10",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
         "@open-harness/agent": "workspace:*",
         "@open-harness/sandbox": "workspace:*",
         "@open-harness/shared": "workspace:*",
+        "@pierre/diffs": "^1.0.10",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -550,6 +551,8 @@
 
     "@oxlint/win32-x64": ["@oxlint/win32-x64@1.38.0", "", { "os": "win32", "cpu": "x64" }, "sha512-7IuZMYiZiOcgg5zHvpJY6jRlEwh8EB/uq7GsoQJO9hANq96TIjyntGByhIjFSsL4asyZmhTEki+MO/u5Fb/WQA=="],
 
+    "@pierre/diffs": ["@pierre/diffs@1.0.10", "", { "dependencies": { "@shikijs/core": "^3.0.0", "@shikijs/engine-javascript": "^3.0.0", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-ahkpfS30NfaB+PBxnf0/Mc20ySBRTQmM28a7Ojpd0UZixmTyhGhJfBFjvmhX8dSzR22lB3h3OIMMxpB4yYTIOQ=="],
+
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
@@ -639,6 +642,8 @@
     "@shikijs/langs": ["@shikijs/langs@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0" } }, "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA=="],
 
     "@shikijs/themes": ["@shikijs/themes@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0" } }, "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw=="],
+
+    "@shikijs/transformers": ["@shikijs/transformers@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/types": "3.22.0" } }, "sha512-E7eRV7mwDBjueLF6852n2oYeJYxBq3NSsDk+uyruYAXONv4U8holGmIrT+mPRJQ1J1SNOH6L8G19KRzmBawrFw=="],
 
     "@shikijs/types": ["@shikijs/types@3.21.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA=="],
 
@@ -1156,6 +1161,8 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
+    "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
+
     "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -1624,6 +1631,8 @@
 
     "@oslojs/jwt/@oslojs/encoding": ["@oslojs/encoding@0.4.1", "", {}, "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q=="],
 
+    "@pierre/diffs/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
@@ -1693,6 +1702,10 @@
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@shikijs/transformers/@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
+
+    "@shikijs/transformers/@shikijs/types": ["@shikijs/types@3.22.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 


### PR DESCRIPTION
## Summary
- Replace hand-rolled diff parsing/rendering in the web app with `@pierre/diffs` components (`PatchDiff`, `MultiFileDiff`, `File`)
- Add `DiffsProvider` with worker pool for offloading diff computation and syntax highlighting
- Remove ~220 lines of custom diff rendering code across `diff-viewer.tsx`, `edit-renderer.tsx`, and `write-renderer.tsx`

## Test plan
- [ ] Verify diff viewer panel renders file diffs with syntax highlighting
- [ ] Verify edit tool calls show correct inline diffs (collapsed and expanded)
- [ ] Verify write tool calls show syntax-highlighted file content
- [ ] Confirm no regressions in approval flow UI for edit/write tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)