### PR TITLE
Refactor env setup to sync selective Vercel vars per app

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -22,10 +22,39 @@ fi
 
 if command -v vc >/dev/null 2>&1; then
   echo "Syncing Vercel env..."
-  "$REPO_ROOT/scripts/refresh-vercel-token.sh"
+  vc env pull "$REPO_ROOT/.env.local" --cwd "$REPO_ROOT"
+
   if [[ -f "$REPO_ROOT/.env.local" ]]; then
-    cp "$REPO_ROOT/.env.local" "$REPO_ROOT/apps/web/.env"
-    echo "✓ Copied .env.local to apps/web/.env"
+    # Variables to sync from .env.local into apps/web/.env
+    WEB_SYNC_VARS=(
+      VERCEL_OIDC_TOKEN
+      BLOB_READ_WRITE_TOKEN
+      REDIS_URL
+      VERCEL_APP_CLIENT_SECRET
+      NEXT_PUBLIC_VERCEL_APP_CLIENT_ID
+      NEXT_PUBLIC_GITHUB_CLIENT_ID
+      GITHUB_CLIENT_SECRET
+    )
+
+    for var in "${WEB_SYNC_VARS[@]}"; do
+      value=$(grep "^${var}=" "$REPO_ROOT/.env.local" | head -1) || true
+      if [[ -n "$value" ]]; then
+        # Remove existing line and append fresh value
+        grep -v "^${var}=" "$REPO_ROOT/apps/web/.env" > "$REPO_ROOT/apps/web/.env.tmp" || true
+        mv "$REPO_ROOT/apps/web/.env.tmp" "$REPO_ROOT/apps/web/.env"
+        echo "$value" >> "$REPO_ROOT/apps/web/.env"
+      fi
+    done
+    echo "✓ Synced Vercel env vars into apps/web/.env"
+
+    # Sync VERCEL_OIDC_TOKEN into CLI .env
+    cli_token=$(grep "^VERCEL_OIDC_TOKEN=" "$REPO_ROOT/.env.local" | head -1) || true
+    if [[ -n "$cli_token" ]]; then
+      grep -v "^VERCEL_OIDC_TOKEN=" "$REPO_ROOT/apps/cli/.env" > "$REPO_ROOT/apps/cli/.env.tmp" || true
+      mv "$REPO_ROOT/apps/cli/.env.tmp" "$REPO_ROOT/apps/cli/.env"
+      echo "$cli_token" >> "$REPO_ROOT/apps/cli/.env"
+      echo "✓ Synced VERCEL_OIDC_TOKEN into apps/cli/.env"
+    fi
   fi
 else
   echo "Vercel CLI (vc) not found. Install it and run scripts/refresh-vercel-token.sh after \"vc link\"."


### PR DESCRIPTION
Replace manual token refresh with native `vc env pull` and selective variable syncing.

- Use `vc env pull` to fetch Vercel environment variables instead of custom refresh script
- Sync only necessary variables to each app (web and cli) rather than copying entire .env file
- Add explicit list of variables needed by apps/web (VERCEL_OIDC_TOKEN, BLOB_READ_WRITE_TOKEN, REDIS_URL, etc.)
- Handle VERCEL_OIDC_TOKEN separately for apps/cli to avoid duplication