### PR TITLE
Improve mobile drawer behavior in session chat

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/diff-viewer.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/diff-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { PatchDiff } from "@pierre/diffs/react";
 import { ChevronDown, ChevronRight, FileText, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { DiffFile } from "@/app/api/sessions/[sessionId]/diff/route";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { defaultDiffOptions, splitDiffOptions } from "@/lib/diffs-config";
 import { cn } from "@/lib/utils";
 import { useSessionChatContext } from "./session-chat-context";
@@ -135,6 +136,7 @@ function FileEntry({
 export function DiffViewer({ open, onOpenChange }: DiffViewerProps) {
   const { diff, diffLoading, diffError, diffCachedAt, sandboxInfo } =
     useSessionChatContext();
+  const isMobile = useIsMobile();
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
   const [diffStyle, setDiffStyle] = useState<DiffStyle>("unified");
 
@@ -162,6 +164,12 @@ export function DiffViewer({ open, onOpenChange }: DiffViewerProps) {
   const collapseAll = () => {
     setExpandedFiles(new Set());
   };
+
+  useEffect(() => {
+    if (isMobile && diffStyle !== "unified") {
+      setDiffStyle("unified");
+    }
+  }, [diffStyle, isMobile]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/diff-viewer.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/diff-viewer.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronDown, ChevronRight, FileText, Loader2 } from "lucide-react";
 import { PatchDiff } from "@pierre/diffs/react";
-import { cn } from "@/lib/utils";
-import { defaultDiffOptions, splitDiffOptions } from "@/lib/diffs-config";
+import { ChevronDown, ChevronRight, FileText, Loader2 } from "lucide-react";
+import { useState } from "react";
+import type { DiffFile } from "@/app/api/sessions/[sessionId]/diff/route";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,7 +12,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import type { DiffFile } from "@/app/api/sessions/[sessionId]/diff/route";
+import { defaultDiffOptions, splitDiffOptions } from "@/lib/diffs-config";
+import { cn } from "@/lib/utils";
 import { useSessionChatContext } from "./session-chat-context";
 
 type DiffViewerProps = {
@@ -187,8 +187,8 @@ export function DiffViewer({ open, onOpenChange }: DiffViewerProps) {
               )}
             </div>
             <div className="flex items-center gap-1">
-              {/* Unified / Split toggle */}
-              <div className="flex items-center rounded-md border border-border">
+              {/* Unified / Split toggle - hidden on mobile, unified forced */}
+              <div className="hidden items-center rounded-md border border-border sm:flex">
                 <button
                   type="button"
                   onClick={() => setDiffStyle("unified")}

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/diff-viewer.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/diff-viewer.tsx
@@ -196,7 +196,7 @@ export function DiffViewer({ open, onOpenChange }: DiffViewerProps) {
             </div>
             <div className="flex items-center gap-1">
               {/* Unified / Split toggle - hidden on mobile, unified forced */}
-              <div className="hidden items-center rounded-md border border-border sm:flex">
+              <div className="hidden items-center rounded-md border border-border md:flex">
                 <button
                   type="button"
                   onClick={() => setDiffStyle("unified")}

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -61,6 +61,7 @@ import {
 import { useAudioRecording } from "@/hooks/use-audio-recording";
 import { useFileSuggestions } from "@/hooks/use-file-suggestions";
 import { useImageAttachments } from "@/hooks/use-image-attachments";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { useScrollToBottom } from "@/hooks/use-scroll-to-bottom";
 import { useSessionChats } from "@/hooks/use-session-chats";
 import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
@@ -389,6 +390,7 @@ export function SessionChatContent() {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState("");
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const isMobile = useIsMobile();
   const [hasMounted, setHasMounted] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -1490,23 +1492,23 @@ export function SessionChatContent() {
   return (
     <div className="flex h-dvh overflow-hidden bg-background text-foreground">
       {/* Desktop sidebar */}
-      <aside className="hidden w-72 shrink-0 border-r border-border bg-muted/20 md:flex md:flex-col">
-        {sidebarContent}
-      </aside>
+      {!isMobile && (
+        <aside className="flex w-72 shrink-0 flex-col border-r border-border bg-muted/20">
+          {sidebarContent}
+        </aside>
+      )}
 
       {/* Mobile sidebar Drawer */}
-      <Drawer
-        open={mobileSidebarOpen}
-        onOpenChange={setMobileSidebarOpen}
-        direction="left"
-      >
-        <DrawerContent className="flex h-full w-[85vw] max-w-sm flex-col p-0">
-          <DrawerHeader className="sr-only">
-            <DrawerTitle>Navigation</DrawerTitle>
-          </DrawerHeader>
-          {sidebarContent}
-        </DrawerContent>
-      </Drawer>
+      {isMobile && (
+        <Drawer open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+          <DrawerContent className="h-[85dvh]">
+            <DrawerHeader className="sr-only">
+              <DrawerTitle>Navigation</DrawerTitle>
+            </DrawerHeader>
+            {sidebarContent}
+          </DrawerContent>
+        </Drawer>
+      )}
 
       {/* Main chat area */}
       <div className="flex min-w-0 flex-1 flex-col">
@@ -1515,13 +1517,15 @@ export function SessionChatContent() {
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2 md:gap-4">
               {/* Menu button - mobile only */}
-              <button
-                type="button"
-                onClick={() => setMobileSidebarOpen(true)}
-                className="shrink-0 md:hidden"
-              >
-                <Menu className="h-4 w-4 text-muted-foreground" />
-              </button>
+              {isMobile && (
+                <button
+                  type="button"
+                  onClick={() => setMobileSidebarOpen(true)}
+                  className="shrink-0"
+                >
+                  <Menu className="h-4 w-4 text-muted-foreground" />
+                </button>
+              )}
               <div className="flex min-w-0 items-center gap-2 text-sm">
                 {session.repoName ? (
                   <>

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -48,11 +48,11 @@ import { TaskGroupView } from "@/components/task-group-view";
 import { ToolCall } from "@/components/tool-call";
 import { Button } from "@/components/ui/button";
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import {
   Tooltip,
   TooltipContent,
@@ -1494,15 +1494,19 @@ export function SessionChatContent() {
         {sidebarContent}
       </aside>
 
-      {/* Mobile sidebar Sheet */}
-      <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
-        <SheetContent side="left" className="flex w-72 flex-col p-0">
-          <SheetHeader className="sr-only">
-            <SheetTitle>Navigation</SheetTitle>
-          </SheetHeader>
+      {/* Mobile sidebar Drawer */}
+      <Drawer
+        open={mobileSidebarOpen}
+        onOpenChange={setMobileSidebarOpen}
+        direction="left"
+      >
+        <DrawerContent className="flex h-full w-[85vw] max-w-sm flex-col p-0">
+          <DrawerHeader className="sr-only">
+            <DrawerTitle>Navigation</DrawerTitle>
+          </DrawerHeader>
           {sidebarContent}
-        </SheetContent>
-      </Sheet>
+        </DrawerContent>
+      </Drawer>
 
       {/* Main chat area */}
       <div className="flex min-w-0 flex-1 flex-col">

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -48,6 +48,16 @@ import { TaskGroupView } from "@/components/task-group-view";
 import { ToolCall } from "@/components/tool-call";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
   Drawer,
   DrawerContent,
   DrawerHeader,
@@ -1577,19 +1587,40 @@ export function SessionChatContent() {
               </span>
             </div>
             <div className="flex items-center gap-1 md:gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  void archiveSession().catch((error) => {
-                    console.error("Failed to archive session:", error);
-                  });
-                  router.push("/");
-                }}
-              >
-                <Archive className="h-4 w-4 md:mr-2" />
-                <span className="hidden md:inline">Archive</span>
-              </Button>
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button variant="ghost" size="sm">
+                    <Archive className="h-4 w-4 md:mr-2" />
+                    <span className="hidden md:inline">Archive</span>
+                  </Button>
+                </DialogTrigger>
+                <DialogContent showCloseButton={false}>
+                  <DialogHeader>
+                    <DialogTitle>Archive session?</DialogTitle>
+                    <DialogDescription>
+                      This will stop the sandbox and archive the session. You
+                      can still view it in the archive tab.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button variant="outline">Cancel</Button>
+                    </DialogClose>
+                    <DialogClose asChild>
+                      <Button
+                        onClick={() => {
+                          void archiveSession().catch((error: unknown) => {
+                            console.error("Failed to archive session:", error);
+                          });
+                          router.push("/");
+                        }}
+                      >
+                        Archive
+                      </Button>
+                    </DialogClose>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
               {!supportsDiff ? (
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -71,7 +71,6 @@ import {
 import { useAudioRecording } from "@/hooks/use-audio-recording";
 import { useFileSuggestions } from "@/hooks/use-file-suggestions";
 import { useImageAttachments } from "@/hooks/use-image-attachments";
-import { useIsMobile } from "@/hooks/use-mobile";
 import { useScrollToBottom } from "@/hooks/use-scroll-to-bottom";
 import { useSessionChats } from "@/hooks/use-session-chats";
 import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
@@ -400,7 +399,6 @@ export function SessionChatContent() {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState("");
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-  const isMobile = useIsMobile();
   const [hasMounted, setHasMounted] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -1502,23 +1500,19 @@ export function SessionChatContent() {
   return (
     <div className="flex h-dvh overflow-hidden bg-background text-foreground">
       {/* Desktop sidebar */}
-      {!isMobile && (
-        <aside className="flex w-72 shrink-0 flex-col border-r border-border bg-muted/20">
-          {sidebarContent}
-        </aside>
-      )}
+      <aside className="hidden w-72 shrink-0 flex-col border-r border-border bg-muted/20 md:flex">
+        {sidebarContent}
+      </aside>
 
       {/* Mobile sidebar Drawer */}
-      {isMobile && (
-        <Drawer open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
-          <DrawerContent className="h-[85dvh]">
-            <DrawerHeader className="sr-only">
-              <DrawerTitle>Navigation</DrawerTitle>
-            </DrawerHeader>
-            {sidebarContent}
-          </DrawerContent>
-        </Drawer>
-      )}
+      <Drawer open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+        <DrawerContent className="h-[85dvh] md:hidden">
+          <DrawerHeader className="sr-only">
+            <DrawerTitle>Navigation</DrawerTitle>
+          </DrawerHeader>
+          {sidebarContent}
+        </DrawerContent>
+      </Drawer>
 
       {/* Main chat area */}
       <div className="flex min-w-0 flex-1 flex-col">
@@ -1527,15 +1521,13 @@ export function SessionChatContent() {
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2 md:gap-4">
               {/* Menu button - mobile only */}
-              {isMobile && (
-                <button
-                  type="button"
-                  onClick={() => setMobileSidebarOpen(true)}
-                  className="shrink-0"
-                >
-                  <Menu className="h-4 w-4 text-muted-foreground" />
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={() => setMobileSidebarOpen(true)}
+                className="shrink-0 md:hidden"
+              >
+                <Menu className="h-4 w-4 text-muted-foreground" />
+              </button>
               <div className="flex min-w-0 items-center gap-2 text-sm">
                 {session.repoName ? (
                   <>

--- a/apps/web/components/session-drawer.tsx
+++ b/apps/web/components/session-drawer.tsx
@@ -2,6 +2,12 @@
 
 import { Archive, GitMerge } from "lucide-react";
 import { useState } from "react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
@@ -9,6 +15,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-mobile";
 import type { Session } from "@/lib/db/schema";
 
 interface SessionDrawerProps {
@@ -144,13 +151,12 @@ function SessionGroup({
 
 type DrawerTab = "sessions" | "archive";
 
-export function SessionDrawer({
-  open,
-  onOpenChange,
+function SessionDrawerInner({
   sessions,
   loading,
   onSessionClick,
-}: SessionDrawerProps) {
+  onOpenChange,
+}: Omit<SessionDrawerProps, "open">) {
   const [tab, setTab] = useState<DrawerTab>("sessions");
 
   const activeSessions = sessions.filter((s) => s.status !== "archived");
@@ -165,84 +171,124 @@ export function SessionDrawer({
   };
 
   return (
+    <>
+      <div className="border-b px-4 py-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold">Sessions</h2>
+        </div>
+        <div className="flex gap-1 pt-1">
+          <button
+            type="button"
+            onClick={() => setTab("sessions")}
+            className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+              tab === "sessions"
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Active
+            {activeSessions.length > 0 && (
+              <span className="ml-1.5 text-muted-foreground">
+                {activeSessions.length}
+              </span>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("archive")}
+            className={`flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+              tab === "archive"
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Archive className="h-3 w-3" />
+            Archive
+            {archivedSessions.length > 0 && (
+              <span className="ml-1 text-muted-foreground">
+                {archivedSessions.length}
+              </span>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <ScrollArea className="flex-1">
+        <div className="p-2">
+          {loading ? (
+            <SessionDrawerSkeleton />
+          ) : displayedSessions.length === 0 ? (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              {tab === "sessions" ? "No sessions yet" : "No archived sessions"}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {Array.from(groupedSessions.entries()).map(
+                ([dateGroup, groupSessions]) => (
+                  <SessionGroup
+                    key={dateGroup}
+                    dateGroup={dateGroup}
+                    sessions={groupSessions}
+                    onSessionClick={handleSessionClick}
+                  />
+                ),
+              )}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </>
+  );
+}
+
+export function SessionDrawer({
+  open,
+  onOpenChange,
+  sessions,
+  loading,
+  onSessionClick,
+}: SessionDrawerProps) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent className="h-[85dvh]">
+          <DrawerHeader className="sr-only">
+            <DrawerTitle>Sessions</DrawerTitle>
+          </DrawerHeader>
+          <SessionDrawerInner
+            sessions={sessions}
+            loading={loading}
+            onSessionClick={onSessionClick}
+            onOpenChange={onOpenChange}
+          />
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
         className="flex flex-col gap-0 p-0 sm:max-w-sm"
       >
-        <SheetHeader className="border-b px-4 py-3">
-          <div className="flex items-center justify-between">
-            <SheetTitle className="text-base">Sessions</SheetTitle>
-          </div>
-          <div className="flex gap-1 pt-1">
-            <button
-              type="button"
-              onClick={() => setTab("sessions")}
-              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                tab === "sessions"
-                  ? "bg-muted text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              Active
-              {activeSessions.length > 0 && (
-                <span className="ml-1.5 text-muted-foreground">
-                  {activeSessions.length}
-                </span>
-              )}
-            </button>
-            <button
-              type="button"
-              onClick={() => setTab("archive")}
-              className={`flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                tab === "archive"
-                  ? "bg-muted text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              <Archive className="h-3 w-3" />
-              Archive
-              {archivedSessions.length > 0 && (
-                <span className="ml-1 text-muted-foreground">
-                  {archivedSessions.length}
-                </span>
-              )}
-            </button>
-          </div>
+        <SheetHeader className="sr-only">
+          <SheetTitle>Sessions</SheetTitle>
         </SheetHeader>
-
-        <ScrollArea className="flex-1">
-          <div className="p-2">
-            {loading ? (
-              <DrawerSkeleton />
-            ) : displayedSessions.length === 0 ? (
-              <div className="py-12 text-center text-sm text-muted-foreground">
-                {tab === "sessions"
-                  ? "No sessions yet"
-                  : "No archived sessions"}
-              </div>
-            ) : (
-              <div className="space-y-4">
-                {Array.from(groupedSessions.entries()).map(
-                  ([dateGroup, groupSessions]) => (
-                    <SessionGroup
-                      key={dateGroup}
-                      dateGroup={dateGroup}
-                      sessions={groupSessions}
-                      onSessionClick={handleSessionClick}
-                    />
-                  ),
-                )}
-              </div>
-            )}
-          </div>
-        </ScrollArea>
+        <SessionDrawerInner
+          sessions={sessions}
+          loading={loading}
+          onSessionClick={onSessionClick}
+          onOpenChange={onOpenChange}
+        />
       </SheetContent>
     </Sheet>
   );
 }
 
-function DrawerSkeleton() {
+function SessionDrawerSkeleton() {
   return (
     <div className="space-y-4 p-3">
       <div>

--- a/apps/web/components/ui/drawer.tsx
+++ b/apps/web/components/ui/drawer.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "streamdown": "^2.2.0",
     "swr": "^2.3.8",
     "tailwind-merge": "^3.4.0",
+    "vaul": "^1.1.2",
     "workflow": "^4.1.0-beta.52",
     "zod": "catalog:"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "streamdown": "^2.2.0",
         "swr": "^2.3.8",
         "tailwind-merge": "^3.4.0",
+        "vaul": "^1.1.2",
         "workflow": "^4.1.0-beta.52",
         "zod": "catalog:",
       },
@@ -1990,6 +1991,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+
+    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 


### PR DESCRIPTION
## Summary
- switch session chat and session list mobile navigation to bottom drawers (vaul), including a shared drawer wrapper and dependency updates
- keep diff viewer in unified mode on mobile so split view cannot get stuck when the toggle is hidden
- remove mobile first-paint layout shift in chat by using CSS breakpoint visibility instead of runtime mobile branching