### PR TITLE
Improve sandbox lifecycle workflow scheduling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,3 +277,4 @@ Use `catalog:` for shared external versions:
 - Optimistic chat-title previews for `"New chat"` must have an explicit rollback on send failures; otherwise the sidebar can keep a title that was never persisted if the first request errors.
 - `hadInitialMessages` is an initial-load snapshot, not a live "first turn" signal; guard one-time optimistic UI (like first-message title previews) with a dedicated runtime ref/state that resets on send failure.
 - In the GitHub App install flow, do a user-token installation sync before redirecting after OAuth-only callbacks or treating zero local installation rows as "not installed"; GitHub can skip callback emissions for pre-existing installs.
+- For sandbox lifecycle kicks, do not persist `lifecycleRunId` before `start(...)`; start first and let the durable workflow claim/verify the lease so canceled fire-and-forget kicks cannot strand a stale lease.

--- a/apps/web/SANDBOX-LIFECYCLE.md
+++ b/apps/web/SANDBOX-LIFECYCLE.md
@@ -48,7 +48,7 @@ When the hard timeout is reached while the sandbox is still active, it hibernate
 
 ## How workflows work
 
-Each session keeps at most one durable workflow run. `kickSandboxLifecycleWorkflow()` starts the workflow only when no run is active and stores a lease token in `sessions.lifecycleRunId`. The workflow checks the lease before each sleep so older runs exit when replaced.
+Each session keeps at most one durable workflow run. `kickSandboxLifecycleWorkflow()` starts the workflow only when no run is active. The workflow then claims a lease token in `sessions.lifecycleRunId` and checks it before each sleep so older runs exit when replaced.
 
 A workflow run does:
 

--- a/apps/web/SANDBOX-LIFECYCLE.md
+++ b/apps/web/SANDBOX-LIFECYCLE.md
@@ -7,7 +7,7 @@ This document describes how sandbox lifecycle management works, including automa
 | Constant | Test | Production | Purpose |
 |---|---|---|---|
 | `DEFAULT_SANDBOX_TIMEOUT_MS` | 3 min | 5 hours | Hard VM expiry from Vercel |
-| `SANDBOX_INACTIVITY_TIMEOUT_MS` | 1 min | 30 min | Inactivity window before hibernate |
+| `SANDBOX_INACTIVITY_TIMEOUT_MS` | 20 min | 20 min | Inactivity window before hibernate |
 
 Configured in `lib/sandbox/config.ts`.
 
@@ -18,7 +18,7 @@ Configured in `lib/sandbox/config.ts`.
                         │ provisioning │
                         └──────┬───────┘
                                │ sandbox created
-                               │ kick workflow W1
+                               │ start workflow run
                                ▼
                    ┌──────────────────────┐
             ┌─────▶│       active          │◀──────────────────┐
@@ -38,71 +38,53 @@ Configured in `lib/sandbox/config.ts`.
             │  │activity  │  │  stops sandbox│    └────────────┘
             │  └──────────┘  └──────────────┘     user clicks
             │       │                              "Resume"
-            │       │ kick workflow W(n+1)          (restore)
+            │       │ workflow continues           (restore)
             └───────┘
 ```
 
 Where **I** = inactivity timeout, **H** = hard timeout.
 
-When the hard timeout is reached while the sandbox is still active, it hibernates the same way as inactivity — snapshot and stop. The user can manually resume if needed. This is simpler than automatic rollover and sufficient because the hard timeout (5 hours) is long enough that inactivity hibernation will almost always trigger first.
+When the hard timeout is reached while the sandbox is still active, it hibernates the same way as inactivity - snapshot and stop. The user can manually resume if needed. This is simpler than automatic rollover and sufficient because the hard timeout (5 hours) is long enough that inactivity hibernation will almost always trigger first.
 
 ## How workflows work
 
-Each lifecycle event calls `kickSandboxLifecycleWorkflow()`, which calls `start(sandboxLifecycleWorkflow, ...)` to create a **new, independent durable workflow run** via the Vercel Workflow DevKit.
+Each session keeps at most one durable workflow run. `kickSandboxLifecycleWorkflow()` starts the workflow only when no run is active and stores a lease token in `sessions.lifecycleRunId`. The workflow checks the lease before each sleep so older runs exit when replaced.
 
-A single workflow run does:
+A workflow run does:
 
-1. Read session from DB
-2. Compute `wakeAtMs = hibernateAfter`
-3. `sleep(wakeAtMs)` — durable sleep that survives deploys and serverless cold starts
+1. Read session from DB and verify the lease
+2. Compute `wakeAtMs = min(hibernateAfter, sandboxExpiresAt - buffer)`
+3. `sleep(wakeAtMs)` - durable sleep that survives deploys and serverless cold starts
 4. Wake up and evaluate:
-   - **User inactive** (`now >= hibernateAfter`) → **hibernate** (snapshot + stop)
-   - **Still active** → **skip** ("not-due-yet"), then retry once with fresh DB state
-5. Exit
-
-### Multiple concurrent workflows
-
-Each kick creates a new run. Multiple runs can coexist for the same session. This is safe because:
-
-- They all sleep until different wake times based on when they were kicked
-- The first one to act (hibernate) clears runtime state
-- Subsequent runs wake up, see no operable sandbox, and exit immediately
-- Workflow runs are cheap — sleep is free
+   - **User inactive** or **hard timeout reached** → **hibernate** (snapshot + stop)
+   - **Still active** → **skip** ("not-due-yet") and loop with fresh DB state
+5. Exit and clear `lifecycleRunId` when hibernated or no longer operable
 
 ### Example timeline
 
 ```
-T=0:00  Create sandbox → kick W1 (sleeps until T=1:00)
+T=0:00  Create sandbox → start W1 (sleeps until T=1:00)
 
 T=0:30  User sends message
-        chat-started: refresh activity, hibernateAfter=1:30
-        kick W2 (sleeps until T=1:30)
+        refresh activity, hibernateAfter=1:30
 
 T=0:45  Chat finishes
-        chat-finished: refresh activity, hibernateAfter=1:45
-        kick W3 (sleeps until T=1:45)
+        refresh activity, hibernateAfter=1:45
 
 T=1:00  W1 wakes → now < hibernateAfter(1:45) → SKIP
-        retry: re-compute, sleep until 1:45
+        re-compute, sleep until 1:45
 
-T=1:30  W2 wakes → now < hibernateAfter(1:45) → SKIP
-        retry: re-compute, sleep until 1:45
-
-T=1:45  W1, W2, W3 all wake
-        First to evaluate: now >= hibernateAfter → HIBERNATE
-        Others: see no operable sandbox → SKIP and exit
+T=1:45  W1 wakes
+        now >= hibernateAfter → HIBERNATE
 ```
 
-## Events that kick workflows
+## Events that start workflows
 
 | Event | Reason | Source |
 |---|---|---|
 | Sandbox created | `sandbox-created` | `POST /api/sandbox` |
 | Cloud sandbox ready (hybrid handoff) | `cloud-ready` | `onCloudSandboxReady` hook |
-| Chat request received | `chat-started` | `POST /api/chat` (before streaming) |
-| Chat response finished | `chat-finished` | `POST /api/chat` (`onFinish`) |
 | Manual extend | `timeout-extended` | `POST /api/sandbox/extend` |
-| Manual snapshot | `manual-snapshot` | `POST /api/sandbox/snapshot` |
 | Snapshot restore | `snapshot-restored` | `PUT /api/sandbox/snapshot` |
 | Status poll finds overdue sandbox | `status-check-overdue` | `GET /api/sandbox/status` |
 
@@ -110,31 +92,33 @@ T=1:45  W1, W2, W3 all wake
 
 `lastActivityAt` and `hibernateAfter` are refreshed:
 
-- **At chat start** — prevents hibernation during long-running AI responses
-- **At chat finish** — resets the inactivity window after each interaction
-- **On sandbox create/extend/restore** — resets after manual lifecycle events
+- **At chat start** - prevents hibernation during long-running AI responses
+- **At chat finish** - resets the inactivity window after each interaction
+- **On sandbox create/extend/restore** - resets after manual lifecycle events
+
+Activity refreshes do not start new workflow runs. The active workflow observes the updated timestamps on its next wake.
 
 These are **not** refreshed on:
-- **Reconnect probes** — otherwise every page load defeats the inactivity timer
-- **Status polling** — read-only DB check, no side effects on activity
+- **Reconnect probes** - otherwise every page load defeats the inactivity timer
+- **Status polling** - read-only DB check, no side effects on activity
 
 ## Safety nets
 
-1. **Status endpoint** (`GET /api/sandbox/status`) — polled every 15s by the client. If the sandbox is overdue for hibernation but the lifecycle hasn't acted, kicks a workflow via `after()`.
-2. **Workflow retry** — if evaluation returns "not-due-yet" (activity happened during sleep), re-computes wake time and tries once more before exiting.
-3. **Inline fallback** — if `start(workflow)` fails (workflow SDK unavailable in dev), runs `evaluateSandboxLifecycle()` synchronously as a fallback.
+1. **Status endpoint** (`GET /api/sandbox/status`) - polled every 15s by the client. If the sandbox is overdue for hibernation but the lifecycle hasn't acted, it triggers a workflow kick. If a run is already active, the kick is ignored.
+2. **Workflow retry** - if evaluation returns "not-due-yet" (activity happened during sleep), re-computes the next wake time and loops.
+3. **Inline fallback** - if `start(workflow)` fails (workflow SDK unavailable in dev), runs `evaluateSandboxLifecycle()` synchronously as a fallback.
 
 ## Client-side UI sync
 
 The client polls `GET /api/sandbox/status` every 15s to get the server's view of lifecycle state. The UI derives sandbox status from:
 
-- **Server lifecycle state** (`active`, `hibernated`, `hibernating`, etc.) — primary source
-- **Local sandbox info** (`createdAt + timeout`) — secondary, for countdown display
+- **Server lifecycle state** (`active`, `hibernated`, `hibernating`, etc.) - primary source
+- **Local sandbox info** (`createdAt + timeout`) - secondary, for countdown display
 
 The status chip shows:
-- **Active** — server says active AND local timeout hasn't expired
-- **Paused** — server says hibernated, or no runtime sandbox state with a snapshot available
-- **No sandbox** — no runtime state and no snapshot
+- **Active** - server says active AND local timeout hasn't expired
+- **Paused** - server says hibernated, or no runtime sandbox state with a snapshot available
+- **No sandbox** - no runtime state and no snapshot
 
 A forced status sync fires immediately after each chat completion (`streaming → ready`) to minimize the gap between server state change and UI update.
 

--- a/apps/web/SANDBOX-LIFECYCLE.md
+++ b/apps/web/SANDBOX-LIFECYCLE.md
@@ -60,6 +60,30 @@ A workflow run does:
    - **Still active** → **skip** ("not-due-yet") and loop with fresh DB state
 5. Exit and clear `lifecycleRunId` when hibernated or no longer operable
 
+### Simple flow
+
+- Start sandbox → start one workflow run
+- Workflow sleeps until the next due time
+- On wake, it either sleeps again or snapshots and stops
+- The workflow only updates its sleep after it wakes, not on every message
+
+### Scenarios
+
+Example 1: user keeps sending messages
+
+- T=0:00 sandbox starts, workflow sleeps until T=0:20
+- T=0:10 message, `hibernateAfter = 0:30`
+- T=0:20 workflow wakes, sees not due, sleeps until T=0:30
+- T=0:25 message, `hibernateAfter = 0:45`
+- T=0:30 workflow wakes, sees not due, sleeps until T=0:45
+
+Example 2: user stops after a message
+
+- T=0:00 sandbox starts, workflow sleeps until T=0:20
+- T=0:10 message, `hibernateAfter = 0:30`
+- T=0:20 workflow wakes, sees not due, sleeps until T=0:30
+- T=0:30 workflow wakes, sees due, snapshots and stops
+
 ### Example timeline
 
 ```
@@ -107,6 +131,7 @@ These are **not** refreshed on:
 1. **Status endpoint** (`GET /api/sandbox/status`) - polled every 15s by the client. If the sandbox is overdue for hibernation but the lifecycle hasn't acted, it triggers a workflow kick. If a run is already active, the kick is ignored.
 2. **Workflow retry** - if evaluation returns "not-due-yet" (activity happened during sleep), re-computes the next wake time and loops.
 3. **Inline fallback** - if `start(workflow)` fails (workflow SDK unavailable in dev), runs `evaluateSandboxLifecycle()` synchronously as a fallback.
+4. **Stale lease guard** - if a workflow lease is overdue by more than 2 minutes, clear the lease so a fresh run can start.
 
 ## Client-side UI sync
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -31,7 +31,6 @@ import { getUserGitHubToken } from "@/lib/github/user-token";
 import { DEFAULT_MODEL_ID } from "@/lib/models";
 import { resumableStreamContext } from "@/lib/resumable-stream-context";
 import { buildActiveLifecycleUpdate } from "@/lib/sandbox/lifecycle";
-import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 import { onStopSignal } from "@/lib/stop-signal";
@@ -454,11 +453,6 @@ export async function POST(req: Request) {
               ...buildActiveLifecycleUpdate(sandboxStateToPersist, {
                 activityAt,
               }),
-            });
-
-            kickSandboxLifecycleWorkflow({
-              sessionId,
-              reason: "chat-finished",
             });
           } catch (error) {
             console.error("Failed to persist sandbox state:", error);

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -332,6 +332,7 @@ export async function DELETE(req: Request) {
     lifecycleState: sessionRecord.snapshotUrl ? "hibernated" : "provisioning",
     sandboxExpiresAt: null,
     hibernateAfter: null,
+    lifecycleRunId: null,
     lifecycleError: null,
   });
 

--- a/apps/web/app/api/sandbox/snapshot/route.ts
+++ b/apps/web/app/api/sandbox/snapshot/route.ts
@@ -1,14 +1,14 @@
 import { connectSandbox } from "@open-harness/sandbox";
-import { getServerSession } from "@/lib/session/get-server-session";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { DEFAULT_SANDBOX_TIMEOUT_MS } from "@/lib/sandbox/config";
-import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
 import {
   buildActiveLifecycleUpdate,
   buildHibernatedLifecycleUpdate,
   getNextLifecycleVersion,
 } from "@/lib/sandbox/lifecycle";
-import { clearSandboxState, canOperateOnSandbox } from "@/lib/sandbox/utils";
+import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
+import { canOperateOnSandbox, clearSandboxState } from "@/lib/sandbox/utils";
+import { getServerSession } from "@/lib/session/get-server-session";
 
 interface CreateSnapshotRequest {
   sessionId: string;
@@ -76,11 +76,6 @@ export async function POST(req: Request) {
       sandboxState: clearedState,
       lifecycleVersion: getNextLifecycleVersion(sessionRecord.lifecycleVersion),
       ...buildHibernatedLifecycleUpdate(),
-    });
-
-    kickSandboxLifecycleWorkflow({
-      sessionId,
-      reason: "manual-snapshot",
     });
 
     return Response.json({

--- a/apps/web/app/api/sandbox/status/route.test.ts
+++ b/apps/web/app/api/sandbox/status/route.test.ts
@@ -21,6 +21,7 @@ const sessionRecord = {
   sandboxExpiresAt: new Date(Date.now() + 5 * 60_000),
   snapshotUrl: null,
   lastActivityAt: new Date(Date.now() - 5_000),
+  updatedAt: new Date(Date.now() - 5_000),
 };
 
 mock.module("@/lib/session/get-server-session", () => ({

--- a/apps/web/app/api/sandbox/status/route.ts
+++ b/apps/web/app/api/sandbox/status/route.ts
@@ -1,4 +1,6 @@
 import { getSessionById } from "@/lib/db/sessions";
+import { SANDBOX_EXPIRES_BUFFER_MS } from "@/lib/sandbox/config";
+import { getLifecycleDueAtMs } from "@/lib/sandbox/lifecycle";
 import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
 import { hasRuntimeSandboxState } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
@@ -43,21 +45,19 @@ export async function GET(req: Request): Promise<Response> {
   // Use the same 10s buffer as the chat route's isSandboxActive() so they agree.
   let isExpired = false;
   if (hasRuntimeState && sessionRecord.sandboxExpiresAt) {
-    isExpired = Date.now() >= sessionRecord.sandboxExpiresAt.getTime() - 10_000;
+    isExpired =
+      Date.now() >=
+      sessionRecord.sandboxExpiresAt.getTime() - SANDBOX_EXPIRES_BUFFER_MS;
   }
 
   const isActive = hasRuntimeState && !isExpired;
 
   // Safety net: if the sandbox has stale runtime state (expired or overdue for
   // hibernation), kick the lifecycle to clean up DB state in the background.
-  if (
-    hasRuntimeState &&
-    sessionRecord.lifecycleState === "active" &&
-    sessionRecord.hibernateAfter
-  ) {
+  if (hasRuntimeState && sessionRecord.lifecycleState === "active") {
     const now = Date.now();
-    const hibernateAfterMs = sessionRecord.hibernateAfter.getTime();
-    if (isExpired || now >= hibernateAfterMs) {
+    const dueAtMs = getLifecycleDueAtMs(sessionRecord);
+    if (isExpired || now >= dueAtMs) {
       kickSandboxLifecycleWorkflow({
         sessionId: sessionRecord.id,
         reason: "status-check-overdue",

--- a/apps/web/app/workflows/sandbox-lifecycle.ts
+++ b/apps/web/app/workflows/sandbox-lifecycle.ts
@@ -1,7 +1,8 @@
 import { sleep } from "workflow";
-import { getSessionById } from "@/lib/db/sessions";
+import { getSessionById, updateSession } from "@/lib/db/sessions";
 import {
   evaluateSandboxLifecycle,
+  getLifecycleDueAtMs,
   type SandboxLifecycleEvaluationResult,
   type SandboxLifecycleReason,
 } from "@/lib/sandbox/lifecycle";
@@ -15,12 +16,16 @@ interface LifecycleWakeDecision {
 
 async function computeLifecycleWakeDecision(
   sessionId: string,
+  runId: string,
 ): Promise<LifecycleWakeDecision> {
   "use step";
 
   const session = await getSessionById(sessionId);
   if (!session) {
     return { shouldContinue: false, reason: "session-not-found" };
+  }
+  if (session.lifecycleRunId !== runId) {
+    return { shouldContinue: false, reason: "run-replaced" };
   }
   if (session.status === "archived" || session.lifecycleState === "archived") {
     return { shouldContinue: false, reason: "session-archived" };
@@ -31,13 +36,9 @@ async function computeLifecycleWakeDecision(
     return { shouldContinue: false, reason: "sandbox-not-operable" };
   }
 
-  if (!session.hibernateAfter) {
-    return { shouldContinue: false, reason: "missing-hibernate-after" };
-  }
-
   return {
     shouldContinue: true,
-    wakeAtMs: session.hibernateAfter.getTime(),
+    wakeAtMs: getLifecycleDueAtMs(session),
   };
 }
 
@@ -49,44 +50,48 @@ async function runLifecycleEvaluation(
   return evaluateSandboxLifecycle(sessionId, reason);
 }
 
+async function clearLifecycleRunIdIfOwned(
+  sessionId: string,
+  runId: string,
+): Promise<void> {
+  "use step";
+
+  const session = await getSessionById(sessionId);
+  if (!session || session.lifecycleRunId !== runId) {
+    return;
+  }
+
+  await updateSession(sessionId, { lifecycleRunId: null });
+}
+
 export async function sandboxLifecycleWorkflow(
   sessionId: string,
   reason: SandboxLifecycleReason,
+  runId: string,
 ) {
   "use workflow";
-
-  const decision = await computeLifecycleWakeDecision(sessionId);
-  if (!decision.shouldContinue || decision.wakeAtMs === undefined) {
-    return { skipped: true, reason: decision.reason ?? "no-decision" };
-  }
-
-  const now = Date.now();
-  if (decision.wakeAtMs > now) {
-    await sleep(new Date(decision.wakeAtMs));
-  }
-
-  const evaluation = await runLifecycleEvaluation(sessionId, reason);
-
-  // If the evaluation skipped because activity happened during the sleep,
-  // re-compute the next wake time and try once more. Without this retry,
-  // the sandbox would never hibernate until a new event kicks a fresh workflow.
-  if (evaluation.action === "skipped" && evaluation.reason === "not-due-yet") {
-    const retryDecision = await computeLifecycleWakeDecision(sessionId);
-    if (!retryDecision.shouldContinue || retryDecision.wakeAtMs === undefined) {
-      return {
-        skipped: true,
-        reason: retryDecision.reason ?? "no-decision-on-retry",
-      };
+  while (true) {
+    const decision = await computeLifecycleWakeDecision(sessionId, runId);
+    if (!decision.shouldContinue || decision.wakeAtMs === undefined) {
+      await clearLifecycleRunIdIfOwned(sessionId, runId);
+      return { skipped: true, reason: decision.reason ?? "no-decision" };
     }
 
-    const retryNow = Date.now();
-    if (retryDecision.wakeAtMs > retryNow) {
-      await sleep(new Date(retryDecision.wakeAtMs));
+    const now = Date.now();
+    if (decision.wakeAtMs > now) {
+      await sleep(new Date(decision.wakeAtMs));
     }
 
-    const retryEvaluation = await runLifecycleEvaluation(sessionId, reason);
-    return { skipped: false, evaluation: retryEvaluation };
-  }
+    const evaluation = await runLifecycleEvaluation(sessionId, reason);
 
-  return { skipped: false, evaluation };
+    if (
+      evaluation.action === "skipped" &&
+      evaluation.reason === "not-due-yet"
+    ) {
+      continue;
+    }
+
+    await clearLifecycleRunIdIfOwned(sessionId, runId);
+    return { skipped: false, evaluation };
+  }
 }

--- a/apps/web/app/workflows/sandbox-lifecycle.ts
+++ b/apps/web/app/workflows/sandbox-lifecycle.ts
@@ -1,5 +1,6 @@
 import { sleep } from "workflow";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
+import { SANDBOX_LIFECYCLE_MIN_SLEEP_MS } from "@/lib/sandbox/config";
 import {
   evaluateSandboxLifecycle,
   getLifecycleDueAtMs,
@@ -78,9 +79,11 @@ export async function sandboxLifecycleWorkflow(
     }
 
     const now = Date.now();
-    if (decision.wakeAtMs > now) {
-      await sleep(new Date(decision.wakeAtMs));
-    }
+    const wakeAtMs = Math.max(
+      decision.wakeAtMs,
+      now + SANDBOX_LIFECYCLE_MIN_SLEEP_MS,
+    );
+    await sleep(new Date(wakeAtMs));
 
     const evaluation = await runLifecycleEvaluation(sessionId, reason);
 

--- a/apps/web/app/workflows/sandbox-lifecycle.ts
+++ b/apps/web/app/workflows/sandbox-lifecycle.ts
@@ -15,6 +15,27 @@ interface LifecycleWakeDecision {
   reason?: string;
 }
 
+async function claimLifecycleLease(
+  sessionId: string,
+  runId: string,
+): Promise<boolean> {
+  const current = await getSessionById(sessionId);
+  if (!current) {
+    return false;
+  }
+
+  if (current.lifecycleRunId && current.lifecycleRunId !== runId) {
+    return false;
+  }
+
+  if (current.lifecycleRunId !== runId) {
+    await updateSession(sessionId, { lifecycleRunId: runId });
+  }
+
+  const verified = await getSessionById(sessionId);
+  return verified?.lifecycleRunId === runId;
+}
+
 async function computeLifecycleWakeDecision(
   sessionId: string,
   runId: string,
@@ -25,9 +46,6 @@ async function computeLifecycleWakeDecision(
   if (!session) {
     return { shouldContinue: false, reason: "session-not-found" };
   }
-  if (session.lifecycleRunId !== runId) {
-    return { shouldContinue: false, reason: "run-replaced" };
-  }
   if (session.status === "archived" || session.lifecycleState === "archived") {
     return { shouldContinue: false, reason: "session-archived" };
   }
@@ -35,6 +53,9 @@ async function computeLifecycleWakeDecision(
   const state = session.sandboxState;
   if (!canOperateOnSandbox(state) || state.type === "just-bash") {
     return { shouldContinue: false, reason: "sandbox-not-operable" };
+  }
+  if (!(await claimLifecycleLease(sessionId, runId))) {
+    return { shouldContinue: false, reason: "run-replaced" };
   }
 
   return {

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -11,3 +11,6 @@ export const EXTEND_TIMEOUT_DURATION_MS = 20 * 60 * 1000;
 
 /** Inactivity window before lifecycle hibernates an idle sandbox (20 minutes) */
 export const SANDBOX_INACTIVITY_TIMEOUT_MS = 20 * 60 * 1000;
+
+/** Buffer for sandbox expiry checks (10 seconds) */
+export const SANDBOX_EXPIRES_BUFFER_MS = 10 * 1000;

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -14,3 +14,6 @@ export const SANDBOX_INACTIVITY_TIMEOUT_MS = 20 * 60 * 1000;
 
 /** Buffer for sandbox expiry checks (10 seconds) */
 export const SANDBOX_EXPIRES_BUFFER_MS = 10 * 1000;
+
+/** Grace window before treating a lifecycle run as stale (2 minutes) */
+export const SANDBOX_LIFECYCLE_STALE_RUN_GRACE_MS = 2 * 60 * 1000;

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -17,3 +17,6 @@ export const SANDBOX_EXPIRES_BUFFER_MS = 10 * 1000;
 
 /** Grace window before treating a lifecycle run as stale (2 minutes) */
 export const SANDBOX_LIFECYCLE_STALE_RUN_GRACE_MS = 2 * 60 * 1000;
+
+/** Minimum sleep between lifecycle workflow loop iterations (5 seconds) */
+export const SANDBOX_LIFECYCLE_MIN_SLEEP_MS = 5 * 1000;

--- a/apps/web/lib/sandbox/lifecycle-kick.ts
+++ b/apps/web/lib/sandbox/lifecycle-kick.ts
@@ -36,7 +36,10 @@ async function startLifecycleRun(
       `[Lifecycle] Failed to start workflow run for session ${sessionId}; using inline fallback:`,
       error,
     );
-    await updateSession(sessionId, { lifecycleRunId: null });
+    const current = await getSessionById(sessionId);
+    if (current?.lifecycleRunId === runId) {
+      await updateSession(sessionId, { lifecycleRunId: null });
+    }
     const fallbackResult = await evaluateSandboxLifecycle(sessionId, reason);
     console.log(
       `[Lifecycle] Inline fallback completed for session ${sessionId} (reason=${reason}, action=${fallbackResult.action}${fallbackResult.reason ? `, detail=${fallbackResult.reason}` : ""}).`,
@@ -109,16 +112,6 @@ export function kickSandboxLifecycleWorkflow(input: KickSandboxLifecycleInput) {
     }
 
     const runId = createLifecycleRunId();
-    await updateSession(input.sessionId, { lifecycleRunId: runId });
-
-    // Re-read to verify our write won the race (another caller may have
-    // clobbered our runId between the shouldStartLifecycle check and the
-    // updateSession call above).
-    const verified = await getSessionById(input.sessionId);
-    if (!verified || verified.lifecycleRunId !== runId) {
-      return;
-    }
-
     await startLifecycleRun(input.sessionId, input.reason, runId);
   };
 

--- a/apps/web/lib/sandbox/lifecycle-kick.ts
+++ b/apps/web/lib/sandbox/lifecycle-kick.ts
@@ -3,8 +3,10 @@ import "server-only";
 import { start } from "workflow/api";
 import { sandboxLifecycleWorkflow } from "@/app/workflows/sandbox-lifecycle";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
+import { SANDBOX_LIFECYCLE_STALE_RUN_GRACE_MS } from "./config";
 import {
   evaluateSandboxLifecycle,
+  getLifecycleDueAtMs,
   type SandboxLifecycleReason,
 } from "./lifecycle";
 import { canOperateOnSandbox } from "./utils";
@@ -71,10 +73,38 @@ function shouldStartLifecycle(
   return true;
 }
 
+function isLifecycleRunStale(
+  session: NonNullable<Awaited<ReturnType<typeof getSessionById>>>,
+): boolean {
+  if (!session.lifecycleRunId) {
+    return false;
+  }
+  if (session.lifecycleState !== "active") {
+    return false;
+  }
+
+  const dueAtMs = getLifecycleDueAtMs(session);
+  const overdueMs = Date.now() - dueAtMs;
+
+  return overdueMs > SANDBOX_LIFECYCLE_STALE_RUN_GRACE_MS;
+}
+
 export function kickSandboxLifecycleWorkflow(input: KickSandboxLifecycleInput) {
   const run = async () => {
     const session = await getSessionById(input.sessionId);
-    if (!shouldStartLifecycle(session)) {
+    if (!session) {
+      return;
+    }
+
+    const sessionForStart = isLifecycleRunStale(session)
+      ? { ...session, lifecycleRunId: null }
+      : session;
+
+    if (sessionForStart !== session) {
+      await updateSession(input.sessionId, { lifecycleRunId: null });
+    }
+
+    if (!shouldStartLifecycle(sessionForStart)) {
       return;
     }
 

--- a/apps/web/lib/sandbox/lifecycle-kick.ts
+++ b/apps/web/lib/sandbox/lifecycle-kick.ts
@@ -1,12 +1,13 @@
 import "server-only";
 
 import { start } from "workflow/api";
-import { updateSession } from "@/lib/db/sessions";
 import { sandboxLifecycleWorkflow } from "@/app/workflows/sandbox-lifecycle";
+import { getSessionById, updateSession } from "@/lib/db/sessions";
 import {
   evaluateSandboxLifecycle,
   type SandboxLifecycleReason,
 } from "./lifecycle";
+import { canOperateOnSandbox } from "./utils";
 
 interface KickSandboxLifecycleInput {
   sessionId: string;
@@ -17,18 +18,23 @@ interface KickSandboxLifecycleInput {
 async function startLifecycleRun(
   sessionId: string,
   reason: SandboxLifecycleReason,
+  runId: string,
 ) {
   try {
-    const run = await start(sandboxLifecycleWorkflow, [sessionId, reason]);
-    await updateSession(sessionId, { lifecycleRunId: run.runId });
+    const run = await start(sandboxLifecycleWorkflow, [
+      sessionId,
+      reason,
+      runId,
+    ]);
     console.log(
-      `[Lifecycle] Started workflow run ${run.runId} for session ${sessionId} (reason=${reason}).`,
+      `[Lifecycle] Started workflow run ${run.runId} for session ${sessionId} (reason=${reason}, lease=${runId}).`,
     );
   } catch (error) {
     console.error(
       `[Lifecycle] Failed to start workflow run for session ${sessionId}; using inline fallback:`,
       error,
     );
+    await updateSession(sessionId, { lifecycleRunId: null });
     const fallbackResult = await evaluateSandboxLifecycle(sessionId, reason);
     console.log(
       `[Lifecycle] Inline fallback completed for session ${sessionId} (reason=${reason}, action=${fallbackResult.action}${fallbackResult.reason ? `, detail=${fallbackResult.reason}` : ""}).`,
@@ -36,9 +42,45 @@ async function startLifecycleRun(
   }
 }
 
+function createLifecycleRunId(): string {
+  return `lifecycle:${Date.now()}:${crypto.randomUUID()}`;
+}
+
+function shouldStartLifecycle(
+  session: Awaited<ReturnType<typeof getSessionById>>,
+): session is NonNullable<Awaited<ReturnType<typeof getSessionById>>> {
+  if (!session) {
+    return false;
+  }
+  if (session.status === "archived" || session.lifecycleState === "archived") {
+    return false;
+  }
+  if (!session.sandboxState) {
+    return false;
+  }
+  if (!canOperateOnSandbox(session.sandboxState)) {
+    return false;
+  }
+  if (session.sandboxState.type === "just-bash") {
+    return false;
+  }
+  if (session.lifecycleRunId) {
+    return false;
+  }
+
+  return true;
+}
+
 export function kickSandboxLifecycleWorkflow(input: KickSandboxLifecycleInput) {
   const run = async () => {
-    await startLifecycleRun(input.sessionId, input.reason);
+    const session = await getSessionById(input.sessionId);
+    if (!shouldStartLifecycle(session)) {
+      return;
+    }
+
+    const runId = createLifecycleRunId();
+    await updateSession(input.sessionId, { lifecycleRunId: runId });
+    await startLifecycleRun(input.sessionId, input.reason, runId);
   };
 
   if (input.scheduleBackgroundWork) {

--- a/apps/web/lib/sandbox/lifecycle-kick.ts
+++ b/apps/web/lib/sandbox/lifecycle-kick.ts
@@ -110,6 +110,15 @@ export function kickSandboxLifecycleWorkflow(input: KickSandboxLifecycleInput) {
 
     const runId = createLifecycleRunId();
     await updateSession(input.sessionId, { lifecycleRunId: runId });
+
+    // Re-read to verify our write won the race (another caller may have
+    // clobbered our runId between the shouldStartLifecycle check and the
+    // updateSession call above).
+    const verified = await getSessionById(input.sessionId);
+    if (!verified || verified.lifecycleRunId !== runId) {
+      return;
+    }
+
     await startLifecycleRun(input.sessionId, input.reason, runId);
   };
 

--- a/apps/web/lib/sandbox/lifecycle.test.ts
+++ b/apps/web/lib/sandbox/lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+import {
+  SANDBOX_EXPIRES_BUFFER_MS,
+  SANDBOX_INACTIVITY_TIMEOUT_MS,
+} from "./config";
+
+mock.module("server-only", () => ({}));
+
+let lifecycleModule: typeof import("./lifecycle");
+
+beforeAll(async () => {
+  lifecycleModule = await import("./lifecycle");
+});
+
+describe("getLifecycleDueAtMs", () => {
+  test("prefers hibernateAfter when earlier than expiry", () => {
+    const baseMs = Date.UTC(2025, 0, 1, 0, 0, 0);
+    const record = {
+      hibernateAfter: new Date(baseMs + 15 * 60 * 1000),
+      lastActivityAt: new Date(baseMs),
+      sandboxExpiresAt: new Date(baseMs + 5 * 60 * 60 * 1000),
+      updatedAt: new Date(baseMs),
+    };
+
+    expect(lifecycleModule.getLifecycleDueAtMs(record)).toBe(
+      record.hibernateAfter.getTime(),
+    );
+  });
+
+  test("uses sandbox expiry when it is earlier", () => {
+    const baseMs = Date.UTC(2025, 0, 1, 0, 0, 0);
+    const expiresAt = new Date(baseMs + 10 * 60 * 1000);
+    const record = {
+      hibernateAfter: new Date(baseMs + 30 * 60 * 1000),
+      lastActivityAt: new Date(baseMs),
+      sandboxExpiresAt: expiresAt,
+      updatedAt: new Date(baseMs),
+    };
+
+    expect(lifecycleModule.getLifecycleDueAtMs(record)).toBe(
+      expiresAt.getTime() - SANDBOX_EXPIRES_BUFFER_MS,
+    );
+  });
+
+  test("falls back to lastActivityAt when hibernateAfter is missing", () => {
+    const baseMs = Date.UTC(2025, 0, 1, 0, 0, 0);
+    const lastActivityAt = new Date(baseMs + 2 * 60 * 1000);
+    const record = {
+      hibernateAfter: null,
+      lastActivityAt,
+      sandboxExpiresAt: null,
+      updatedAt: new Date(baseMs),
+    };
+
+    expect(lifecycleModule.getLifecycleDueAtMs(record)).toBe(
+      lastActivityAt.getTime() + SANDBOX_INACTIVITY_TIMEOUT_MS,
+    );
+  });
+
+  test("falls back to updatedAt when lastActivityAt is missing", () => {
+    const baseMs = Date.UTC(2025, 0, 1, 0, 0, 0);
+    const updatedAt = new Date(baseMs + 3 * 60 * 1000);
+    const record = {
+      hibernateAfter: null,
+      lastActivityAt: null,
+      sandboxExpiresAt: null,
+      updatedAt,
+    };
+
+    expect(lifecycleModule.getLifecycleDueAtMs(record)).toBe(
+      updatedAt.getTime() + SANDBOX_INACTIVITY_TIMEOUT_MS,
+    );
+  });
+});

--- a/apps/web/lib/sandbox/lifecycle.ts
+++ b/apps/web/lib/sandbox/lifecycle.ts
@@ -25,7 +25,6 @@ export type SandboxLifecycleReason =
   | "sandbox-created"
   | "cloud-ready"
   | "timeout-extended"
-  | "manual-snapshot"
   | "snapshot-restored"
   | "reconnect"
   | "manual-stop"

--- a/apps/web/lib/sandbox/lifecycle.ts
+++ b/apps/web/lib/sandbox/lifecycle.ts
@@ -6,7 +6,10 @@ import {
   type SnapshotResult,
 } from "@open-harness/sandbox";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
-import { SANDBOX_INACTIVITY_TIMEOUT_MS } from "./config";
+import {
+  SANDBOX_EXPIRES_BUFFER_MS,
+  SANDBOX_INACTIVITY_TIMEOUT_MS,
+} from "./config";
 import { canOperateOnSandbox, clearSandboxState } from "./utils";
 
 export type SandboxLifecycleState =
@@ -21,8 +24,6 @@ export type SandboxLifecycleState =
 export type SandboxLifecycleReason =
   | "sandbox-created"
   | "cloud-ready"
-  | "chat-started"
-  | "chat-finished"
   | "timeout-extended"
   | "manual-snapshot"
   | "snapshot-restored"
@@ -33,6 +34,13 @@ export type SandboxLifecycleReason =
 export interface SandboxLifecycleEvaluationResult {
   action: "skipped" | "hibernated" | "failed";
   reason?: string;
+}
+
+interface LifecycleTimingSource {
+  hibernateAfter: Date | null;
+  lastActivityAt: Date | null;
+  sandboxExpiresAt: Date | null;
+  updatedAt: Date;
 }
 
 function extractSnapshotConflictDetails(error: unknown): string {
@@ -116,15 +124,42 @@ export function buildHibernatedLifecycleUpdate(): LifecycleUpdate {
     lifecycleState: "hibernated",
     sandboxExpiresAt: null,
     hibernateAfter: null,
+    lifecycleRunId: null,
     lifecycleError: null,
   };
 }
 
+function getInactivityDueAtMs(source: LifecycleTimingSource): number {
+  if (source.hibernateAfter) {
+    return source.hibernateAfter.getTime();
+  }
+
+  const lastActivityMs =
+    source.lastActivityAt?.getTime() ?? source.updatedAt.getTime();
+  return lastActivityMs + SANDBOX_INACTIVITY_TIMEOUT_MS;
+}
+
+function getExpiryDueAtMs(source: LifecycleTimingSource): number | null {
+  if (!source.sandboxExpiresAt) {
+    return null;
+  }
+  return source.sandboxExpiresAt.getTime() - SANDBOX_EXPIRES_BUFFER_MS;
+}
+
+export function getLifecycleDueAtMs(source: LifecycleTimingSource): number {
+  const inactivityDueAtMs = getInactivityDueAtMs(source);
+  const expiryDueAtMs = getExpiryDueAtMs(source);
+  if (expiryDueAtMs === null) {
+    return inactivityDueAtMs;
+  }
+  return Math.min(inactivityDueAtMs, expiryDueAtMs);
+}
+
 /**
- * One-shot lifecycle evaluator for event-kicked orchestration.
+ * One-shot lifecycle evaluator for workflow orchestration.
  *
- * This intentionally performs a single evaluation pass and exits.
- * Callers kick it from lifecycle events (create, chat-finished, extend, etc).
+ * This performs a single evaluation pass and exits.
+ * The durable workflow loops and calls this when it wakes.
  */
 export async function evaluateSandboxLifecycle(
   sessionId: string,
@@ -139,9 +174,6 @@ export async function evaluateSandboxLifecycle(
     return { action: "skipped", reason: "session-archived" };
   }
 
-  const lifecycleRunId = `${reason}:${Date.now()}`;
-  await updateSession(sessionId, { lifecycleRunId });
-
   const sandboxState = session.sandboxState;
   if (!canOperateOnSandbox(sandboxState)) {
     return { action: "skipped", reason: "sandbox-not-operable" };
@@ -151,11 +183,8 @@ export async function evaluateSandboxLifecycle(
   }
 
   const nowMs = Date.now();
-  const lastActivityMs =
-    session.lastActivityAt?.getTime() ?? session.updatedAt.getTime();
-  const hibernateAfterMs = lastActivityMs + SANDBOX_INACTIVITY_TIMEOUT_MS;
-
-  const isInactive = nowMs >= hibernateAfterMs;
+  const dueAtMs = getLifecycleDueAtMs(session);
+  const isInactive = nowMs >= dueAtMs;
 
   if (!isInactive) {
     return { action: "skipped", reason: "not-due-yet" };
@@ -217,6 +246,7 @@ export async function evaluateSandboxLifecycle(
     const message = error instanceof Error ? error.message : String(error);
     await updateSession(sessionId, {
       lifecycleState: "failed",
+      lifecycleRunId: null,
       lifecycleError: message,
     });
     console.error(

--- a/apps/web/lib/sandbox/utils.ts
+++ b/apps/web/lib/sandbox/utils.ts
@@ -1,4 +1,5 @@
 import type { SandboxState } from "@open-harness/sandbox";
+import { SANDBOX_EXPIRES_BUFFER_MS } from "./config";
 
 /**
  * Type guard to check if a sandbox is active and ready to accept operations.
@@ -18,7 +19,7 @@ export function isSandboxActive(
 
   // Check expiration first (with 10s buffer for clock skew)
   if ("expiresAt" in state && state.expiresAt !== undefined) {
-    if (Date.now() >= state.expiresAt - 10_000) {
+    if (Date.now() >= state.expiresAt - SANDBOX_EXPIRES_BUFFER_MS) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- keep one leased lifecycle workflow per session and recompute wake times from inactivity or hard expiry
- remove per-message workflow kicks and add a stale-lease safety guard
- document the simplified flow and add lifecycle timing tests

## Testing
- `bun test apps/web/lib/sandbox/lifecycle.test.ts`
- `turbo typecheck`
- `turbo lint`