### PR TITLE
fix: unify env sync between worktree and setup script

### DIFF
--- a/.worktree-setup
+++ b/.worktree-setup
@@ -1,11 +1,14 @@
 #!/bin/zsh
 
 git fetch origin
-bun install
+
+# Copy env files from main worktree as base
 cp "$GWT_MAIN_PATH/apps/cli/.env" apps/cli/.env
 cp "$GWT_MAIN_PATH/apps/web/.env" apps/web/.env
 
+# Pull fresh Vercel env to main worktree and copy to this worktree
 vc env pull "$GWT_MAIN_PATH/.env.local" --cwd "$GWT_MAIN_PATH"
-grep "^VERCEL_OIDC_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/cli/.env
-grep "^VERCEL_OIDC_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/web/.env
-grep "^BLOB_READ_WRITE_TOKEN=" "$GWT_MAIN_PATH/.env.local" >> apps/web/.env
+cp "$GWT_MAIN_PATH/.env.local" .env.local
+
+# Delegate to setup script for dependency install and env sync
+./scripts/setup.sh --no-pull

--- a/bun.lock
+++ b/bun.lock
@@ -914,7 +914,7 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
-    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -1156,7 +1156,7 @@
 
     "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
 
-    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "bun-webgpu": ["bun-webgpu@0.1.4", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.4", "bun-webgpu-darwin-x64": "^0.1.4", "bun-webgpu-linux-x64": "^0.1.4", "bun-webgpu-win32-x64": "^0.1.4" } }, "sha512-Kw+HoXl1PMWJTh9wvh63SSRofTA8vYBFCw0XEP1V1fFdQEDhI8Sgf73sdndE/oDpN/7CMx0Yv/q8FCvO39ROMQ=="],
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+SKIP_PULL=false
+for arg in "$@"; do
+  case "$arg" in
+    --no-pull) SKIP_PULL=true ;;
+  esac
+done
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
@@ -20,44 +27,48 @@ if [[ ! -f "$REPO_ROOT/apps/web/.env" ]]; then
   echo "✓ Created apps/web/.env from .env.example"
 fi
 
-if command -v vc >/dev/null 2>&1; then
+if [[ "$SKIP_PULL" == true ]]; then
+  echo "Skipping vc env pull (--no-pull)"
+elif command -v vc >/dev/null 2>&1; then
   echo "Syncing Vercel env..."
   vc env pull "$REPO_ROOT/.env.local" --cwd "$REPO_ROOT"
+else
+  echo "Vercel CLI (vc) not found. Install it and run 'vc link' to enable env syncing."
+fi
 
-  if [[ -f "$REPO_ROOT/.env.local" ]]; then
-    # Variables to sync from .env.local into apps/web/.env
-    WEB_SYNC_VARS=(
-      VERCEL_OIDC_TOKEN
-      BLOB_READ_WRITE_TOKEN
-      REDIS_URL
-      VERCEL_APP_CLIENT_SECRET
-      NEXT_PUBLIC_VERCEL_APP_CLIENT_ID
-      NEXT_PUBLIC_GITHUB_CLIENT_ID
-      GITHUB_CLIENT_SECRET
-    )
+if [[ -f "$REPO_ROOT/.env.local" ]]; then
+  # Variables to sync from .env.local into apps/web/.env
+  WEB_SYNC_VARS=(
+    VERCEL_OIDC_TOKEN
+    BLOB_READ_WRITE_TOKEN
+    REDIS_URL
+    VERCEL_APP_CLIENT_SECRET
+    NEXT_PUBLIC_VERCEL_APP_CLIENT_ID
+    NEXT_PUBLIC_GITHUB_CLIENT_ID
+    GITHUB_CLIENT_SECRET
+  )
 
-    for var in "${WEB_SYNC_VARS[@]}"; do
-      value=$(grep "^${var}=" "$REPO_ROOT/.env.local" | head -1) || true
-      if [[ -n "$value" ]]; then
-        # Remove existing line and append fresh value
-        grep -v "^${var}=" "$REPO_ROOT/apps/web/.env" > "$REPO_ROOT/apps/web/.env.tmp" || true
-        mv "$REPO_ROOT/apps/web/.env.tmp" "$REPO_ROOT/apps/web/.env"
-        echo "$value" >> "$REPO_ROOT/apps/web/.env"
-      fi
-    done
-    echo "✓ Synced Vercel env vars into apps/web/.env"
-
-    # Sync VERCEL_OIDC_TOKEN into CLI .env
-    cli_token=$(grep "^VERCEL_OIDC_TOKEN=" "$REPO_ROOT/.env.local" | head -1) || true
-    if [[ -n "$cli_token" ]]; then
-      grep -v "^VERCEL_OIDC_TOKEN=" "$REPO_ROOT/apps/cli/.env" > "$REPO_ROOT/apps/cli/.env.tmp" || true
-      mv "$REPO_ROOT/apps/cli/.env.tmp" "$REPO_ROOT/apps/cli/.env"
-      echo "$cli_token" >> "$REPO_ROOT/apps/cli/.env"
-      echo "✓ Synced VERCEL_OIDC_TOKEN into apps/cli/.env"
+  for var in "${WEB_SYNC_VARS[@]}"; do
+    value=$(grep "^${var}=" "$REPO_ROOT/.env.local" | head -1) || true
+    if [[ -n "$value" ]]; then
+      # Remove existing line and append fresh value
+      grep -v "^${var}=" "$REPO_ROOT/apps/web/.env" > "$REPO_ROOT/apps/web/.env.tmp" || true
+      mv "$REPO_ROOT/apps/web/.env.tmp" "$REPO_ROOT/apps/web/.env"
+      echo "$value" >> "$REPO_ROOT/apps/web/.env"
     fi
+  done
+  echo "✓ Synced Vercel env vars into apps/web/.env"
+
+  # Sync VERCEL_OIDC_TOKEN into CLI .env
+  cli_token=$(grep "^VERCEL_OIDC_TOKEN=" "$REPO_ROOT/.env.local" | head -1) || true
+  if [[ -n "$cli_token" ]]; then
+    grep -v "^VERCEL_OIDC_TOKEN=" "$REPO_ROOT/apps/cli/.env" > "$REPO_ROOT/apps/cli/.env.tmp" || true
+    mv "$REPO_ROOT/apps/cli/.env.tmp" "$REPO_ROOT/apps/cli/.env"
+    echo "$cli_token" >> "$REPO_ROOT/apps/cli/.env"
+    echo "✓ Synced VERCEL_OIDC_TOKEN into apps/cli/.env"
   fi
 else
-  echo "Vercel CLI (vc) not found. Install it and run scripts/refresh-vercel-token.sh after \"vc link\"."
+  echo "No .env.local found. Run 'vc env pull' or use scripts/setup.sh without --no-pull."
 fi
 
 echo "Setup complete. Fill in any remaining env vars in apps/cli/.env (GitHub token) and apps/web/.env."


### PR DESCRIPTION
## Summary
- `.worktree-setup` now delegates to `./scripts/setup.sh --no-pull` instead of manually grepping individual env vars
- `setup.sh` accepts `--no-pull` flag to skip `vc env pull` (used when `.env.local` is already copied from the main worktree)
- Single source of truth for `WEB_SYNC_VARS` — no more maintaining env var lists in two places

## Test plan
- [ ] Run `./scripts/setup.sh` standalone — should pull env and sync all vars into `apps/web/.env`
- [ ] Verify worktree setup copies `.env.local` and delegates to setup script with `--no-pull`
- [ ] Confirm `VERCEL_APP_CLIENT_SECRET`, `NEXT_PUBLIC_VERCEL_APP_CLIENT_ID`, and `REDIS_URL` appear in `apps/web/.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)