### PR TITLE
Fix sandbox lifecycle snapshot reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,5 @@ Use `catalog:` for shared external versions:
 - When the lifecycle workflow inline fallback runs (SDK unavailable), it evaluates immediately and skips because the sandbox isn't due yet; the status endpoint should detect overdue `hibernateAfter` and kick the lifecycle as a safety net.
 - Lifecycle workflow must retry after a `skipped/not-due-yet` evaluation; without retry the sandbox never hibernates unless a new event kicks a fresh workflow.
 - Next.js `after()` defers callbacks until the response is fully sent; for streaming endpoints this means `after()` runs after the entire stream completes, not at call time. Use fire-and-forget (`void run()`) for lifecycle kicks that must happen at request start.
+- For lifecycle workflow kicks in request handlers, call `kickSandboxLifecycleWorkflow(...)` directly instead of wrapping it in `after(...)`; delayed/deferred scheduling can miss the initial hibernation timer for idle sessions.
+- Hybrid sandbox wrappers must delegate `snapshot()` to the underlying cloud sandbox after handoff; if `snapshot` is missing on hybrid, lifecycle hibernation skips snapshotting and expired sessions fall back to creating a new sandbox.

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -6,7 +6,6 @@ import {
   type LanguageModelUsage,
 } from "ai";
 import { nanoid } from "nanoid";
-import { after } from "next/server";
 import { webAgent } from "@/app/config";
 import type { WebAgentUIMessage } from "@/app/types";
 import {
@@ -22,11 +21,11 @@ import {
 import { getUserGitHubToken } from "@/lib/github/user-token";
 import { DEFAULT_MODEL_ID } from "@/lib/models";
 import { resumableStreamContext } from "@/lib/resumable-stream-context";
-import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
 import { buildActiveLifecycleUpdate } from "@/lib/sandbox/lifecycle";
-import { onStopSignal } from "@/lib/stop-signal";
+import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
+import { onStopSignal } from "@/lib/stop-signal";
 
 // Allow streaming responses up to 5 minutes per response turn.
 export const maxDuration = 300;
@@ -289,7 +288,6 @@ export async function POST(req: Request) {
                 kickSandboxLifecycleWorkflow({
                   sessionId,
                   reason: "chat-finished",
-                  scheduleBackgroundWork: (cb) => after(cb),
                 });
                 return;
               }
@@ -303,7 +301,6 @@ export async function POST(req: Request) {
             kickSandboxLifecycleWorkflow({
               sessionId,
               reason: "chat-finished",
-              scheduleBackgroundWork: (cb) => after(cb),
             });
           } catch (error) {
             console.error("Failed to persist sandbox state:", error);

--- a/apps/web/app/api/sandbox/route.test.ts
+++ b/apps/web/app/api/sandbox/route.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+interface TestSessionRecord {
+  id: string;
+  userId: string;
+  lifecycleVersion: number;
+  sandboxState: { type: "vercel" | "hybrid" | "just-bash" };
+}
+
+interface KickCall {
+  sessionId: string;
+  reason: string;
+  scheduleBackgroundWork?: (callback: () => Promise<void>) => void;
+}
+
+const kickCalls: KickCall[] = [];
+const updateCalls: Array<{
+  sessionId: string;
+  patch: Record<string, unknown>;
+}> = [];
+
+let sessionRecord: TestSessionRecord;
+
+function isConnectConfig(value: unknown): value is {
+  state: {
+    type: "vercel" | "hybrid" | "just-bash";
+    sandboxId?: string;
+  };
+} {
+  if (!value || typeof value !== "object") return false;
+  if (!("state" in value)) return false;
+  const state = value.state;
+  if (!state || typeof state !== "object") return false;
+  if (!("type" in state)) return false;
+  return (
+    state.type === "vercel" ||
+    state.type === "hybrid" ||
+    state.type === "just-bash"
+  );
+}
+
+mock.module("next/server", () => ({
+  after: (callback: () => void | Promise<void>) => {
+    void callback();
+  },
+}));
+
+mock.module("@/lib/session/get-server-session", () => ({
+  getServerSession: async () => ({
+    user: {
+      id: "user-1",
+      username: "nico",
+      name: "Nico",
+      email: "nico@example.com",
+    },
+  }),
+}));
+
+mock.module("@/lib/github/user-token", () => ({
+  getUserGitHubToken: async () => null,
+}));
+
+mock.module("@/lib/github/tarball", () => ({
+  downloadAndExtractTarball: async () => ({ files: {} }),
+}));
+
+mock.module("@/lib/db/sessions", () => ({
+  getSessionById: async () => sessionRecord,
+  updateSession: async (sessionId: string, patch: Record<string, unknown>) => {
+    updateCalls.push({ sessionId, patch });
+    return {
+      ...sessionRecord,
+      ...patch,
+    };
+  },
+}));
+
+mock.module("@/lib/sandbox/lifecycle-kick", () => ({
+  kickSandboxLifecycleWorkflow: (input: KickCall) => {
+    kickCalls.push(input);
+  },
+}));
+
+mock.module("@open-harness/sandbox", () => ({
+  connectSandbox: async (config: unknown) => {
+    const nextState: {
+      type: "vercel" | "hybrid";
+      sandboxId: string;
+      expiresAt: number;
+    } = isConnectConfig(config)
+      ? config.state.type === "vercel"
+        ? {
+            type: "vercel",
+            sandboxId: "sbx-vercel-1",
+            expiresAt: Date.now() + 120_000,
+          }
+        : {
+            type: "hybrid",
+            sandboxId: config.state.sandboxId ?? "sbx-hybrid-1",
+            expiresAt: Date.now() + 120_000,
+          }
+      : {
+          type: "vercel",
+          sandboxId: "sbx-default-1",
+          expiresAt: Date.now() + 120_000,
+        };
+
+    return {
+      currentBranch: "main",
+      workingDirectory: "/vercel/sandbox",
+      getState: () => nextState,
+      stop: async () => {},
+    };
+  },
+}));
+
+const routeModulePromise = import("./route");
+
+describe("/api/sandbox lifecycle kicks", () => {
+  beforeEach(() => {
+    kickCalls.length = 0;
+    updateCalls.length = 0;
+    sessionRecord = {
+      id: "session-1",
+      userId: "user-1",
+      lifecycleVersion: 3,
+      sandboxState: { type: "vercel" },
+    };
+  });
+
+  test("reconnect branch kicks lifecycle immediately", async () => {
+    const { POST } = await routeModulePromise;
+
+    const request = new Request("http://localhost/api/sandbox", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId: "session-1",
+        sandboxId: "sbx-existing-1",
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.ok).toBe(true);
+    expect(kickCalls.length).toBe(1);
+    expect(kickCalls[0]?.sessionId).toBe("session-1");
+    expect(kickCalls[0]?.reason).toBe("sandbox-created");
+    expect(kickCalls[0]?.scheduleBackgroundWork).toBeUndefined();
+  });
+
+  test("new vercel sandbox kicks lifecycle immediately", async () => {
+    const { POST } = await routeModulePromise;
+
+    const request = new Request("http://localhost/api/sandbox", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId: "session-1",
+        sandboxType: "vercel",
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.ok).toBe(true);
+    expect(kickCalls.length).toBe(1);
+    expect(kickCalls[0]?.sessionId).toBe("session-1");
+    expect(kickCalls[0]?.reason).toBe("sandbox-created");
+    expect(kickCalls[0]?.scheduleBackgroundWork).toBeUndefined();
+    expect(updateCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -8,11 +8,11 @@ import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { downloadAndExtractTarball } from "@/lib/github/tarball";
 import { getUserGitHubToken } from "@/lib/github/user-token";
 import { DEFAULT_SANDBOX_TIMEOUT_MS } from "@/lib/sandbox/config";
-import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
 import {
   buildActiveLifecycleUpdate,
   getNextLifecycleVersion,
 } from "@/lib/sandbox/lifecycle";
+import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
 import { canOperateOnSandbox, clearSandboxState } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 
@@ -118,7 +118,6 @@ export async function POST(req: Request) {
       kickSandboxLifecycleWorkflow({
         sessionId,
         reason: "sandbox-created",
-        scheduleBackgroundWork: (cb) => after(cb),
       });
     }
 
@@ -259,7 +258,6 @@ export async function POST(req: Request) {
     kickSandboxLifecycleWorkflow({
       sessionId,
       reason: "sandbox-created",
-      scheduleBackgroundWork: (cb) => after(cb),
     });
   }
 

--- a/apps/web/app/api/sandbox/status/route.test.ts
+++ b/apps/web/app/api/sandbox/status/route.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface KickCall {
+  sessionId: string;
+  reason: string;
+}
+
+const kickCalls: KickCall[] = [];
+
+const sessionRecord = {
+  id: "session-1",
+  userId: "user-1",
+  sandboxState: {
+    type: "vercel",
+    sandboxId: "sbx-1",
+    expiresAt: Date.now() + 5 * 60_000,
+  },
+  lifecycleState: "active",
+  lifecycleVersion: 10,
+  hibernateAfter: new Date(Date.now() - 2_000),
+  sandboxExpiresAt: new Date(Date.now() + 5 * 60_000),
+  snapshotUrl: null,
+  lastActivityAt: new Date(Date.now() - 5_000),
+};
+
+mock.module("@/lib/session/get-server-session", () => ({
+  getServerSession: async () => ({ user: { id: "user-1" } }),
+}));
+
+mock.module("@/lib/db/sessions", () => ({
+  getSessionById: async () => sessionRecord,
+}));
+
+mock.module("@/lib/sandbox/lifecycle-kick", () => ({
+  kickSandboxLifecycleWorkflow: (input: KickCall) => {
+    kickCalls.push(input);
+  },
+}));
+
+const routeModulePromise = import("./route");
+
+describe("/api/sandbox/status lifecycle safety net", () => {
+  beforeEach(() => {
+    kickCalls.length = 0;
+  });
+
+  test("kicks overdue lifecycle immediately", async () => {
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(
+      new Request("http://localhost/api/sandbox/status?sessionId=session-1"),
+    );
+
+    expect(response.ok).toBe(true);
+    expect(kickCalls.length).toBe(1);
+    expect(kickCalls[0]).toEqual({
+      sessionId: "session-1",
+      reason: "status-check-overdue",
+    });
+  });
+});

--- a/apps/web/app/api/sandbox/status/route.ts
+++ b/apps/web/app/api/sandbox/status/route.ts
@@ -1,4 +1,3 @@
-import { after } from "next/server";
 import { getSessionById } from "@/lib/db/sessions";
 import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
 import { hasRuntimeSandboxState } from "@/lib/sandbox/utils";
@@ -59,12 +58,10 @@ export async function GET(req: Request): Promise<Response> {
     const now = Date.now();
     const hibernateAfterMs = sessionRecord.hibernateAfter.getTime();
     if (isExpired || now >= hibernateAfterMs) {
-      after(() =>
-        kickSandboxLifecycleWorkflow({
-          sessionId: sessionRecord.id,
-          reason: "status-check-overdue",
-        }),
-      );
+      kickSandboxLifecycleWorkflow({
+        sessionId: sessionRecord.id,
+        reason: "status-check-overdue",
+      });
     }
   }
 

--- a/packages/sandbox/hybrid/sandbox.ts
+++ b/packages/sandbox/hybrid/sandbox.ts
@@ -12,7 +12,12 @@
  */
 
 import type { Dirent } from "fs";
-import type { ExecResult, Sandbox, SandboxStats } from "../interface";
+import type {
+  ExecResult,
+  Sandbox,
+  SandboxStats,
+  SnapshotResult,
+} from "../interface";
 import type { JustBashSandbox } from "../just-bash/sandbox";
 import type { PendingOperation, SandboxStatus } from "../types";
 import type { HybridState } from "./state";
@@ -278,6 +283,14 @@ export class HybridSandbox implements Sandbox {
       await this.vercel.stop();
     }
     // Don't stop JustBash - it will be serialized for persistence
+  }
+
+  async snapshot(): Promise<SnapshotResult> {
+    if (!this.vercel || !this.vercel.snapshot) {
+      throw new Error("Snapshot is only supported after cloud handoff");
+    }
+
+    return this.vercel.snapshot();
   }
 
   /**


### PR DESCRIPTION
## Summary
- trigger sandbox lifecycle workflow kicks immediately in sandbox/chat/status routes so idle sessions reliably schedule hibernation instead of relying on deferred `after(...)` callbacks
- add regression tests for `/api/sandbox` and `/api/sandbox/status` to assert lifecycle kicks are emitted in the expected paths
- delegate `snapshot()` in hybrid sandboxes to the underlying cloud sandbox after handoff so lifecycle hibernation can snapshot hybrid sessions too

## Validation
- `bun test \"apps/web/app/api/sandbox/route.test.ts\" \"apps/web/app/api/sandbox/status/route.test.ts\"`
- `turbo typecheck --filter=web`
- `turbo typecheck --filter=@open-harness/sandbox`