### PR TITLE
Exempt API routes and install script from Vercel deployment protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,3 +280,4 @@ Use `catalog:` for shared external versions:
 - For sandbox lifecycle kicks, do not persist `lifecycleRunId` before `start(...)`; start first and let the durable workflow claim/verify the lease so canceled fire-and-forget kicks cannot strand a stale lease.
 - Server-side optimistic chat route lookup must allow realistic persistence latency (multi-second retry window), otherwise `/sessions/[sessionId]/chats/[chatId]` can redirect away before chat creation finishes.
 - When session overlay maps are deleted after becoming empty, any later overlay writes in the same hook instance must re-register the map in the global registry, or optimistic overlays will not survive route transitions.
+- `bunx @vercel/config validate` executes the CLI under Node via its shebang and cannot parse TypeScript-style `vercel.ts` imports; use `bunx --bun @vercel/config validate` (or `bun node_modules/@vercel/config/dist/cli.js validate`) for reliable local validation.

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
         "@vercel/blob": "^0.27.0",
+        "@vercel/config": "^0.0.31",
         "turbo": "^2.5.4",
         "typescript": "^5",
       },
@@ -934,6 +935,8 @@
 
     "@vercel/blob": ["@vercel/blob@0.27.3", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^5.28.4" } }, "sha512-WizeAxzOTmv0JL7wOaxvLIU/KdBcrclM1ZUOdSlIZAxsTTTe1jsyBthStLby0Ueh7FnmKYAjLz26qRJTk5SDkQ=="],
 
+    "@vercel/config": ["@vercel/config@0.0.31", "", { "dependencies": { "pretty-cache-header": "^1.0.0", "zod": "^3.22.0" }, "bin": { "config": "dist/cli.js" } }, "sha512-wWLvJ1GsOAOtcKhDwEhfDiTn3BJrWM9dVjcsR+QmiiGf5II8nuToHYp9GZLwdolhQgnDqikGbtNHpfoDeg2hFg=="],
+
     "@vercel/functions": ["@vercel/functions@3.4.1", "", { "dependencies": { "@vercel/oidc": "3.1.0" }, "peerDependencies": { "@aws-sdk/credential-provider-web-identity": "*" }, "optionalPeers": ["@aws-sdk/credential-provider-web-identity"] }, "sha512-+wqs1fscC1l2NZYL8Ahxe/vba4YzcuhxTV99Kf8sNwNeATaxQ9rbR6BILksoGDmm99YiD0wc0hBJcYxVNwiNaw=="],
 
     "@vercel/oidc": ["@vercel/oidc@2.0.2", "", { "dependencies": { "@types/ms": "2.1.0", "ms": "2.1.3" } }, "sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g=="],
@@ -1708,6 +1711,8 @@
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 
+    "pretty-cache-header": ["pretty-cache-header@1.0.0", "", { "dependencies": { "timestring": "^6.0.0" } }, "sha512-xtXazslu25CdnGnUkByU1RoOjK55TqwatJkjjJLg5ZAdz2Lngko/mmaUgeET36P2GMlNwh3fdM7FWBO717pNcw=="],
+
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
@@ -1903,6 +1908,8 @@
     "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
+
+    "timestring": ["timestring@6.0.0", "", {}, "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA=="],
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
     "@vercel/blob": "^0.27.0",
+    "@vercel/config": "^0.0.31",
     "turbo": "^2.5.4",
     "typescript": "^5"
   },

--- a/vercel.ts
+++ b/vercel.ts
@@ -1,0 +1,26 @@
+import { deploymentEnv, type VercelConfig } from "@vercel/config/v1";
+
+const bypassSecret = deploymentEnv("VERCEL_AUTOMATION_BYPASS_SECRET");
+
+export const config: VercelConfig = {
+  headers: [
+    {
+      source: "/api/(.*)",
+      headers: [
+        {
+          key: "x-vercel-protection-bypass",
+          value: bypassSecret,
+        },
+      ],
+    },
+    {
+      source: "/install",
+      headers: [
+        {
+          key: "x-vercel-protection-bypass",
+          value: bypassSecret,
+        },
+      ],
+    },
+  ],
+};

--- a/vercel.ts
+++ b/vercel.ts
@@ -1,8 +1,6 @@
-import type { VercelConfig } from "@vercel/config/v1";
+const bypassSecret = "$VERCEL_AUTOMATION_BYPASS_SECRET";
 
-const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? "";
-
-export const config: VercelConfig = {
+const config = {
   headers: [
     {
       source: "/api/(.*)",
@@ -24,3 +22,5 @@ export const config: VercelConfig = {
     },
   ],
 };
+
+export default config;

--- a/vercel.ts
+++ b/vercel.ts
@@ -1,26 +1,24 @@
-const bypassSecret = "$VERCEL_AUTOMATION_BYPASS_SECRET";
+import { routes, type VercelConfig } from "@vercel/config/v1";
 
-const config = {
-  headers: [
-    {
-      source: "/api/(.*)",
-      headers: [
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
+const bypassHeaders = bypassSecret
+  ? [
+      routes.header("/api/(.*)", [
         {
           key: "x-vercel-protection-bypass",
           value: bypassSecret,
         },
-      ],
-    },
-    {
-      source: "/install",
-      headers: [
+      ]),
+      routes.header("/install", [
         {
           key: "x-vercel-protection-bypass",
           value: bypassSecret,
         },
-      ],
-    },
-  ],
+      ]),
+    ]
+  : [];
+
+export const config: VercelConfig = {
+  headers: bypassHeaders,
 };
-
-export default config;

--- a/vercel.ts
+++ b/vercel.ts
@@ -1,4 +1,5 @@
-import { deploymentEnv, type VercelConfig } from "@vercel/config/v1";
+import type { VercelConfig } from "@vercel/config/v1";
+import { deploymentEnv } from "@vercel/config/v1";
 
 const bypassSecret = deploymentEnv("VERCEL_AUTOMATION_BYPASS_SECRET");
 

--- a/vercel.ts
+++ b/vercel.ts
@@ -1,7 +1,6 @@
 import type { VercelConfig } from "@vercel/config/v1";
-import { deploymentEnv } from "@vercel/config/v1";
 
-const bypassSecret = deploymentEnv("VERCEL_AUTOMATION_BYPASS_SECRET");
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? "";
 
 export const config: VercelConfig = {
   headers: [


### PR DESCRIPTION
## Summary
- add `vercel.ts` config with `x-vercel-protection-bypass` headers for `/api/(.*)` and `/install` using `deploymentEnv("VERCEL_AUTOMATION_BYPASS_SECRET")`
- add `@vercel/config` to dev dependencies and update `bun.lock` for config compilation support
- split `vercel.ts` value/type imports for compatibility and document local validation with `bunx --bun @vercel/config validate` in `AGENTS.md`