### PR TITLE
Fix PR generation fork fallback and permission error detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,3 +287,4 @@ Use `catalog:` for shared external versions:
 - For PR/push flows, installation tokens can fail on repos outside selected installation scope even when the user's GitHub token has write access; retry origin push/PR creation with user token before forcing fork fallback.
 - Even when branch push succeeds, GitHub PR creation can still return `403 Resource not accessible by integration`; expose a compare URL fallback so users can complete PR creation manually in the browser.
 - For manual compare fallback, include `title` and `body` query params on the GitHub compare URL so PR details are prefilled when API creation is unavailable.
+- Preserve fork PR metadata across retries: if a branch already tracks `fork/<branch>` and no new push is needed, derive and return `prHeadOwner` from fork upstream/remote state so later PR creation still uses a qualified head ref.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,3 +280,10 @@ Use `catalog:` for shared external versions:
 - For sandbox lifecycle kicks, do not persist `lifecycleRunId` before `start(...)`; start first and let the durable workflow claim/verify the lease so canceled fire-and-forget kicks cannot strand a stale lease.
 - Server-side optimistic chat route lookup must allow realistic persistence latency (multi-second retry window), otherwise `/sessions/[sessionId]/chats/[chatId]` can redirect away before chat creation finishes.
 - When session overlay maps are deleted after becoming empty, any later overlay writes in the same hook instance must re-register the map in the global registry, or optimistic overlays will not survive route transitions.
+- Public upstream repositories may reject direct branch pushes; PR generation should fall back to creating/pushing to the user's fork and PR creation must use a qualified head ref (`forkOwner:branch`).
+- GitHub fork creation can take longer than a few seconds to become pushable; PR fallback should retry fork push on transient `repository not found` errors instead of failing immediately.
+- Git push failures from Vercel sandboxes can return empty output even when auth/write is denied; PR fallback logic should not rely only on matching "permission" text before attempting fork fallback.
+- GitHub App user/integration tokens may return `403 Resource not accessible by integration` for fork creation; PR fallback should surface a manual-fork guidance path instead of assuming automatic fork creation is always allowed.
+- For PR/push flows, installation tokens can fail on repos outside selected installation scope even when the user's GitHub token has write access; retry origin push/PR creation with user token before forcing fork fallback.
+- Even when branch push succeeds, GitHub PR creation can still return `403 Resource not accessible by integration`; expose a compare URL fallback so users can complete PR creation manually in the browser.
+- For manual compare fallback, include `title` and `body` query params on the GitHub compare URL so PR details are prefilled when API creation is unavailable.

--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -48,7 +48,9 @@ interface EnsureForkOptions {
   forkOwner: string;
 }
 
-type EnsureForkResult = { success: true } | { success: false; error: string };
+type EnsureForkResult =
+  | { success: true; forkRepoName: string }
+  | { success: false; error: string };
 
 const FORK_PUSH_RETRY_ATTEMPTS = 12;
 const FORK_PUSH_RETRY_DELAY_MS = 2000;
@@ -70,11 +72,14 @@ function sleep(ms: number): Promise<void> {
 function isPermissionPushError(output: string): boolean {
   const lowerOutput = output.toLowerCase();
   return (
-    lowerOutput.includes("permission") ||
-    lowerOutput.includes("403") ||
-    lowerOutput.includes("denied") ||
+    lowerOutput.includes("permission to") ||
+    lowerOutput.includes("permission denied") ||
+    lowerOutput.includes("the requested url returned error: 403") ||
+    lowerOutput.includes("access denied") ||
     lowerOutput.includes("authentication failed") ||
-    lowerOutput.includes("invalid username")
+    lowerOutput.includes("invalid username") ||
+    lowerOutput.includes("unable to access") ||
+    lowerOutput.includes("resource not accessible by integration")
   );
 }
 
@@ -128,7 +133,15 @@ async function ensureForkExists({
   });
 
   if (publicForkResponse.ok) {
-    return { success: true };
+    const repoData: unknown = await publicForkResponse.json();
+    const forkRepoName =
+      typeof repoData === "object" &&
+      repoData !== null &&
+      "name" in repoData &&
+      typeof repoData.name === "string"
+        ? repoData.name
+        : upstreamRepo;
+    return { success: true, forkRepoName };
   }
 
   const existingForkResponse = await fetch(forkRepoUrl, {
@@ -137,7 +150,15 @@ async function ensureForkExists({
   });
 
   if (existingForkResponse.ok) {
-    return { success: true };
+    const repoData: unknown = await existingForkResponse.json();
+    const forkRepoName =
+      typeof repoData === "object" &&
+      repoData !== null &&
+      "name" in repoData &&
+      typeof repoData.name === "string"
+        ? repoData.name
+        : upstreamRepo;
+    return { success: true, forkRepoName };
   }
 
   if (existingForkResponse.status !== 404) {
@@ -182,7 +203,15 @@ async function ensureForkExists({
     };
   }
 
-  return { success: true };
+  const createData: unknown = await createForkResponse.json().catch(() => null);
+  const forkRepoName =
+    typeof createData === "object" &&
+    createData !== null &&
+    "name" in createData &&
+    typeof createData.name === "string"
+      ? createData.name
+      : upstreamRepo;
+  return { success: true, forkRepoName };
 }
 
 // Allow up to 2 minutes for AI generation and git operations
@@ -634,7 +663,8 @@ Respond with ONLY the commit message, nothing else.`,
             );
           }
 
-          const forkAuthUrl = `https://x-access-token:${cachedUserToken}@github.com/${forkOwner}/${sessionRecord.repoName}.git`;
+          const { forkRepoName } = forkResult;
+          const forkAuthUrl = `https://x-access-token:${cachedUserToken}@github.com/${forkOwner}/${forkRepoName}.git`;
 
           await sandbox.exec(
             "git remote remove fork 2>/dev/null || true",
@@ -673,7 +703,7 @@ Respond with ONLY the commit message, nothing else.`,
             if (pushForkResult.success) {
               pushToForkSucceeded = true;
               console.log(
-                `[generate-pr] Push to origin denied; pushed branch to fork ${forkOwner}/${sessionRecord.repoName}`,
+                `[generate-pr] Push to origin denied; pushed branch to fork ${forkOwner}/${forkRepoName}`,
               );
               prHeadOwner = forkOwner;
               gitActions.pushed = true;
@@ -711,7 +741,7 @@ Respond with ONLY the commit message, nothing else.`,
 
             return Response.json(
               {
-                error: `Failed to push to fork ${forkOwner}/${sessionRecord.repoName}: ${redactGitHubToken(lastPushForkOutput).slice(0, 200)}`,
+                error: `Failed to push to fork ${forkOwner}/${forkRepoName}: ${redactGitHubToken(lastPushForkOutput).slice(0, 200)}`,
               },
               { status: 500 },
             );

--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -1,8 +1,10 @@
 import { connectSandbox } from "@open-harness/sandbox";
 import { gateway, generateText, NoObjectGeneratedError, Output } from "ai";
 import { z } from "zod";
+import { getGitHubAccount } from "@/lib/db/accounts";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { getRepoToken } from "@/lib/github/get-repo-token";
+import { getUserGitHubToken } from "@/lib/github/user-token";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 
@@ -37,6 +39,134 @@ function generateBranchName(username: string, name?: string | null): string {
  */
 function looksLikeCommitHash(str: string): boolean {
   return /^[0-9a-f]{7,40}$/i.test(str);
+}
+
+interface EnsureForkOptions {
+  token: string;
+  upstreamOwner: string;
+  upstreamRepo: string;
+  forkOwner: string;
+}
+
+type EnsureForkResult = { success: true } | { success: false; error: string };
+
+const FORK_PUSH_RETRY_ATTEMPTS = 12;
+const FORK_PUSH_RETRY_DELAY_MS = 2000;
+
+function getGitHubHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isPermissionPushError(output: string): boolean {
+  const lowerOutput = output.toLowerCase();
+  return (
+    lowerOutput.includes("permission") ||
+    lowerOutput.includes("403") ||
+    lowerOutput.includes("denied") ||
+    lowerOutput.includes("authentication failed") ||
+    lowerOutput.includes("invalid username")
+  );
+}
+
+function isRetryableForkPushError(output: string): boolean {
+  const lowerOutput = output.toLowerCase();
+  return (
+    lowerOutput.includes("repository not found") ||
+    lowerOutput.includes("could not read from remote repository") ||
+    lowerOutput.includes("remote not found")
+  );
+}
+
+function redactGitHubToken(text: string): string {
+  return text.replace(
+    /https:\/\/x-access-token:[^@\s]+@github\.com/gi,
+    "https://x-access-token:***@github.com",
+  );
+}
+
+async function ensureForkExists({
+  token,
+  upstreamOwner,
+  upstreamRepo,
+  forkOwner,
+}: EnsureForkOptions): Promise<EnsureForkResult> {
+  const headers = getGitHubHeaders(token);
+  const forkRepoUrl = `https://api.github.com/repos/${forkOwner}/${upstreamRepo}`;
+
+  const publicForkResponse = await fetch(forkRepoUrl, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    cache: "no-store",
+  });
+
+  if (publicForkResponse.ok) {
+    return { success: true };
+  }
+
+  const existingForkResponse = await fetch(forkRepoUrl, {
+    headers,
+    cache: "no-store",
+  });
+
+  if (existingForkResponse.ok) {
+    return { success: true };
+  }
+
+  if (existingForkResponse.status !== 404) {
+    const responseText = await existingForkResponse.text();
+    return {
+      success: false,
+      error: `Failed to check fork repository: ${responseText.slice(0, 200)}`,
+    };
+  }
+
+  const createForkResponse = await fetch(
+    `https://api.github.com/repos/${upstreamOwner}/${upstreamRepo}/forks`,
+    {
+      method: "POST",
+      headers,
+      cache: "no-store",
+    },
+  );
+
+  if (
+    !createForkResponse.ok &&
+    createForkResponse.status !== 202 &&
+    createForkResponse.status !== 422
+  ) {
+    const responseText = await createForkResponse.text();
+    const lowerResponseText = responseText.toLowerCase();
+
+    if (
+      createForkResponse.status === 403 &&
+      lowerResponseText.includes("resource not accessible by integration")
+    ) {
+      return {
+        success: false,
+        error:
+          "GitHub denied automatic fork creation for this token. Create a fork manually on GitHub, then retry creating the PR.",
+      };
+    }
+
+    return {
+      success: false,
+      error: `Failed to create fork: ${responseText.slice(0, 200)}`,
+    };
+  }
+
+  return { success: true };
 }
 
 // Allow up to 2 minutes for AI generation and git operations
@@ -111,14 +241,16 @@ export async function POST(req: Request) {
   // 3. Connect to sandbox
   const sandbox = await connectSandbox(sessionRecord.sandboxState);
   const cwd = sandbox.workingDirectory;
+  let repoTokenResult: Awaited<ReturnType<typeof getRepoToken>> | null = null;
+  let cachedUserToken: string | null = null;
 
   if (sessionRecord.repoOwner && sessionRecord.repoName) {
     try {
-      const tokenResult = await getRepoToken(
+      repoTokenResult = await getRepoToken(
         session.user.id,
         sessionRecord.repoOwner,
       );
-      const authUrl = `https://x-access-token:${tokenResult.token}@github.com/${sessionRecord.repoOwner}/${sessionRecord.repoName}.git`;
+      const authUrl = `https://x-access-token:${repoTokenResult.token}@github.com/${sessionRecord.repoOwner}/${sessionRecord.repoName}.git`;
       await sandbox.exec(`git remote set-url origin "${authUrl}"`, cwd, 5000);
     } catch {
       return Response.json(
@@ -282,19 +414,12 @@ export async function POST(req: Request) {
     committed?: boolean;
     commitMessage?: string;
     pushed?: boolean;
+    pushedToFork?: boolean;
   } = {};
+  let prHeadOwner: string | null = null;
 
   if (hasUncommittedChanges) {
-    // 4a. Get diff for commit message generation
-    const diffResult = await sandbox.exec("git diff HEAD", cwd, 30000);
-    const stagedDiffResult = await sandbox.exec(
-      "git diff --cached",
-      cwd,
-      30000,
-    );
-    const diffForCommit = diffResult.stdout + stagedDiffResult.stdout;
-
-    // 4b. Stage all changes
+    // 4a. Stage all changes first so untracked files are included in diff
     const addResult = await sandbox.exec("git add -A", cwd, 10000);
     if (!addResult.success) {
       return Response.json(
@@ -303,10 +428,22 @@ export async function POST(req: Request) {
       );
     }
 
+    // 4b. Get staged diff for commit message generation
+    const stagedDiffResult = await sandbox.exec(
+      "git diff --cached",
+      cwd,
+      30000,
+    );
+    const diffForCommit = stagedDiffResult.stdout;
+
+    const fallbackCommitMessage = "chore: update repository changes";
+
     // 4c. Generate commit message with AI
-    const commitMsgResult = await generateText({
-      model: gateway("anthropic/claude-haiku-4.5"),
-      prompt: `Generate a concise git commit message for these changes. Use conventional commit format (e.g., "feat:", "fix:", "refactor:"). One line only, max 72 characters.
+    let commitMessage = fallbackCommitMessage;
+    if (diffForCommit.trim()) {
+      const commitMsgResult = await generateText({
+        model: gateway("anthropic/claude-haiku-4.5"),
+        prompt: `Generate a concise git commit message for these changes. Use conventional commit format (e.g., "feat:", "fix:", "refactor:"). One line only, max 72 characters.
 
 Session context: ${sessionTitle}
 
@@ -314,9 +451,16 @@ Diff:
 ${diffForCommit.slice(0, 8000)}
 
 Respond with ONLY the commit message, nothing else.`,
-    });
+      });
 
-    const commitMessage = commitMsgResult.text.trim();
+      const generatedCommitMessage = commitMsgResult.text
+        .trim()
+        .split("\n")[0]
+        ?.trim();
+      if (generatedCommitMessage && generatedCommitMessage.length > 0) {
+        commitMessage = generatedCommitMessage.slice(0, 72);
+      }
+    }
 
     // 4d. Create commit (escape shell special characters in message)
     // Using single quotes is safest, but we need to handle single quotes in the message
@@ -369,35 +513,203 @@ Respond with ONLY the commit message, nothing else.`,
     const branchExistsOnRemote = remoteBranchCheck.stdout.trim().length > 0;
 
     // 5c. Push branch
-    const pushResult = await sandbox.exec(
-      `git push -u origin ${resolvedBranch}`,
+    let pushResult = await sandbox.exec(
+      `GIT_TERMINAL_PROMPT=0 git push --verbose -u origin ${resolvedBranch}`,
       cwd,
       60000,
     );
 
     if (!pushResult.success) {
-      const pushOutput = pushResult.stdout.trim() + pushResult.stderr;
+      let pushOutput =
+        `${pushResult.stdout}\n${pushResult.stderr ?? ""}`.trim();
+      let redactedPushOutput = redactGitHubToken(pushOutput);
+      console.log(
+        `[generate-pr] Push to origin failed (exitCode=${pushResult.exitCode}, output=${redactedPushOutput.slice(0, 200) || "none"})`,
+      );
       let errorMessage = "Failed to push branch.";
+      let isPermissionError = isPermissionPushError(pushOutput);
 
       if (
-        pushOutput.includes("rejected") ||
-        pushOutput.includes("non-fast-forward")
+        repoTokenResult?.type === "installation" &&
+        sessionRecord.repoOwner &&
+        sessionRecord.repoName
       ) {
-        if (branchExistsOnRemote) {
-          errorMessage = `Branch '${resolvedBranch}' already exists on remote with different commits. Try creating a new branch or pull the latest changes.`;
-        } else {
-          errorMessage = `Push rejected. The remote may have changes that conflict with your local branch.`;
+        if (!cachedUserToken) {
+          cachedUserToken = await getUserGitHubToken();
         }
-      } else if (
-        pushOutput.includes("permission") ||
-        pushOutput.includes("403")
-      ) {
-        errorMessage = "Permission denied. Check your GitHub access.";
-      } else {
-        errorMessage = `Push failed: ${pushOutput.slice(0, 200)}`;
+
+        if (cachedUserToken) {
+          const userAuthUrl = `https://x-access-token:${cachedUserToken}@github.com/${sessionRecord.repoOwner}/${sessionRecord.repoName}.git`;
+          const setOriginUserAuthResult = await sandbox.exec(
+            `git remote set-url origin "${userAuthUrl}"`,
+            cwd,
+            10000,
+          );
+
+          if (setOriginUserAuthResult.success) {
+            pushResult = await sandbox.exec(
+              `GIT_TERMINAL_PROMPT=0 git push --verbose -u origin ${resolvedBranch}`,
+              cwd,
+              60000,
+            );
+
+            if (pushResult.success) {
+              console.log(
+                `[generate-pr] Push to origin succeeded with user token after installation token failure`,
+              );
+              gitActions.pushed = true;
+            } else {
+              pushOutput =
+                `${pushResult.stdout}\n${pushResult.stderr ?? ""}`.trim();
+              redactedPushOutput = redactGitHubToken(pushOutput);
+              isPermissionError = isPermissionPushError(pushOutput);
+              console.log(
+                `[generate-pr] Push to origin with user token also failed (exitCode=${pushResult.exitCode}, output=${redactedPushOutput.slice(0, 200) || "none"})`,
+              );
+            }
+          }
+        }
       }
 
-      return Response.json({ error: errorMessage }, { status: 500 });
+      if (
+        !gitActions.pushed &&
+        sessionRecord.repoOwner &&
+        sessionRecord.repoName
+      ) {
+        if (!cachedUserToken) {
+          cachedUserToken = await getUserGitHubToken();
+        }
+        const githubAccount = await getGitHubAccount(session.user.id);
+
+        if (cachedUserToken && githubAccount?.username) {
+          const forkOwner = githubAccount.username;
+          const forkResult = await ensureForkExists({
+            token: cachedUserToken,
+            upstreamOwner: sessionRecord.repoOwner,
+            upstreamRepo: sessionRecord.repoName,
+            forkOwner,
+          });
+
+          if (!forkResult.success) {
+            return Response.json(
+              {
+                error: `Failed to push to upstream and fork fallback failed: ${forkResult.error}`,
+              },
+              { status: 500 },
+            );
+          }
+
+          const forkAuthUrl = `https://x-access-token:${cachedUserToken}@github.com/${forkOwner}/${sessionRecord.repoName}.git`;
+
+          await sandbox.exec(
+            "git remote remove fork 2>/dev/null || true",
+            cwd,
+            10000,
+          );
+          const addForkResult = await sandbox.exec(
+            `git remote add fork "${forkAuthUrl}"`,
+            cwd,
+            10000,
+          );
+
+          if (!addForkResult.success) {
+            return Response.json(
+              {
+                error: `Failed to configure fork remote: ${(addForkResult.stderr ?? addForkResult.stdout).slice(0, 200)}`,
+              },
+              { status: 500 },
+            );
+          }
+
+          let pushToForkSucceeded = false;
+          let lastPushForkOutput = "";
+
+          for (
+            let attempt = 1;
+            attempt <= FORK_PUSH_RETRY_ATTEMPTS;
+            attempt += 1
+          ) {
+            const pushForkResult = await sandbox.exec(
+              `GIT_TERMINAL_PROMPT=0 git push --verbose -u fork ${resolvedBranch}`,
+              cwd,
+              60000,
+            );
+
+            if (pushForkResult.success) {
+              pushToForkSucceeded = true;
+              console.log(
+                `[generate-pr] Push to origin denied; pushed branch to fork ${forkOwner}/${sessionRecord.repoName}`,
+              );
+              prHeadOwner = forkOwner;
+              gitActions.pushed = true;
+              gitActions.pushedToFork = true;
+              break;
+            }
+
+            lastPushForkOutput =
+              `${pushForkResult.stdout}\n${pushForkResult.stderr ?? ""}`.trim();
+
+            if (
+              isRetryableForkPushError(lastPushForkOutput) &&
+              attempt < FORK_PUSH_RETRY_ATTEMPTS
+            ) {
+              console.log(
+                `[generate-pr] Fork push retry ${attempt}/${FORK_PUSH_RETRY_ATTEMPTS}: waiting for fork repository to become available`,
+              );
+              await sleep(FORK_PUSH_RETRY_DELAY_MS);
+              continue;
+            }
+
+            break;
+          }
+
+          if (!pushToForkSucceeded) {
+            if (isPermissionPushError(lastPushForkOutput)) {
+              return Response.json(
+                {
+                  error:
+                    "Failed to push to your fork. Ensure your linked GitHub account has permission to create and push to forks.",
+                },
+                { status: 403 },
+              );
+            }
+
+            return Response.json(
+              {
+                error: `Failed to push to fork ${forkOwner}/${sessionRecord.repoName}: ${redactGitHubToken(lastPushForkOutput).slice(0, 200)}`,
+              },
+              { status: 500 },
+            );
+          }
+        } else {
+          return Response.json(
+            {
+              error:
+                "Failed to push to upstream and no linked GitHub account is available for fork fallback.",
+            },
+            { status: 500 },
+          );
+        }
+      }
+
+      if (!gitActions.pushed) {
+        if (
+          pushOutput.includes("rejected") ||
+          pushOutput.includes("non-fast-forward")
+        ) {
+          if (branchExistsOnRemote) {
+            errorMessage = `Branch '${resolvedBranch}' already exists on remote with different commits. Try creating a new branch or pull the latest changes.`;
+          } else {
+            errorMessage = `Push rejected. The remote may have changes that conflict with your local branch.`;
+          }
+        } else if (isPermissionError) {
+          errorMessage = "Permission denied. Check your GitHub access.";
+        } else {
+          errorMessage = `Push failed: ${redactedPushOutput.slice(0, 200)}`;
+        }
+
+        return Response.json({ error: errorMessage }, { status: 500 });
+      }
     }
 
     gitActions.pushed = true;
@@ -408,6 +720,7 @@ Respond with ONLY the commit message, nothing else.`,
     return Response.json({
       branchName: resolvedBranch,
       gitActions,
+      ...(prHeadOwner ? { prHeadOwner } : {}),
     });
   }
 
@@ -605,6 +918,7 @@ ${commitLog}`,
     title: prContent.title,
     body: prContent.body,
     branchName: resolvedBranch,
+    ...(prHeadOwner ? { prHeadOwner } : {}),
     ...(Object.keys(gitActions).length > 0 && { gitActions }),
   });
 }

--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -94,6 +94,20 @@ function redactGitHubToken(text: string): string {
   );
 }
 
+function extractGitHubOwnerFromRemoteUrl(remoteUrl: string): string | null {
+  const trimmedRemoteUrl = remoteUrl.trim();
+  if (!trimmedRemoteUrl) {
+    return null;
+  }
+
+  const githubUrlMatch = trimmedRemoteUrl.match(/github\.com[:/]([^/]+)\/[^/]+$/i);
+  if (githubUrlMatch?.[1]) {
+    return githubUrlMatch[1];
+  }
+
+  return null;
+}
+
 async function ensureForkExists({
   token,
   upstreamOwner,
@@ -499,6 +513,24 @@ Respond with ONLY the commit message, nothing else.`,
   const needsPush =
     trackingResult.stdout.includes("needs-push") ||
     trackingResult.stdout.trim().length > 0;
+
+  const upstreamRefResult = await sandbox.exec(
+    "git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true",
+    cwd,
+    10000,
+  );
+  const upstreamRef = upstreamRefResult.stdout.trim();
+  if (upstreamRef.startsWith("fork/")) {
+    const forkUrlResult = await sandbox.exec(
+      "git remote get-url fork 2>/dev/null || true",
+      cwd,
+      10000,
+    );
+    const forkOwner = extractGitHubOwnerFromRemoteUrl(forkUrlResult.stdout);
+    if (forkOwner) {
+      prHeadOwner = forkOwner;
+    }
+  }
 
   if (needsPush) {
     // 5a. Fetch latest from origin to check for conflicts

--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -100,7 +100,9 @@ function extractGitHubOwnerFromRemoteUrl(remoteUrl: string): string | null {
     return null;
   }
 
-  const githubUrlMatch = trimmedRemoteUrl.match(/github\.com[:/]([^/]+)\/[^/]+$/i);
+  const githubUrlMatch = trimmedRemoteUrl.match(
+    /github\.com[:/]([^/]+)\/[^/]+$/i,
+  );
   if (githubUrlMatch?.[1]) {
     return githubUrlMatch[1];
   }
@@ -605,6 +607,7 @@ Respond with ONLY the commit message, nothing else.`,
 
       if (
         !gitActions.pushed &&
+        isPermissionError &&
         sessionRecord.repoOwner &&
         sessionRecord.repoName
       ) {

--- a/apps/web/app/api/github/branches/route.ts
+++ b/apps/web/app/api/github/branches/route.ts
@@ -3,6 +3,137 @@ import { getCachedGitHubBranches } from "@/lib/github/cached-api";
 import { getRepoToken } from "@/lib/github/get-repo-token";
 import { getServerSession } from "@/lib/session/get-server-session";
 
+interface PublicRepoInfo {
+  default_branch: string;
+}
+
+interface PublicBranch {
+  name: string;
+}
+
+function parsePublicRepoInfo(value: unknown): PublicRepoInfo | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const defaultBranch = Reflect.get(value, "default_branch");
+  if (typeof defaultBranch !== "string") {
+    return null;
+  }
+
+  return { default_branch: defaultBranch };
+}
+
+function parsePublicBranches(value: unknown): PublicBranch[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const branches: PublicBranch[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      return null;
+    }
+
+    const name = Reflect.get(item, "name");
+    if (typeof name !== "string") {
+      return null;
+    }
+
+    branches.push({ name });
+  }
+
+  return branches;
+}
+
+async function fetchPublicGitHubBranches(
+  owner: string,
+  repo: string,
+): Promise<{
+  branches: string[];
+  defaultBranch: string;
+} | null> {
+  const repoInfoResponse = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!repoInfoResponse.ok) {
+    return null;
+  }
+
+  const repoInfoJson: unknown = await repoInfoResponse.json();
+  const repoInfo = parsePublicRepoInfo(repoInfoJson);
+  if (!repoInfo) {
+    return null;
+  }
+  const defaultBranch = repoInfo.default_branch;
+  const branches: string[] = [];
+
+  const perPage = 100;
+  const maxPages = 10;
+  for (let page = 1; page <= maxPages; page += 1) {
+    const branchesResponse = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/branches?per_page=${perPage}&page=${page}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        cache: "no-store",
+      },
+    );
+
+    if (!branchesResponse.ok) {
+      if (page === 1) {
+        return null;
+      }
+      break;
+    }
+
+    const pageBranchesJson: unknown = await branchesResponse.json();
+    const pageBranches = parsePublicBranches(pageBranchesJson);
+    if (!pageBranches) {
+      if (page === 1) {
+        return null;
+      }
+      break;
+    }
+    if (pageBranches.length === 0) {
+      break;
+    }
+
+    for (const branch of pageBranches) {
+      branches.push(branch.name);
+    }
+
+    if (pageBranches.length < perPage) {
+      break;
+    }
+  }
+
+  branches.sort((a, b) => {
+    if (a === defaultBranch) {
+      return -1;
+    }
+    if (b === defaultBranch) {
+      return 1;
+    }
+    return a.toLowerCase().localeCompare(b.toLowerCase());
+  });
+
+  return {
+    branches,
+    defaultBranch,
+  };
+}
+
 export async function GET(request: NextRequest) {
   const session = await getServerSession();
 
@@ -24,32 +155,37 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  let tokenResult: Awaited<ReturnType<typeof getRepoToken>>;
+  let token: string | null = null;
   try {
-    tokenResult = await getRepoToken(session.user.id, owner);
+    const tokenResult = await getRepoToken(session.user.id, owner);
+    token = tokenResult.token;
   } catch {
-    return NextResponse.json(
-      { error: "GitHub not connected" },
-      { status: 401 },
-    );
+    token = null;
   }
 
   try {
-    const result = await getCachedGitHubBranches(
-      session.user.id,
-      tokenResult.token,
-      owner,
-      repo,
-    );
-
-    if (!result) {
-      return NextResponse.json(
-        { error: "Failed to fetch branches" },
-        { status: 500 },
+    if (token) {
+      const result = await getCachedGitHubBranches(
+        session.user.id,
+        token,
+        owner,
+        repo,
       );
+
+      if (result) {
+        return NextResponse.json(result);
+      }
     }
 
-    return NextResponse.json(result);
+    const publicResult = await fetchPublicGitHubBranches(owner, repo);
+    if (publicResult) {
+      return NextResponse.json(publicResult);
+    }
+
+    return NextResponse.json(
+      { error: "Failed to fetch branches" },
+      { status: 500 },
+    );
   } catch (error) {
     console.error("Error fetching branches:", error);
     return NextResponse.json(

--- a/apps/web/app/api/pr/route.ts
+++ b/apps/web/app/api/pr/route.ts
@@ -1,6 +1,7 @@
 import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { createPullRequest, parseGitHubUrl } from "@/lib/github/client";
 import { getRepoToken } from "@/lib/github/get-repo-token";
+import { getUserGitHubToken } from "@/lib/github/user-token";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 interface CreatePRRequest {
@@ -10,6 +11,34 @@ interface CreatePRRequest {
   title: string;
   body?: string;
   baseBranch: string;
+  headOwner?: string;
+}
+
+function buildGitHubCompareUrl(params: {
+  owner: string;
+  repo: string;
+  baseBranch: string;
+  headRef: string;
+  title?: string;
+  body?: string;
+}): string {
+  const { owner, repo, baseBranch, headRef, title, body } = params;
+  const compareUrl = new URL(
+    `https://github.com/${owner}/${repo}/compare/${encodeURIComponent(baseBranch)}...${encodeURIComponent(headRef)}`,
+  );
+  compareUrl.searchParams.set("expand", "1");
+
+  const trimmedTitle = title?.trim();
+  if (trimmedTitle) {
+    compareUrl.searchParams.set("title", trimmedTitle);
+  }
+
+  const trimmedBody = body?.trim();
+  if (trimmedBody) {
+    compareUrl.searchParams.set("body", trimmedBody);
+  }
+
+  return compareUrl.toString();
 }
 
 export async function POST(req: Request) {
@@ -34,6 +63,7 @@ export async function POST(req: Request) {
     title,
     body: prBody,
     baseBranch,
+    headOwner,
   } = body;
 
   if (!sessionId || !repoUrl || !title || !baseBranch) {
@@ -79,13 +109,13 @@ export async function POST(req: Request) {
     return Response.json({ error: "Invalid branch name" }, { status: 400 });
   }
 
-  let githubToken: string;
+  if (headOwner && !safeBranchPattern.test(headOwner)) {
+    return Response.json({ error: "Invalid head owner" }, { status: 400 });
+  }
+
+  let tokenResult: Awaited<ReturnType<typeof getRepoToken>>;
   try {
-    const tokenResult = await getRepoToken(
-      session.user.id,
-      parsedRepoUrl.owner,
-    );
-    githubToken = tokenResult.token;
+    tokenResult = await getRepoToken(session.user.id, parsedRepoUrl.owner);
   } catch {
     return Response.json(
       { error: "No GitHub token available for this repository" },
@@ -93,18 +123,75 @@ export async function POST(req: Request) {
     );
   }
 
+  const userToken = await getUserGitHubToken();
+  const tokenCandidates: string[] = [];
+
+  let headRef = resolvedBranch;
+  const normalizedBaseOwner = parsedRepoUrl.owner.toLowerCase();
+  const normalizedHeadOwner = headOwner?.trim().toLowerCase();
+
+  if (normalizedHeadOwner && normalizedHeadOwner !== normalizedBaseOwner) {
+    headRef = `${headOwner}:${resolvedBranch}`;
+    if (userToken) {
+      tokenCandidates.push(userToken);
+    }
+  } else if (tokenResult.type === "installation" && userToken) {
+    // Installation tokens can be repo-scoped and miss this target repo even when
+    // the user's token has direct write/PR permission.
+    tokenCandidates.push(userToken);
+  }
+
+  tokenCandidates.push(tokenResult.token);
+
+  const dedupedTokenCandidates: string[] = [];
+  for (const token of tokenCandidates) {
+    if (!dedupedTokenCandidates.includes(token)) {
+      dedupedTokenCandidates.push(token);
+    }
+  }
+
   // 4. Create PR using existing function
-  const result = await createPullRequest({
+  let result = await createPullRequest({
     repoUrl,
     branchName: resolvedBranch,
+    headRef,
     title,
     body: prBody || "",
     baseBranch,
-    token: githubToken,
+    token: dedupedTokenCandidates[0],
   });
+
+  if (!result.success && dedupedTokenCandidates.length > 1) {
+    result = await createPullRequest({
+      repoUrl,
+      branchName: resolvedBranch,
+      headRef,
+      title,
+      body: prBody || "",
+      baseBranch,
+      token: dedupedTokenCandidates[1],
+    });
+  }
 
   if (!result.success) {
     const error = result.error || "Failed to create pull request";
+
+    if (error === "Permission denied") {
+      const compareUrl = buildGitHubCompareUrl({
+        owner: parsedRepoUrl.owner,
+        repo: parsedRepoUrl.repo,
+        baseBranch,
+        headRef,
+        title,
+        body: prBody,
+      });
+
+      return Response.json({
+        success: true,
+        prUrl: compareUrl,
+        requiresManualCreation: true,
+      });
+    }
 
     // Determine appropriate status code based on error type
     // Client errors (400): invalid input, PR already exists
@@ -134,5 +221,6 @@ export async function POST(req: Request) {
     success: true,
     prUrl: result.prUrl,
     prNumber: result.prNumber,
+    prStatus: "open",
   });
 }

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -500,6 +500,7 @@ export function SessionChatContent() {
     syncSandboxStatus,
     attemptReconnection,
     updateSessionRepo,
+    updateSessionPullRequest,
   } = useSessionChatContext();
   const {
     messages,
@@ -2215,6 +2216,9 @@ export function SessionChatContent() {
           onOpenChange={setPrDialogOpen}
           session={session}
           hasSandbox={sandboxInfo !== null}
+          onPrDetected={(pr) => {
+            updateSessionPullRequest(pr);
+          }}
         />
       )}
 

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -161,6 +161,11 @@ type SessionChatContextValue = {
     repoName: string;
     branch: string;
   }) => void;
+  /** Update local PR metadata after creating/discovering a PR */
+  updateSessionPullRequest: (info: {
+    prNumber: number;
+    prStatus: "open" | "merged" | "closed";
+  }) => void;
 };
 
 const SessionChatContext = createContext<SessionChatContextValue | undefined>(
@@ -586,6 +591,36 @@ export function SessionChatProvider({
     [],
   );
 
+  const updateSessionPullRequest = useCallback(
+    (info: { prNumber: number; prStatus: "open" | "merged" | "closed" }) => {
+      setSessionRecord((prev) => ({
+        ...prev,
+        prNumber: info.prNumber,
+        prStatus: info.prStatus,
+      }));
+
+      void mutate<SessionsResponse>(
+        "/api/sessions",
+        (current) =>
+          current
+            ? {
+                sessions: current.sessions.map((s) =>
+                  s.id === sessionId
+                    ? {
+                        ...s,
+                        prNumber: info.prNumber,
+                        prStatus: info.prStatus,
+                      }
+                    : s,
+                ),
+              }
+            : current,
+        { revalidate: false },
+      );
+    },
+    [mutate, sessionId],
+  );
+
   const updateSessionSnapshot = useCallback(
     (snapshotUrl: string, snapshotCreatedAt: Date) => {
       setHasSnapshotState(true);
@@ -808,6 +843,7 @@ export function SessionChatProvider({
         syncSandboxStatus,
         attemptReconnection,
         updateSessionRepo,
+        updateSessionPullRequest,
       }}
     >
       {children}

--- a/apps/web/components/create-pr-dialog.tsx
+++ b/apps/web/components/create-pr-dialog.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import {
-  Sparkles,
-  ExternalLink,
-  Check,
-  Loader2,
-  GitCommit,
   AlertCircle,
+  Check,
+  ExternalLink,
+  GitCommit,
+  Loader2,
+  Sparkles,
 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -17,10 +18,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
@@ -28,6 +27,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import type { Session } from "@/lib/db/schema";
 
 interface CreatePRDialogProps {
@@ -35,21 +35,54 @@ interface CreatePRDialogProps {
   onOpenChange: (open: boolean) => void;
   session: Session;
   hasSandbox: boolean;
+  onPrDetected?: (info: {
+    prNumber: number;
+    prStatus: "open" | "merged" | "closed";
+  }) => void;
 }
 
 interface GitActions {
   committed?: boolean;
   commitMessage?: string;
   pushed?: boolean;
+  pushedToFork?: boolean;
 }
 
 type WizardStep = "create-branch" | "commit" | "generate";
+
+function buildCompareUrl(params: {
+  owner: string;
+  repo: string;
+  baseBranch: string;
+  headRef: string;
+  title?: string;
+  body?: string;
+}): string {
+  const { owner, repo, baseBranch, headRef, title, body } = params;
+  const compareUrl = new URL(
+    `https://github.com/${owner}/${repo}/compare/${encodeURIComponent(baseBranch)}...${encodeURIComponent(headRef)}`,
+  );
+  compareUrl.searchParams.set("expand", "1");
+
+  const trimmedTitle = title?.trim();
+  if (trimmedTitle) {
+    compareUrl.searchParams.set("title", trimmedTitle);
+  }
+
+  const trimmedBody = body?.trim();
+  if (trimmedBody) {
+    compareUrl.searchParams.set("body", trimmedBody);
+  }
+
+  return compareUrl.toString();
+}
 
 export function CreatePRDialog({
   open,
   onOpenChange,
   session,
   hasSandbox,
+  onPrDetected,
 }: CreatePRDialogProps) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
@@ -59,7 +92,10 @@ export function CreatePRDialog({
   const [isGenerating, setIsGenerating] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [isCreatingBranch, setIsCreatingBranch] = useState(false);
-  const [result, setResult] = useState<{ prUrl: string } | null>(null);
+  const [result, setResult] = useState<{
+    prUrl: string;
+    requiresManualCreation?: boolean;
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [gitActions, setGitActions] = useState<GitActions | null>(null);
   const [resolvedBranch, setResolvedBranch] = useState<string | null>(null);
@@ -70,6 +106,7 @@ export function CreatePRDialog({
   const [isCommitting, setIsCommitting] = useState(false);
   const [uncommittedFileCount, setUncommittedFileCount] = useState(0);
   const [hasGenerated, setHasGenerated] = useState(false);
+  const [prHeadOwner, setPrHeadOwner] = useState<string | null>(null);
 
   // Reset state when dialog opens
   useEffect(() => {
@@ -86,6 +123,7 @@ export function CreatePRDialog({
       setStep("generate");
       setUncommittedFileCount(0);
       setHasGenerated(false);
+      setPrHeadOwner(null);
     }
   }, [open]);
 
@@ -126,6 +164,14 @@ export function CreatePRDialog({
   const displayBranch = currentBranch === "HEAD" ? baseBranch : currentBranch;
   const isOnBaseBranch = displayBranch === baseBranch;
   const needsNewBranch = isOnBaseBranch || isDetachedHead;
+  const normalizedRepoOwner = session.repoOwner?.toLowerCase() ?? null;
+  const normalizedHeadOwner = prHeadOwner?.toLowerCase() ?? null;
+  const shouldOpenCompareInsteadOfApi = Boolean(
+    gitActions?.pushedToFork ||
+      (normalizedRepoOwner &&
+        normalizedHeadOwner &&
+        normalizedHeadOwner !== normalizedRepoOwner),
+  );
 
   useEffect(() => {
     if (!isCheckingStatus && open) {
@@ -243,6 +289,9 @@ export function CreatePRDialog({
       if (data.gitActions) {
         setGitActions(data.gitActions);
       }
+      if (typeof data.prHeadOwner === "string" && data.prHeadOwner.length > 0) {
+        setPrHeadOwner(data.prHeadOwner);
+      }
       if (data.branchName && data.branchName !== "HEAD") {
         setResolvedBranch(data.branchName as string);
       }
@@ -283,6 +332,9 @@ export function CreatePRDialog({
       if (data.gitActions) {
         setGitActions(data.gitActions);
       }
+      if (typeof data.prHeadOwner === "string" && data.prHeadOwner.length > 0) {
+        setPrHeadOwner(data.prHeadOwner);
+      }
       if (data.branchName && data.branchName !== "HEAD") {
         setResolvedBranch(data.branchName as string);
       }
@@ -297,6 +349,31 @@ export function CreatePRDialog({
     setIsCreating(true);
     setError(null);
     try {
+      if (
+        shouldOpenCompareInsteadOfApi &&
+        session.repoOwner &&
+        session.repoName
+      ) {
+        const headOwner = prHeadOwner?.trim() || session.repoOwner;
+        const sameOwner =
+          headOwner.toLowerCase() === session.repoOwner.toLowerCase();
+        const headRef = sameOwner
+          ? displayBranch
+          : `${headOwner}:${displayBranch}`;
+        const compareUrl = buildCompareUrl({
+          owner: session.repoOwner,
+          repo: session.repoName,
+          baseBranch,
+          headRef,
+          title,
+          body,
+        });
+
+        window.open(compareUrl, "_blank", "noopener,noreferrer");
+        setResult({ prUrl: compareUrl, requiresManualCreation: true });
+        return;
+      }
+
       const res = await fetch("/api/pr", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -307,6 +384,7 @@ export function CreatePRDialog({
           title,
           body,
           baseBranch,
+          headOwner: prHeadOwner ?? undefined,
         }),
       });
 
@@ -316,7 +394,20 @@ export function CreatePRDialog({
         throw new Error(data.error || "Failed to create PR");
       }
 
-      setResult({ prUrl: data.prUrl });
+      setResult({
+        prUrl: data.prUrl,
+        requiresManualCreation: Boolean(data.requiresManualCreation),
+      });
+
+      if (typeof data.prNumber === "number") {
+        onPrDetected?.({
+          prNumber: data.prNumber,
+          prStatus:
+            data.prStatus === "merged" || data.prStatus === "closed"
+              ? data.prStatus
+              : "open",
+        });
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create PR");
     } finally {
@@ -348,7 +439,11 @@ export function CreatePRDialog({
               <Check className="h-6 w-6 text-green-500" />
             </div>
             <div className="text-center">
-              <p className="font-medium">Pull request created successfully!</p>
+              <p className="font-medium">
+                {result.requiresManualCreation
+                  ? "Open GitHub to create the pull request"
+                  : "Pull request created successfully!"}
+              </p>
               {/* External link to GitHub - not internal navigation */}
               {/* oxlint-disable-next-line nextjs/no-html-link-for-pages */}
               <a
@@ -357,7 +452,9 @@ export function CreatePRDialog({
                 rel="noopener noreferrer"
                 className="mt-2 inline-flex items-center gap-1 text-sm text-blue-500 hover:underline"
               >
-                View on GitHub
+                {result.requiresManualCreation
+                  ? "Open compare page"
+                  : "View on GitHub"}
                 <ExternalLink className="h-3 w-3" />
               </a>
             </div>
@@ -444,12 +541,22 @@ export function CreatePRDialog({
                           )}
                           {gitActions.pushed && (
                             <p className="text-muted-foreground">
-                              Branch pushed to origin
+                              {gitActions.pushedToFork && prHeadOwner
+                                ? `Branch pushed to fork ${prHeadOwner}`
+                                : "Branch pushed to origin"}
                             </p>
                           )}
                         </div>
                       </div>
                     )}
+
+                  {shouldOpenCompareInsteadOfApi && (
+                    <div className="rounded-md border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-800 dark:text-blue-300">
+                      We pushed your branch, but this repository does not allow
+                      API-based PR creation for the current app token. Open
+                      GitHub to create the PR from the compare page.
+                    </div>
+                  )}
 
                   {/* Title Input */}
                   <div className="grid gap-2">
@@ -561,6 +668,8 @@ export function CreatePRDialog({
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                         Creating...
                       </>
+                    ) : shouldOpenCompareInsteadOfApi ? (
+                      "Open Compare Page"
                     ) : (
                       "Create PR"
                     )}

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -32,6 +32,7 @@ export function parseGitHubUrl(
 export async function createPullRequest(params: {
   repoUrl: string;
   branchName: string;
+  headRef?: string;
   title: string;
   body?: string;
   baseBranch?: string;
@@ -45,6 +46,7 @@ export async function createPullRequest(params: {
   const {
     repoUrl,
     branchName,
+    headRef,
     title,
     body = "",
     baseBranch = "main",
@@ -70,7 +72,7 @@ export async function createPullRequest(params: {
       repo,
       title,
       body,
-      head: branchName,
+      head: headRef ?? branchName,
       base: baseBranch,
     });
 


### PR DESCRIPTION
## Summary

- **Gate fork fallback on permission errors only** -- The fork creation/push fallback now only triggers for actual permission/auth push failures, not for rejected/non-fast-forward errors. This ensures users who need to reconcile divergent branches get informative error messages instead of having an unnecessary fork created.
- **Tighten `isPermissionPushError` heuristic** -- Replaced broad substring matches (`"permission"`, `"403"`, `"denied"`) with specific git error patterns (`"permission to"`, `"the requested url returned error: 403"`, etc.) to avoid false positives from commit messages or ref names containing those words.
- **Use actual fork repo name from GitHub API** -- `ensureForkExists` now parses the `name` field from the GitHub API response instead of assuming the fork has the same name as the upstream repo, handling edge cases where GitHub appends a suffix due to naming conflicts.