### PR TITLE
Add URL-driven session creation for GitHub repos

### DIFF
--- a/apps/web/app/[username]/[repo]/page.tsx
+++ b/apps/web/app/[username]/[repo]/page.tsx
@@ -1,0 +1,104 @@
+import { nanoid } from "nanoid";
+import { notFound, redirect } from "next/navigation";
+import { createSessionWithInitialChat } from "@/lib/db/sessions";
+import { getUserPreferences } from "@/lib/db/user-preferences";
+import { getRepoToken } from "@/lib/github/get-repo-token";
+import { getServerSession } from "@/lib/session/get-server-session";
+
+interface RepoPageProps {
+  params: Promise<{ username: string; repo: string }>;
+}
+
+interface GitHubRepoInfo {
+  default_branch: string;
+  clone_url: string;
+  full_name: string;
+}
+
+async function fetchRepoInfo(
+  owner: string,
+  repo: string,
+  token?: string,
+): Promise<GitHubRepoInfo | null> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}`,
+    { headers },
+  );
+
+  if (!response.ok) {
+    console.error(
+      `[repo-page] GitHub API returned ${response.status} for /repos/${owner}/${repo}`,
+    );
+    return null;
+  }
+  return response.json() as Promise<GitHubRepoInfo>;
+}
+
+export default async function RepoPage({ params }: RepoPageProps) {
+  const { username, repo } = await params;
+
+  // Auth check -- redirect to sign-in, preserving the URL for return
+  const session = await getServerSession();
+  if (!session?.user) {
+    redirect(
+      `/api/auth/signin/vercel?next=${encodeURIComponent(`/${username}/${repo}`)}`,
+    );
+  }
+
+  // Get a GitHub token (if available) for private repo access
+  let token: string | undefined;
+  try {
+    const result = await getRepoToken(session.user.id, username);
+    token = result.token;
+  } catch {
+    // No token available -- will try unauthenticated (works for public repos)
+  }
+
+  // Validate the repo exists and get its default branch
+  let repoInfo = await fetchRepoInfo(username, repo, token);
+
+  // If authenticated request failed, retry without auth (public repos)
+  if (!repoInfo && token) {
+    repoInfo = await fetchRepoInfo(username, repo);
+  }
+
+  if (!repoInfo) {
+    notFound();
+  }
+
+  // Use the user's preferred sandbox type and model
+  const preferences = await getUserPreferences(session.user.id);
+
+  const cloneUrl = `https://github.com/${username}/${repo}.git`;
+
+  const result = await createSessionWithInitialChat({
+    session: {
+      id: nanoid(),
+      userId: session.user.id,
+      title: repo,
+      status: "running",
+      repoOwner: username,
+      repoName: repo,
+      branch: repoInfo.default_branch,
+      cloneUrl,
+      isNewBranch: false,
+      sandboxState: { type: preferences.defaultSandboxType },
+      lifecycleState: "provisioning",
+      lifecycleVersion: 0,
+    },
+    initialChat: {
+      id: nanoid(),
+      title: "New chat",
+      modelId: preferences.defaultModelId,
+    },
+  });
+
+  redirect(`/sessions/${result.session.id}/chats/${result.chat.id}`);
+}


### PR DESCRIPTION
## Summary
- add a repo route (`/[username]/[repo]`) that validates GitHub repositories and derives default branch
- create a session + initial chat from the URL using user preferences, then redirect to the new chat

## Testing
- not run (not requested)