### PR TITLE
Scope tool renderer expand/collapse toggle to header area only

### DIFF
--- a/apps/web/components/tool-call/renderers/ask-user-question-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/ask-user-question-renderer.tsx
@@ -61,20 +61,20 @@ export function AskUserQuestionRenderer({
   };
 
   return (
-    <div
-      className={cn(
-        "my-2 rounded-lg border border-border bg-card p-3",
-        hasExpandableContent && "cursor-pointer hover:bg-accent/50",
-      )}
-      {...(hasExpandableContent && {
-        onClick: handleClick,
-        onKeyDown: handleKeyDown,
-        role: "button",
-        tabIndex: 0,
-        "aria-expanded": isExpanded,
-      })}
-    >
-      <div className="flex items-center gap-2">
+    <div className="my-2 rounded-lg border border-border bg-card p-3">
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          hasExpandableContent && "cursor-pointer",
+        )}
+        {...(hasExpandableContent && {
+          onClick: handleClick,
+          onKeyDown: handleKeyDown,
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": isExpanded,
+        })}
+      >
         {state.running || isStreaming ? (
           <Loader2 className="h-3 w-3 animate-spin text-yellow-500" />
         ) : (

--- a/apps/web/components/tool-call/renderers/bash-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/bash-renderer.tsx
@@ -59,20 +59,20 @@ export function BashRenderer({
   };
 
   return (
-    <div
-      className={cn(
-        "my-2 rounded-lg border border-border bg-card p-3",
-        hasExpandableContent && "cursor-pointer hover:bg-accent/50",
-      )}
-      {...(hasExpandableContent && {
-        onClick: handleClick,
-        onKeyDown: handleKeyDown,
-        role: "button",
-        tabIndex: 0,
-        "aria-expanded": isExpanded,
-      })}
-    >
-      <div className="flex items-center gap-2">
+    <div className="my-2 rounded-lg border border-border bg-card p-3">
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          hasExpandableContent && "cursor-pointer",
+        )}
+        {...(hasExpandableContent && {
+          onClick: handleClick,
+          onKeyDown: handleKeyDown,
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": isExpanded,
+        })}
+      >
         {state.interrupted ? (
           <span className="inline-block h-2 w-2 rounded-full border border-yellow-500" />
         ) : state.running ? (

--- a/apps/web/components/tool-call/renderers/edit-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/edit-renderer.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { toRelativePath } from "@open-harness/shared/lib/tool-state";
+import { MultiFileDiff } from "@pierre/diffs/react";
 import { Loader2 } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
-import { MultiFileDiff } from "@pierre/diffs/react";
-import { toRelativePath } from "@open-harness/shared/lib/tool-state";
 import type { ToolRendererProps } from "@/app/lib/render-tool";
 import { defaultDiffOptions } from "@/lib/diffs-config";
 import { cn } from "@/lib/utils";
@@ -84,20 +84,20 @@ export function EditRenderer({
   };
 
   return (
-    <div
-      className={cn(
-        "my-2 rounded-lg border border-border bg-card p-3",
-        hasExpandableContent && "cursor-pointer hover:bg-accent/50",
-      )}
-      {...(hasExpandableContent && {
-        onClick: handleClick,
-        onKeyDown: handleKeyDown,
-        role: "button",
-        tabIndex: 0,
-        "aria-expanded": isExpanded,
-      })}
-    >
-      <div className="flex items-center gap-2">
+    <div className="my-2 rounded-lg border border-border bg-card p-3">
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          hasExpandableContent && "cursor-pointer",
+        )}
+        {...(hasExpandableContent && {
+          onClick: handleClick,
+          onKeyDown: handleKeyDown,
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": isExpanded,
+        })}
+      >
         {mergedState.interrupted ? (
           <span className="inline-block h-2 w-2 rounded-full border border-yellow-500" />
         ) : mergedState.running ? (

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import type { SubagentUIMessage } from "@open-harness/agent";
+import { formatTokens } from "@open-harness/shared";
+import { getToolName, isTextUIPart, isToolUIPart } from "ai";
 import { Loader2 } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
-import { isToolUIPart, isTextUIPart, getToolName } from "ai";
-import { formatTokens } from "@open-harness/shared";
-import type { SubagentUIMessage } from "@open-harness/agent";
 import type { ToolRendererProps } from "@/app/lib/render-tool";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "../approval-buttons";
@@ -178,20 +178,20 @@ export function TaskRenderer({
   };
 
   return (
-    <div
-      className={cn(
-        "my-2 rounded-lg border border-border bg-card p-3",
-        hasExpandableContent && "cursor-pointer hover:bg-accent/50",
-      )}
-      {...(hasExpandableContent && {
-        onClick: handleClick,
-        onKeyDown: handleKeyDown,
-        role: "button",
-        tabIndex: 0,
-        "aria-expanded": isExpanded,
-      })}
-    >
-      <div className="flex items-center gap-2">
+    <div className="my-2 rounded-lg border border-border bg-card p-3">
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          hasExpandableContent && "cursor-pointer",
+        )}
+        {...(hasExpandableContent && {
+          onClick: handleClick,
+          onKeyDown: handleKeyDown,
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": isExpanded,
+        })}
+      >
         {state.interrupted ? (
           <span className="inline-block h-2 w-2 rounded-full border border-yellow-500" />
         ) : state.running || isActuallyRunning ? (

--- a/apps/web/components/tool-call/renderers/todo-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/todo-renderer.tsx
@@ -53,20 +53,20 @@ export function TodoRenderer({
   };
 
   return (
-    <div
-      className={cn(
-        "my-2 rounded-lg border border-border bg-card p-3",
-        hasExpandableContent && "cursor-pointer hover:bg-accent/50",
-      )}
-      {...(hasExpandableContent && {
-        onClick: handleClick,
-        onKeyDown: handleKeyDown,
-        role: "button",
-        tabIndex: 0,
-        "aria-expanded": isExpanded,
-      })}
-    >
-      <div className="flex items-center gap-2">
+    <div className="my-2 rounded-lg border border-border bg-card p-3">
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          hasExpandableContent && "cursor-pointer",
+        )}
+        {...(hasExpandableContent && {
+          onClick: handleClick,
+          onKeyDown: handleKeyDown,
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": isExpanded,
+        })}
+      >
         {state.running ? (
           <Loader2 className="h-3 w-3 animate-spin text-yellow-500" />
         ) : (

--- a/apps/web/components/tool-call/renderers/write-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/write-renderer.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { toRelativePath } from "@open-harness/shared/lib/tool-state";
+import { File as DiffsFile } from "@pierre/diffs/react";
 import { Loader2 } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
-import { File as DiffsFile } from "@pierre/diffs/react";
-import { toRelativePath } from "@open-harness/shared/lib/tool-state";
 import type { ToolRendererProps } from "@/app/lib/render-tool";
 import { defaultFileOptions } from "@/lib/diffs-config";
 import { cn } from "@/lib/utils";
@@ -68,20 +68,20 @@ export function WriteRenderer({
   };
 
   return (
-    <div
-      className={cn(
-        "my-2 rounded-lg border border-border bg-card p-3",
-        hasExpandableContent && "cursor-pointer hover:bg-accent/50",
-      )}
-      {...(hasExpandableContent && {
-        onClick: handleClick,
-        onKeyDown: handleKeyDown,
-        role: "button",
-        tabIndex: 0,
-        "aria-expanded": isExpanded,
-      })}
-    >
-      <div className="flex items-center gap-2">
+    <div className="my-2 rounded-lg border border-border bg-card p-3">
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          hasExpandableContent && "cursor-pointer",
+        )}
+        {...(hasExpandableContent && {
+          onClick: handleClick,
+          onKeyDown: handleKeyDown,
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": isExpanded,
+        })}
+      >
         {mergedState.interrupted ? (
           <span className="inline-block h-2 w-2 rounded-full border border-yellow-500" />
         ) : mergedState.running ? (

--- a/apps/web/components/tool-call/tool-layout.tsx
+++ b/apps/web/components/tool-call/tool-layout.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import type { ToolRenderState } from "@open-harness/shared/lib/tool-state";
 import { Loader2 } from "lucide-react";
 import type React from "react";
 import { type ReactNode, useState } from "react";
-import type { ToolRenderState } from "@open-harness/shared/lib/tool-state";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "./approval-buttons";
 
@@ -63,27 +63,27 @@ export function ToolLayout({
   };
 
   return (
-    <div
-      className={cn(
-        "my-2 rounded-lg border border-border bg-card p-3",
-        hasExpandedContent && "cursor-pointer hover:bg-accent/50",
-      )}
-      {...(hasExpandedContent && {
-        onClick: handleClick,
-        onKeyDown: (e: React.KeyboardEvent) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            if (hasExpandedContent) {
-              setIsExpanded(!isExpanded);
+    <div className="my-2 rounded-lg border border-border bg-card p-3">
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          hasExpandedContent && "cursor-pointer",
+        )}
+        {...(hasExpandedContent && {
+          onClick: handleClick,
+          onKeyDown: (e: React.KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              if (hasExpandedContent) {
+                setIsExpanded(!isExpanded);
+              }
             }
-          }
-        },
-        role: "button",
-        tabIndex: 0,
-        "aria-expanded": isExpanded,
-      })}
-    >
-      <div className="flex items-center gap-2">
+          },
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": isExpanded,
+        })}
+      >
         <StatusDot state={state} />
         <span
           className={cn(


### PR DESCRIPTION
## Summary
- move expand/collapse handlers to tool-call header rows only
- remove full-card hover/click affordance in tool renderers
- align header cursor styles with header-only toggles