### PR TITLE
fix: preserve chat streams across multi-chat navigation

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -22,6 +22,10 @@ import type { ReconnectResponse } from "@/app/api/sandbox/reconnect/route";
 import type { SandboxStatusResponse } from "@/app/api/sandbox/status/route";
 import { useSessionDiff } from "@/hooks/use-session-diff";
 import { useSessionFiles } from "@/hooks/use-session-files";
+import {
+  getOrCreateChatInstance,
+  removeChatInstance,
+} from "@/lib/chat-instance-manager";
 
 const KNOWN_SANDBOX_TYPES = ["just-bash", "vercel", "hybrid"] as const;
 type KnownSandboxType = (typeof KNOWN_SANDBOX_TYPES)[number];
@@ -238,13 +242,37 @@ export function SessionChatProvider({
 
   const hadInitialMessages = initialMessages.length > 0;
 
+  const { instance: chatInstance, alreadyExisted } = useMemo(
+    () =>
+      getOrCreateChatInstance(chatInfo.id, {
+        id: chatInfo.id,
+        transport,
+        messages: initialMessages,
+        sendAutomaticallyWhen: shouldAutoSubmit,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only create once per chatId; init values are only used at creation time
+    [chatInfo.id],
+  );
+
+  // Only resume on fresh page load (new Chat instance + active stream in DB).
+  // If instance already existed, the stream is either still running or finished —
+  // no resume needed since the instance tracked it the whole time.
+  const shouldResume = !alreadyExisted && !!initialChat.activeStreamId;
+
   const chat = useChat<WebAgentUIMessage>({
-    id: chatInfo.id,
-    transport,
-    messages: initialMessages,
-    resume: !!initialChat.activeStreamId,
-    sendAutomaticallyWhen: shouldAutoSubmit,
+    chat: chatInstance,
+    resume: shouldResume,
   });
+
+  // Cleanup: remove idle instances when leaving a chat
+  useEffect(() => {
+    return () => {
+      // Only clean up if the chat is not actively streaming
+      if (chatInstance.status === "ready") {
+        removeChatInstance(chatInfo.id);
+      }
+    };
+  }, [chatInfo.id, chatInstance]);
 
   const [sandboxInfo, setSandboxInfoState] = useState<SandboxInfo | null>(
     () => sandboxInfoCache.get(sessionId) ?? null,

--- a/apps/web/lib/chat-instance-manager.ts
+++ b/apps/web/lib/chat-instance-manager.ts
@@ -1,0 +1,23 @@
+import { Chat } from "@ai-sdk/react";
+import type { WebAgentUIMessage } from "@/app/types";
+
+type ChatInstanceInit = ConstructorParameters<
+  typeof Chat<WebAgentUIMessage>
+>[0];
+
+const chatInstances = new Map<string, Chat<WebAgentUIMessage>>();
+
+export function getOrCreateChatInstance(
+  chatId: string,
+  init: ChatInstanceInit,
+): { instance: Chat<WebAgentUIMessage>; alreadyExisted: boolean } {
+  const existing = chatInstances.get(chatId);
+  if (existing) return { instance: existing, alreadyExisted: true };
+  const instance = new Chat<WebAgentUIMessage>(init);
+  chatInstances.set(chatId, instance);
+  return { instance, alreadyExisted: false };
+}
+
+export function removeChatInstance(chatId: string): void {
+  chatInstances.delete(chatId);
+}

--- a/apps/web/lib/chat-instance-manager.ts
+++ b/apps/web/lib/chat-instance-manager.ts
@@ -5,6 +5,9 @@ type ChatInstanceInit = ConstructorParameters<
   typeof Chat<WebAgentUIMessage>
 >[0];
 
+// NOTE: Instances are retained while streaming (status !== "ready") and only
+// cleaned up when the user revisits the chat and then navigates away.
+// If usage scales to many concurrent chats, consider adding a size bound or TTL.
 const chatInstances = new Map<string, Chat<WebAgentUIMessage>>();
 
 export function getOrCreateChatInstance(

--- a/bun.lock
+++ b/bun.lock
@@ -914,7 +914,7 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
-    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -1156,7 +1156,7 @@
 
     "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
 
-    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "bun-webgpu": ["bun-webgpu@0.1.4", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.4", "bun-webgpu-darwin-x64": "^0.1.4", "bun-webgpu-linux-x64": "^0.1.4", "bun-webgpu-win32-x64": "^0.1.4" } }, "sha512-Kw+HoXl1PMWJTh9wvh63SSRofTA8vYBFCw0XEP1V1fFdQEDhI8Sgf73sdndE/oDpN/7CMx0Yv/q8FCvO39ROMQ=="],
 


### PR DESCRIPTION
## Summary
- Introduces a module-level `Chat` instance manager so streaming state survives navigation between chats in the same session
- Only resumes streams on fresh page loads (new instance + active stream in DB), avoiding duplicate resumes when returning to an already-tracked chat
- Cleans up idle instances on unmount; retains actively streaming ones for seamless navigation
- Makes sandbox lifecycle kicks fire immediately (`void run()`) instead of deferring via `after()`, ensuring snapshots happen reliably for streaming endpoints

## Test plan
- [ ] Start a chat stream, navigate to another chat in the same session, navigate back — stream should still be visible and progressing
- [ ] Hard-refresh the page while a stream is active — stream should resume via `shouldResume`
- [ ] Verify idle chats are cleaned up from the instance map on navigation away
- [ ] Confirm sandbox lifecycle hibernation triggers reliably after inactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)