### PR TITLE
Fix optimistic chat redirect race and overlay persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,3 +278,5 @@ Use `catalog:` for shared external versions:
 - `hadInitialMessages` is an initial-load snapshot, not a live "first turn" signal; guard one-time optimistic UI (like first-message title previews) with a dedicated runtime ref/state that resets on send failure.
 - In the GitHub App install flow, do a user-token installation sync before redirecting after OAuth-only callbacks or treating zero local installation rows as "not installed"; GitHub can skip callback emissions for pre-existing installs.
 - For sandbox lifecycle kicks, do not persist `lifecycleRunId` before `start(...)`; start first and let the durable workflow claim/verify the lease so canceled fire-and-forget kicks cannot strand a stale lease.
+- Server-side optimistic chat route lookup must allow realistic persistence latency (multi-second retry window), otherwise `/sessions/[sessionId]/chats/[chatId]` can redirect away before chat creation finishes.
+- When session overlay maps are deleted after becoming empty, any later overlay writes in the same hook instance must re-register the map in the global registry, or optimistic overlays will not survive route transitions.

--- a/apps/web/app/api/sessions/[sessionId]/chats/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/chats/route.ts
@@ -27,8 +27,11 @@ export async function GET(_req: Request, context: RouteContext) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const chats = await getChatSummariesBySessionId(sessionId, session.user.id);
-  return Response.json({ chats });
+  const [chats, preferences] = await Promise.all([
+    getChatSummariesBySessionId(sessionId, session.user.id),
+    getUserPreferences(session.user.id),
+  ]);
+  return Response.json({ chats, defaultModelId: preferences.defaultModelId });
 }
 
 export async function POST(req: Request, context: RouteContext) {

--- a/apps/web/app/api/sessions/[sessionId]/chats/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/chats/route.ts
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import {
   createChat,
+  getChatById,
   getChatSummariesBySessionId,
   getSessionById,
 } from "@/lib/db/sessions";
@@ -30,7 +31,7 @@ export async function GET(_req: Request, context: RouteContext) {
   return Response.json({ chats });
 }
 
-export async function POST(_req: Request, context: RouteContext) {
+export async function POST(req: Request, context: RouteContext) {
   const session = await getServerSession();
   if (!session?.user) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
@@ -45,9 +46,37 @@ export async function POST(_req: Request, context: RouteContext) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  let requestedChatId: string | null = null;
+  try {
+    const body = await req.json();
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      "id" in body &&
+      body.id !== undefined
+    ) {
+      if (typeof body.id !== "string" || body.id.length === 0) {
+        return Response.json({ error: "Invalid chat id" }, { status: 400 });
+      }
+      requestedChatId = body.id;
+    }
+  } catch {
+    requestedChatId = null;
+  }
+
+  if (requestedChatId) {
+    const existing = await getChatById(requestedChatId);
+    if (existing) {
+      if (existing.sessionId !== sessionId) {
+        return Response.json({ error: "Chat ID conflict" }, { status: 409 });
+      }
+      return Response.json({ chat: existing });
+    }
+  }
+
   const preferences = await getUserPreferences(session.user.id);
   const chat = await createChat({
-    id: nanoid(),
+    id: requestedChatId ?? nanoid(),
     sessionId,
     title: "New chat",
     modelId: preferences.defaultModelId,

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
@@ -1,18 +1,39 @@
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import type { WebAgentUIMessage } from "@/app/types";
+import { DiffsProvider } from "@/components/diffs-provider";
 import {
   getChatById,
   getChatMessages,
   getSessionById,
 } from "@/lib/db/sessions";
 import { getServerSession } from "@/lib/session/get-server-session";
-import { DiffsProvider } from "@/components/diffs-provider";
-import { SessionChatProvider } from "./session-chat-context";
 import { SessionChatContent } from "./session-chat-content";
+import { SessionChatProvider } from "./session-chat-context";
 
 interface SessionChatPageProps {
   params: Promise<{ sessionId: string; chatId: string }>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getChatByIdWithRetry(
+  chatId: string,
+  sessionId: string,
+): Promise<Awaited<ReturnType<typeof getChatById>>> {
+  const maxAttempts = 6;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const chat = await getChatById(chatId);
+    if (chat && chat.sessionId === sessionId) {
+      return chat;
+    }
+    if (attempt < maxAttempts) {
+      await sleep(80);
+    }
+  }
+  return undefined;
 }
 
 export async function generateMetadata({
@@ -48,8 +69,8 @@ export default async function SessionChatPage({
     redirect("/");
   }
 
-  const chat = await getChatById(chatId);
-  if (!chat || chat.sessionId !== sessionId) {
+  const chat = await getChatByIdWithRetry(chatId, sessionId);
+  if (!chat) {
     notFound();
   }
 

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
@@ -25,18 +25,23 @@ function isOptimisticChatId(chatId: string): boolean {
   );
 }
 
+const OPTIMISTIC_CHAT_RETRY_DELAY_MS = 100;
+const OPTIMISTIC_CHAT_RETRY_ATTEMPTS = 50;
+
 async function getChatByIdWithRetry(
   chatId: string,
   sessionId: string,
 ): Promise<Awaited<ReturnType<typeof getChatById>>> {
-  const maxAttempts = isOptimisticChatId(chatId) ? 4 : 1;
+  const maxAttempts = isOptimisticChatId(chatId)
+    ? OPTIMISTIC_CHAT_RETRY_ATTEMPTS
+    : 1;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const chat = await getChatById(chatId);
     if (chat && chat.sessionId === sessionId) {
       return chat;
     }
     if (attempt < maxAttempts) {
-      await sleep(40);
+      await sleep(OPTIMISTIC_CHAT_RETRY_DELAY_MS);
     }
   }
   return undefined;

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
@@ -19,18 +19,24 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isOptimisticChatId(chatId: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    chatId,
+  );
+}
+
 async function getChatByIdWithRetry(
   chatId: string,
   sessionId: string,
 ): Promise<Awaited<ReturnType<typeof getChatById>>> {
-  const maxAttempts = 6;
+  const maxAttempts = isOptimisticChatId(chatId) ? 4 : 1;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const chat = await getChatById(chatId);
     if (chat && chat.sessionId === sessionId) {
       return chat;
     }
     if (attempt < maxAttempts) {
-      await sleep(80);
+      await sleep(40);
     }
   }
   return undefined;
@@ -71,6 +77,9 @@ export default async function SessionChatPage({
 
   const chat = await getChatByIdWithRetry(chatId, sessionId);
   if (!chat) {
+    if (isOptimisticChatId(chatId)) {
+      redirect(`/sessions/${sessionId}`);
+    }
     notFound();
   }
 

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -23,7 +23,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import type { ComponentProps, ReactNode } from "react";
 import {
   Children,
@@ -378,6 +378,7 @@ function SandboxInputOverlay({
 
 export function SessionChatContent() {
   const router = useRouter();
+  const pathname = usePathname();
   const [input, setInput] = useState("");
   const [isCreatingSandbox, setIsCreatingSandbox] = useState(false);
   const [isRestoringSnapshot, setIsRestoringSnapshot] = useState(false);
@@ -531,6 +532,8 @@ export function SessionChatContent() {
   const statusSyncInFlightRef = useRef(false);
   const pendingOptimisticTitleChatIdRef = useRef<string | null>(null);
   const hasSetOptimisticTitleRef = useRef(false);
+  const pathnameRef = useRef(pathname);
+  const sidebarActiveChatIdRef = useRef<string | null>(null);
   const markReadRef = useRef<{
     lastAt: number;
     lastChatId: string | null;
@@ -623,6 +626,14 @@ export function SessionChatContent() {
 
   const sidebarActiveChatId = optimisticActiveChatId ?? chatInfo.id;
 
+  useEffect(() => {
+    pathnameRef.current = pathname;
+  }, [pathname]);
+
+  useEffect(() => {
+    sidebarActiveChatIdRef.current = sidebarActiveChatId;
+  }, [sidebarActiveChatId]);
+
   // Refresh chats list when the first message completes to pick up the auto-generated title
   useEffect(() => {
     if (
@@ -677,8 +688,8 @@ export function SessionChatContent() {
         console.error("Failed to create chat:", err);
         void refreshChats();
         if (
-          typeof window !== "undefined" &&
-          window.location.pathname === optimisticPath
+          sidebarActiveChatIdRef.current === newChat.id ||
+          pathnameRef.current === optimisticPath
         ) {
           setOptimisticActiveChatId(previousChatId);
           router.replace(`/sessions/${session.id}/chats/${previousChatId}`);

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -523,6 +523,9 @@ export function SessionChatContent() {
   const [editingChatId, setEditingChatId] = useState<string | null>(null);
   const [editingChatTitle, setEditingChatTitle] = useState("");
   const [isUpdatingModel, setIsUpdatingModel] = useState(false);
+  const [optimisticActiveChatId, setOptimisticActiveChatId] = useState<
+    string | null
+  >(null);
   const chatTitleInputRef = useRef<HTMLInputElement | null>(null);
   const lastStatusSyncAtRef = useRef(0);
   const statusSyncInFlightRef = useRef(false);
@@ -614,6 +617,12 @@ export function SessionChatContent() {
     }
   }, [editingChatId]);
 
+  useEffect(() => {
+    setOptimisticActiveChatId(null);
+  }, [chatInfo.id]);
+
+  const sidebarActiveChatId = optimisticActiveChatId ?? chatInfo.id;
+
   // Refresh chats list when the first message completes to pick up the auto-generated title
   useEffect(() => {
     if (
@@ -649,21 +658,36 @@ export function SessionChatContent() {
 
   const handleChatSwitch = useCallback(
     (nextChatId: string) => {
-      if (nextChatId === chatInfo.id) return;
+      if (nextChatId === sidebarActiveChatId) return;
+      setOptimisticActiveChatId(nextChatId);
       setMobileSidebarOpen(false);
       router.push(`/sessions/${session.id}/chats/${nextChatId}`);
     },
-    [router, session.id, chatInfo.id],
+    [router, session.id, sidebarActiveChatId],
   );
 
-  const handleCreateChat = useCallback(async () => {
+  const handleCreateChat = useCallback(() => {
+    const previousChatId = chatInfo.id;
     try {
-      const newChat = await createChat();
+      const { chat: newChat, persisted } = createChat();
+      const optimisticPath = `/sessions/${session.id}/chats/${newChat.id}`;
+      setOptimisticActiveChatId(newChat.id);
       router.push(`/sessions/${session.id}/chats/${newChat.id}`);
+      void persisted.catch((err) => {
+        console.error("Failed to create chat:", err);
+        void refreshChats();
+        if (
+          typeof window !== "undefined" &&
+          window.location.pathname === optimisticPath
+        ) {
+          setOptimisticActiveChatId(previousChatId);
+          router.replace(`/sessions/${session.id}/chats/${previousChatId}`);
+        }
+      });
     } catch (err) {
       console.error("Failed to create chat:", err);
     }
-  }, [createChat, router, session.id]);
+  }, [chatInfo.id, createChat, refreshChats, router, session.id]);
 
   const handleRenameChat = useCallback(
     async (targetChatId: string, nextTitle: string) => {
@@ -1403,7 +1427,7 @@ export function SessionChatContent() {
             <div
               key={c.id}
               className={`group relative flex items-center rounded-md ${
-                c.id === chatInfo.id ? "bg-secondary" : "hover:bg-muted"
+                c.id === sidebarActiveChatId ? "bg-secondary" : "hover:bg-muted"
               }`}
             >
               {editingChatId === c.id ? (
@@ -1430,7 +1454,7 @@ export function SessionChatContent() {
                   type="button"
                   onClick={() => handleChatSwitch(c.id)}
                   className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 pr-10 text-left text-sm transition-colors ${
-                    c.id === chatInfo.id
+                    c.id === sidebarActiveChatId
                       ? "text-secondary-foreground"
                       : "text-muted-foreground group-hover:text-foreground"
                   }`}
@@ -1446,7 +1470,7 @@ export function SessionChatContent() {
                 />
               )}
               {editingChatId !== c.id &&
-                c.id !== chatInfo.id &&
+                c.id !== sidebarActiveChatId &&
                 !c.isStreaming &&
                 c.hasUnread && (
                   <span

--- a/apps/web/hooks/use-session-chats.ts
+++ b/apps/web/hooks/use-session-chats.ts
@@ -154,6 +154,9 @@ export function useSessionChats(sessionId: string | null) {
         return;
       }
 
+      if (!sessionChatOverlays.has(sessionId)) {
+        sessionChatOverlays.set(sessionId, optimisticOverlay);
+      }
       optimisticOverlay.set(chatId, next);
       setOverlayVersion((value) => value + 1);
     },

--- a/apps/web/hooks/use-session-chats.ts
+++ b/apps/web/hooks/use-session-chats.ts
@@ -11,6 +11,7 @@ export type SessionChatListItem = Chat & {
 };
 
 interface ChatsResponse {
+  defaultModelId: string | null;
   chats: SessionChatListItem[];
 }
 
@@ -30,16 +31,39 @@ type ChatOptimisticOverlay = {
 };
 
 const STREAMING_RACE_GRACE_MS = 12_000;
+const OVERLAY_INACTIVE_TTL_MS = 5 * 60_000;
 
 // Persist optimistic chat UI state across chat route transitions.
 const sessionChatOverlays = new Map<
   string,
   Map<string, ChatOptimisticOverlay>
 >();
+const overlayCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function clearOverlayCleanup(sessionId: string): void {
+  const existingTimer = overlayCleanupTimers.get(sessionId);
+  if (!existingTimer) {
+    return;
+  }
+
+  clearTimeout(existingTimer);
+  overlayCleanupTimers.delete(sessionId);
+}
+
+function scheduleOverlayCleanup(sessionId: string): void {
+  clearOverlayCleanup(sessionId);
+  const timer = setTimeout(() => {
+    sessionChatOverlays.delete(sessionId);
+    overlayCleanupTimers.delete(sessionId);
+  }, OVERLAY_INACTIVE_TTL_MS);
+  overlayCleanupTimers.set(sessionId, timer);
+}
 
 function getSessionOverlay(
   sessionId: string,
 ): Map<string, ChatOptimisticOverlay> {
+  clearOverlayCleanup(sessionId);
+
   const existing = sessionChatOverlays.get(sessionId);
   if (existing) {
     return existing;
@@ -67,11 +91,22 @@ function overlaysEqual(
 }
 
 export function useSessionChats(sessionId: string | null) {
-  const [overlayVersion, setOverlayVersion] = useState(0);
+  const [_overlayVersion, setOverlayVersion] = useState(0);
   const optimisticOverlay = useMemo(
     () => (sessionId ? getSessionOverlay(sessionId) : null),
     [sessionId],
   );
+
+  useEffect(() => {
+    if (!sessionId) {
+      return;
+    }
+
+    clearOverlayCleanup(sessionId);
+    return () => {
+      scheduleOverlayCleanup(sessionId);
+    };
+  }, [sessionId]);
 
   const { data, error, isLoading, mutate } = useSWR<ChatsResponse>(
     sessionId ? `/api/sessions/${sessionId}/chats` : null,
@@ -108,6 +143,7 @@ export function useSessionChats(sessionId: string | null) {
           optimisticOverlay.delete(chatId);
           if (optimisticOverlay.size === 0) {
             sessionChatOverlays.delete(sessionId);
+            clearOverlayCleanup(sessionId);
           }
           setOverlayVersion((value) => value + 1);
         }
@@ -124,25 +160,21 @@ export function useSessionChats(sessionId: string | null) {
     [optimisticOverlay, sessionId],
   );
 
-  const chats = useMemo(
-    () =>
-      (data?.chats ?? []).map((chat) => {
-        const overlay = optimisticOverlay?.get(chat.id);
-        if (!overlay) {
-          return chat;
-        }
+  const chats = (data?.chats ?? []).map((chat) => {
+    const overlay = optimisticOverlay?.get(chat.id);
+    if (!overlay) {
+      return chat;
+    }
 
-        let next = chat;
-        if (overlay.title && chat.title === "New chat") {
-          next = { ...next, title: overlay.title };
-        }
-        if (overlay.streaming && !chat.isStreaming) {
-          next = { ...next, isStreaming: true };
-        }
-        return next;
-      }),
-    [data, optimisticOverlay, overlayVersion],
-  );
+    let next = chat;
+    if (overlay.title && chat.title === "New chat") {
+      next = { ...next, title: overlay.title };
+    }
+    if (overlay.streaming && !chat.isStreaming) {
+      next = { ...next, isStreaming: true };
+    }
+    return next;
+  });
 
   useEffect(() => {
     if (!data || !optimisticOverlay || !sessionId) {
@@ -214,9 +246,21 @@ export function useSessionChats(sessionId: string | null) {
 
     if (optimisticOverlay.size === 0) {
       sessionChatOverlays.delete(sessionId);
+      clearOverlayCleanup(sessionId);
     }
     setOverlayVersion((value) => value + 1);
   }, [data, optimisticOverlay, sessionId]);
+
+  const toChatsResponse = useCallback(
+    (
+      current: ChatsResponse | undefined,
+      nextChats: SessionChatListItem[],
+    ): ChatsResponse => ({
+      defaultModelId: current?.defaultModelId ?? data?.defaultModelId ?? null,
+      chats: nextChats,
+    }),
+    [data?.defaultModelId],
+  );
 
   const createChat = (): CreateChatResult => {
     if (!sessionId) {
@@ -228,7 +272,7 @@ export function useSessionChats(sessionId: string | null) {
       id: crypto.randomUUID(),
       sessionId,
       title: "New chat",
-      modelId: data?.chats[0]?.modelId ?? null,
+      modelId: data?.defaultModelId ?? null,
       activeStreamId: null,
       lastAssistantMessageAt: null,
       createdAt: now,
@@ -236,8 +280,8 @@ export function useSessionChats(sessionId: string | null) {
     };
 
     void mutate(
-      (current) => ({
-        chats: [
+      (current) =>
+        toChatsResponse(current, [
           {
             ...optimisticChat,
             hasUnread: false,
@@ -246,8 +290,7 @@ export function useSessionChats(sessionId: string | null) {
           ...(current?.chats ?? []).filter(
             (chat) => chat.id !== optimisticChat.id,
           ),
-        ],
-      }),
+        ]),
       { revalidate: false },
     );
 
@@ -265,11 +308,13 @@ export function useSessionChats(sessionId: string | null) {
 
       if (!res.ok || !responseData.chat) {
         await mutate(
-          (current) => ({
-            chats: (current?.chats ?? []).filter(
-              (chat) => chat.id !== optimisticChat.id,
+          (current) =>
+            toChatsResponse(
+              current,
+              (current?.chats ?? []).filter(
+                (chat) => chat.id !== optimisticChat.id,
+              ),
             ),
-          }),
           { revalidate: false },
         );
         throw new Error(responseData.error ?? "Failed to create chat");
@@ -278,8 +323,8 @@ export function useSessionChats(sessionId: string | null) {
       const createdChat = responseData.chat;
 
       await mutate(
-        (current) => ({
-          chats: [
+        (current) =>
+          toChatsResponse(current, [
             {
               ...createdChat,
               hasUnread: false,
@@ -288,8 +333,7 @@ export function useSessionChats(sessionId: string | null) {
             ...(current?.chats ?? []).filter(
               (chat) => chat.id !== createdChat.id,
             ),
-          ],
-        }),
+          ]),
         { revalidate: false },
       );
 
@@ -317,11 +361,13 @@ export function useSessionChats(sessionId: string | null) {
 
     const updatedChat = responseData.chat;
     await mutate(
-      (current) => ({
-        chats: (current?.chats ?? []).map((chat) =>
-          chat.id === chatId ? { ...chat, ...updatedChat } : chat,
+      (current) =>
+        toChatsResponse(
+          current,
+          (current?.chats ?? []).map((chat) =>
+            chat.id === chatId ? { ...chat, ...updatedChat } : chat,
+          ),
         ),
-      }),
       { revalidate: false },
     );
 
@@ -347,9 +393,11 @@ export function useSessionChats(sessionId: string | null) {
     }
 
     await mutate(
-      (current) => ({
-        chats: (current?.chats ?? []).filter((chat) => chat.id !== chatId),
-      }),
+      (current) =>
+        toChatsResponse(
+          current,
+          (current?.chats ?? []).filter((chat) => chat.id !== chatId),
+        ),
       { revalidate: false },
     );
   };
@@ -373,11 +421,13 @@ export function useSessionChats(sessionId: string | null) {
     }
 
     await mutate(
-      (current) => ({
-        chats: (current?.chats ?? []).map((chat) =>
-          chat.id === chatId ? { ...chat, hasUnread: false } : chat,
+      (current) =>
+        toChatsResponse(
+          current,
+          (current?.chats ?? []).map((chat) =>
+            chat.id === chatId ? { ...chat, hasUnread: false } : chat,
+          ),
         ),
-      }),
       { revalidate: false },
     );
   };
@@ -405,11 +455,12 @@ export function useSessionChats(sessionId: string | null) {
           return current;
         }
 
-        return {
-          chats: current.chats.map((chat) =>
+        return toChatsResponse(
+          current,
+          current.chats.map((chat) =>
             chat.id === chatId ? { ...chat, isStreaming } : chat,
           ),
-        };
+        );
       },
       { revalidate: false },
     );

--- a/apps/web/hooks/use-session-chats.ts
+++ b/apps/web/hooks/use-session-chats.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import type { Chat } from "@/lib/db/schema";
 import { fetcher } from "@/lib/swr";
@@ -14,50 +14,204 @@ interface ChatsResponse {
   chats: SessionChatListItem[];
 }
 
+type StreamingOverlay = {
+  setAt: number;
+  seenServerStreaming: boolean;
+};
+
+type ChatOptimisticOverlay = {
+  title?: string;
+  streaming?: StreamingOverlay;
+};
+
+const STREAMING_RACE_GRACE_MS = 12_000;
+
+// Persist optimistic chat UI state across chat route transitions.
+const sessionChatOverlays = new Map<
+  string,
+  Map<string, ChatOptimisticOverlay>
+>();
+
+function getSessionOverlay(
+  sessionId: string,
+): Map<string, ChatOptimisticOverlay> {
+  const existing = sessionChatOverlays.get(sessionId);
+  if (existing) {
+    return existing;
+  }
+
+  const created = new Map<string, ChatOptimisticOverlay>();
+  sessionChatOverlays.set(sessionId, created);
+  return created;
+}
+
+function isOverlayEmpty(overlay: ChatOptimisticOverlay): boolean {
+  return !overlay.title && !overlay.streaming;
+}
+
+function overlaysEqual(
+  left: ChatOptimisticOverlay | undefined,
+  right: ChatOptimisticOverlay,
+): boolean {
+  return (
+    left?.title === right.title &&
+    left?.streaming?.setAt === right.streaming?.setAt &&
+    left?.streaming?.seenServerStreaming ===
+      right.streaming?.seenServerStreaming
+  );
+}
+
 export function useSessionChats(sessionId: string | null) {
+  const [overlayVersion, setOverlayVersion] = useState(0);
+  const optimisticOverlay = useMemo(
+    () => (sessionId ? getSessionOverlay(sessionId) : null),
+    [sessionId],
+  );
+
   const { data, error, isLoading, mutate } = useSWR<ChatsResponse>(
     sessionId ? `/api/sessions/${sessionId}/chats` : null,
     fetcher,
     {
       refreshInterval: (latestData) =>
-        latestData?.chats.some((chat) => chat.isStreaming) ? 1_000 : 5_000,
+        latestData?.chats.some((chat) => chat.isStreaming) ||
+        (optimisticOverlay
+          ? Array.from(optimisticOverlay.values()).some(
+              (overlay) => overlay.streaming,
+            )
+          : false)
+          ? 1_000
+          : 5_000,
       refreshWhenHidden: false,
       revalidateOnFocus: true,
     },
   );
 
-  const [optimisticTitles, setOptimisticTitles] = useState<
-    Record<string, string>
-  >({});
+  const updateOverlay = useCallback(
+    (
+      chatId: string,
+      updater: (overlay: ChatOptimisticOverlay) => ChatOptimisticOverlay,
+    ) => {
+      if (!optimisticOverlay || !sessionId) {
+        return;
+      }
 
-  const chats = (data?.chats ?? []).map((chat) => {
-    const optimisticTitle = optimisticTitles[chat.id];
-    if (!optimisticTitle || chat.title !== "New chat") {
-      return chat;
-    }
-    return { ...chat, title: optimisticTitle };
-  });
+      const current = optimisticOverlay.get(chatId);
+      const next = updater(current ? { ...current } : {});
+
+      if (isOverlayEmpty(next)) {
+        if (current) {
+          optimisticOverlay.delete(chatId);
+          if (optimisticOverlay.size === 0) {
+            sessionChatOverlays.delete(sessionId);
+          }
+          setOverlayVersion((value) => value + 1);
+        }
+        return;
+      }
+
+      if (overlaysEqual(current, next)) {
+        return;
+      }
+
+      optimisticOverlay.set(chatId, next);
+      setOverlayVersion((value) => value + 1);
+    },
+    [optimisticOverlay, sessionId],
+  );
+
+  const chats = useMemo(
+    () =>
+      (data?.chats ?? []).map((chat) => {
+        const overlay = optimisticOverlay?.get(chat.id);
+        if (!overlay) {
+          return chat;
+        }
+
+        let next = chat;
+        if (overlay.title && chat.title === "New chat") {
+          next = { ...next, title: overlay.title };
+        }
+        if (overlay.streaming && !chat.isStreaming) {
+          next = { ...next, isStreaming: true };
+        }
+        return next;
+      }),
+    [data, optimisticOverlay, overlayVersion],
+  );
 
   useEffect(() => {
-    if (!data) return;
-    setOptimisticTitles((current) => {
-      let next = current;
-      let changed = false;
+    if (!data || !optimisticOverlay || !sessionId) {
+      return;
+    }
 
-      for (const chat of data.chats) {
-        if (!current[chat.id]) continue;
-        if (chat.title !== "New chat") {
-          if (next === current) {
-            next = { ...current };
+    let changed = false;
+    const chatsById = new Map(data.chats.map((chat) => [chat.id, chat]));
+
+    for (const [chatId, overlay] of optimisticOverlay) {
+      const chat = chatsById.get(chatId);
+
+      if (!chat) {
+        optimisticOverlay.delete(chatId);
+        changed = true;
+        continue;
+      }
+
+      let nextOverlay = overlay;
+
+      if (overlay.title && chat.title !== "New chat") {
+        if (nextOverlay === overlay) {
+          nextOverlay = { ...overlay };
+        }
+        delete nextOverlay.title;
+      }
+
+      if (overlay.streaming) {
+        const streaming = nextOverlay.streaming ?? overlay.streaming;
+        if (chat.isStreaming) {
+          if (!streaming.seenServerStreaming) {
+            if (nextOverlay === overlay) {
+              nextOverlay = { ...overlay };
+            }
+            nextOverlay.streaming = {
+              ...streaming,
+              seenServerStreaming: true,
+            };
           }
-          delete next[chat.id];
-          changed = true;
+        } else {
+          const ageMs = Date.now() - streaming.setAt;
+          if (
+            streaming.seenServerStreaming ||
+            ageMs > STREAMING_RACE_GRACE_MS
+          ) {
+            if (nextOverlay === overlay) {
+              nextOverlay = { ...overlay };
+            }
+            delete nextOverlay.streaming;
+          }
         }
       }
 
-      return changed ? next : current;
-    });
-  }, [data]);
+      if (nextOverlay === overlay) {
+        continue;
+      }
+
+      changed = true;
+      if (isOverlayEmpty(nextOverlay)) {
+        optimisticOverlay.delete(chatId);
+      } else {
+        optimisticOverlay.set(chatId, nextOverlay);
+      }
+    }
+
+    if (!changed) {
+      return;
+    }
+
+    if (optimisticOverlay.size === 0) {
+      sessionChatOverlays.delete(sessionId);
+    }
+    setOverlayVersion((value) => value + 1);
+  }, [data, optimisticOverlay, sessionId]);
 
   const createChat = async () => {
     if (!sessionId) {
@@ -74,11 +228,13 @@ export function useSessionChats(sessionId: string | null) {
       throw new Error(responseData.error ?? "Failed to create chat");
     }
 
+    const createdChat = responseData.chat;
+
     await mutate(
       (current) => ({
         chats: [
           {
-            ...responseData.chat!,
+            ...createdChat,
             hasUnread: false,
             isStreaming: false,
           },
@@ -88,7 +244,7 @@ export function useSessionChats(sessionId: string | null) {
       { revalidate: false },
     );
 
-    return responseData.chat;
+    return createdChat;
   };
 
   const renameChat = async (chatId: string, title: string) => {
@@ -175,6 +331,22 @@ export function useSessionChats(sessionId: string | null) {
   };
 
   const setChatStreaming = async (chatId: string, isStreaming: boolean) => {
+    if (isStreaming) {
+      updateOverlay(chatId, (overlay) => ({
+        ...overlay,
+        streaming: {
+          setAt: Date.now(),
+          seenServerStreaming: false,
+        },
+      }));
+    } else {
+      updateOverlay(chatId, (overlay) => {
+        const next = { ...overlay };
+        delete next.streaming;
+        return next;
+      });
+    }
+
     await mutate(
       (current) => {
         if (!current) {
@@ -191,18 +363,22 @@ export function useSessionChats(sessionId: string | null) {
     );
   };
 
-  const setChatTitle = async (chatId: string, title: string) => {
-    setOptimisticTitles((current) => ({ ...current, [chatId]: title }));
+  const setChatTitle = (chatId: string, title: string) => {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      return;
+    }
+
+    updateOverlay(chatId, (overlay) => ({
+      ...overlay,
+      title: trimmedTitle,
+    }));
   };
 
-  const clearChatTitle = async (chatId: string) => {
-    setOptimisticTitles((current) => {
-      if (!current[chatId]) {
-        return current;
-      }
-
-      const next = { ...current };
-      delete next[chatId];
+  const clearChatTitle = (chatId: string) => {
+    updateOverlay(chatId, (overlay) => {
+      const next = { ...overlay };
+      delete next.title;
       return next;
     });
   };

--- a/apps/web/hooks/use-session-chats.ts
+++ b/apps/web/hooks/use-session-chats.ts
@@ -14,6 +14,11 @@ interface ChatsResponse {
   chats: SessionChatListItem[];
 }
 
+type CreateChatResult = {
+  chat: Chat;
+  persisted: Promise<Chat>;
+};
+
 type StreamingOverlay = {
   setAt: number;
   seenServerStreaming: boolean;
@@ -213,38 +218,85 @@ export function useSessionChats(sessionId: string | null) {
     setOverlayVersion((value) => value + 1);
   }, [data, optimisticOverlay, sessionId]);
 
-  const createChat = async () => {
+  const createChat = (): CreateChatResult => {
     if (!sessionId) {
       throw new Error("Missing sessionId");
     }
 
-    const res = await fetch(`/api/sessions/${sessionId}/chats`, {
-      method: "POST",
-    });
+    const now = new Date();
+    const optimisticChat: Chat = {
+      id: crypto.randomUUID(),
+      sessionId,
+      title: "New chat",
+      modelId: data?.chats[0]?.modelId ?? null,
+      activeStreamId: null,
+      lastAssistantMessageAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
 
-    const responseData = (await res.json()) as { chat?: Chat; error?: string };
-
-    if (!res.ok || !responseData.chat) {
-      throw new Error(responseData.error ?? "Failed to create chat");
-    }
-
-    const createdChat = responseData.chat;
-
-    await mutate(
+    void mutate(
       (current) => ({
         chats: [
           {
-            ...createdChat,
+            ...optimisticChat,
             hasUnread: false,
             isStreaming: false,
           },
-          ...(current?.chats ?? []),
+          ...(current?.chats ?? []).filter(
+            (chat) => chat.id !== optimisticChat.id,
+          ),
         ],
       }),
       { revalidate: false },
     );
 
-    return createdChat;
+    const persisted = (async () => {
+      const res = await fetch(`/api/sessions/${sessionId}/chats`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: optimisticChat.id }),
+      });
+
+      const responseData = (await res.json()) as {
+        chat?: Chat;
+        error?: string;
+      };
+
+      if (!res.ok || !responseData.chat) {
+        await mutate(
+          (current) => ({
+            chats: (current?.chats ?? []).filter(
+              (chat) => chat.id !== optimisticChat.id,
+            ),
+          }),
+          { revalidate: false },
+        );
+        throw new Error(responseData.error ?? "Failed to create chat");
+      }
+
+      const createdChat = responseData.chat;
+
+      await mutate(
+        (current) => ({
+          chats: [
+            {
+              ...createdChat,
+              hasUnread: false,
+              isStreaming: false,
+            },
+            ...(current?.chats ?? []).filter(
+              (chat) => chat.id !== createdChat.id,
+            ),
+          ],
+        }),
+        { revalidate: false },
+      );
+
+      return createdChat;
+    })();
+
+    return { chat: optimisticChat, persisted };
   };
 
   const renameChat = async (chatId: string, title: string) => {

--- a/apps/web/hooks/use-sessions.ts
+++ b/apps/web/hooks/use-sessions.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import useSWR from "swr";
-import type { Session } from "@/lib/db/schema";
+import useSWR, { useSWRConfig } from "swr";
+import type { Chat, Session } from "@/lib/db/schema";
 import { fetcher } from "@/lib/swr";
 
 interface CreateSessionInput {
@@ -20,7 +20,7 @@ interface SessionsResponse {
 
 interface CreateSessionResponse {
   session: Session;
-  chat: { id: string };
+  chat: Chat;
 }
 
 export function useSessions(options?: { enabled?: boolean }) {
@@ -29,6 +29,7 @@ export function useSessions(options?: { enabled?: boolean }) {
     enabled ? "/api/sessions" : null,
     fetcher,
   );
+  const { mutate: globalMutate } = useSWRConfig();
 
   const sessions = data?.sessions ?? [];
 
@@ -41,7 +42,7 @@ export function useSessions(options?: { enabled?: boolean }) {
 
     const responseData = (await res.json()) as {
       session?: Session;
-      chat?: { id: string };
+      chat?: Chat;
       error?: string;
     };
 
@@ -51,6 +52,25 @@ export function useSessions(options?: { enabled?: boolean }) {
 
     const createdSession = responseData.session;
     const createdChat = responseData.chat;
+
+    // Pre-seed the session chats SWR cache so the sidebar shows the
+    // initial chat immediately on navigation instead of waiting for a
+    // fresh fetch.
+    void globalMutate(
+      `/api/sessions/${createdSession.id}/chats`,
+      {
+        chats: [
+          {
+            ...createdChat,
+            hasUnread: false,
+            isStreaming: false,
+          },
+        ],
+        defaultModelId: createdChat.modelId,
+      },
+      { revalidate: false },
+    );
+
     await mutate(
       {
         sessions: [createdSession, ...sessions],
@@ -61,7 +81,7 @@ export function useSessions(options?: { enabled?: boolean }) {
     return {
       session: createdSession,
       chat: createdChat,
-    } as CreateSessionResponse;
+    } satisfies CreateSessionResponse;
   };
 
   const archiveSession = async (sessionId: string) => {


### PR DESCRIPTION
## Summary
- increase optimistic chat route lookup retry window to avoid redirecting before chat creation persists
- re-register cleared session overlay maps before writing new optimistic overlays so state persists across navigation
- document both issues in AGENTS.md lessons learned

## Validation
- turbo typecheck --filter=web
- turbo lint --filter=web