### PR TITLE
feat: add skills CLI instructions to system prompt

### DIFF
--- a/packages/agent/system-prompt.ts
+++ b/packages/agent/system-prompt.ts
@@ -230,7 +230,15 @@ Available skills:
 ${skillsList}
 
 When a skill is relevant, invoke it IMMEDIATELY using the skill tool.
-If you see a <command-name> tag in the conversation, the skill is already loaded - follow its instructions directly.`;
+If you see a <command-name> tag in the conversation, the skill is already loaded - follow its instructions directly.
+
+To find and install new skills, use \`npx skills\`. Prefer \`-a amp\` (the universal agent format) so skills work across all agents.
+
+\`\`\`
+npx skills find <keyword>              # search for skills
+npx skills add vercel/ai -y -a amp     # install the AI SDK skill
+npx skills --help                      # all options
+\`\`\``;
 }
 
 export function buildSystemPrompt(options: BuildSystemPromptOptions): string {


### PR DESCRIPTION
## Summary
- Adds brief `npx skills` usage instructions to the skills section of the agent system prompt
- Guides the agent to use `-a amp` (universal agent format) and shows `find`, `add`, and `--help` commands

## Test plan
- [ ] Verify system prompt includes skills CLI instructions when skills are available
- [ ] Confirm agent can reference these instructions when asked about installing skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)