### PR TITLE
Fix resumed chat stop handling across chat switches

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -477,6 +477,7 @@ export function SessionChatContent() {
     session,
     chatInfo,
     chat,
+    stopChatStream,
     initialMessages,
     sandboxInfo,
     setSandboxInfo,
@@ -509,7 +510,6 @@ export function SessionChatContent() {
     status,
     addToolApprovalResponse,
     addToolOutput,
-    stop,
   } = chat;
   const {
     chats,
@@ -2175,7 +2175,7 @@ export function SessionChatContent() {
                           fetch(`/api/chat/${chatInfo.id}/stop`, {
                             method: "POST",
                           }).catch(() => {});
-                          stop();
+                          stopChatStream();
                         }}
                         className="h-8 w-8 rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90"
                       >

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -23,6 +23,7 @@ import { useSessionDiff } from "@/hooks/use-session-diff";
 import { useSessionFiles } from "@/hooks/use-session-files";
 import { AbortableChatTransport } from "@/lib/abortable-chat-transport";
 import {
+  abortChatInstanceTransport,
   getOrCreateChatInstance,
   removeChatInstance,
 } from "@/lib/chat-instance-manager";
@@ -102,6 +103,7 @@ type SessionChatContextValue = {
   session: Session;
   chatInfo: Chat;
   chat: UseChatHelpers<WebAgentUIMessage>;
+  stopChatStream: () => void;
   sandboxInfo: SandboxInfo | null;
   setSandboxInfo: (info: SandboxInfo) => void;
   clearSandboxInfo: () => void;
@@ -270,6 +272,11 @@ export function SessionChatProvider({
     [chatInfo.id],
   );
 
+  const stopChatStream = useCallback(() => {
+    void chatInstance.stop();
+    abortChatInstanceTransport(chatInfo.id);
+  }, [chatInfo.id, chatInstance]);
+
   // Only resume on fresh page load (new Chat instance + active stream in DB).
   // If instance already existed, the stream is either still running or finished —
   // no resume needed since the instance tracked it the whole time.
@@ -282,21 +289,20 @@ export function SessionChatProvider({
   });
 
   // Cleanup: always release chat instances when leaving a route.
-  // If this chat is still streaming, stop the local stream processing so
+  // If this chat is still streaming, stop local stream processing so
   // background chats do not consume render/CPU budget in this tab.
-  // Also abort the transport's fetch connections — the SDK's reconnectToStream
+  // Also abort the instance transport fetch connections. reconnectToStream
   // does not pass an abort signal, so chatInstance.stop() alone cannot cancel
-  // resumed streams. Without this, navigating away from a resumed chat leaves
-  // an immortal stream consumer on the main thread.
+  // resumed streams.
   useEffect(() => {
     return () => {
       if (chatInstance.status === "streaming") {
-        chatInstance.stop();
+        void chatInstance.stop();
       }
-      transport.abort();
+      abortChatInstanceTransport(chatInfo.id);
       removeChatInstance(chatInfo.id);
     };
-  }, [chatInfo.id, chatInstance, transport]);
+  }, [chatInfo.id, chatInstance]);
 
   const [sandboxInfo, setSandboxInfoState] = useState<SandboxInfo | null>(
     () => sandboxInfoCache.get(sessionId) ?? null,
@@ -813,6 +819,7 @@ export function SessionChatProvider({
         session: sessionRecord,
         chatInfo,
         chat,
+        stopChatStream,
         sandboxInfo,
         setSandboxInfo,
         clearSandboxInfo,

--- a/apps/web/lib/chat-instance-manager.ts
+++ b/apps/web/lib/chat-instance-manager.ts
@@ -5,20 +5,67 @@ type ChatInstanceInit = ConstructorParameters<
   typeof Chat<WebAgentUIMessage>
 >[0];
 
+type ManagedChatInstance = {
+  instance: Chat<WebAgentUIMessage>;
+  transport: ChatInstanceInit["transport"];
+};
+
+type AbortableTransport = {
+  abort: () => void;
+};
+
+function isAbortableTransport(value: unknown): value is AbortableTransport {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "abort" in value &&
+    typeof value.abort === "function"
+  );
+}
+
 // Instances are scoped to an active chat route and removed on route teardown.
 // This avoids accumulating background streams/message buffers when users switch
 // between multiple chats quickly.
-const chatInstances = new Map<string, Chat<WebAgentUIMessage>>();
+const chatInstances = new Map<string, ManagedChatInstance>();
 
 export function getOrCreateChatInstance(
   chatId: string,
   init: ChatInstanceInit,
-): { instance: Chat<WebAgentUIMessage>; alreadyExisted: boolean } {
+): {
+  instance: Chat<WebAgentUIMessage>;
+  transport: ChatInstanceInit["transport"];
+  alreadyExisted: boolean;
+} {
   const existing = chatInstances.get(chatId);
-  if (existing) return { instance: existing, alreadyExisted: true };
+  if (existing) {
+    return {
+      instance: existing.instance,
+      transport: existing.transport,
+      alreadyExisted: true,
+    };
+  }
+
   const instance = new Chat<WebAgentUIMessage>(init);
-  chatInstances.set(chatId, instance);
-  return { instance, alreadyExisted: false };
+  const managed = {
+    instance,
+    transport: init.transport,
+  };
+  chatInstances.set(chatId, managed);
+
+  return {
+    instance,
+    transport: init.transport,
+    alreadyExisted: false,
+  };
+}
+
+export function abortChatInstanceTransport(chatId: string): void {
+  const managed = chatInstances.get(chatId);
+  if (!managed || !isAbortableTransport(managed.transport)) {
+    return;
+  }
+
+  managed.transport.abort();
 }
 
 export function removeChatInstance(chatId: string): void {

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -77,6 +77,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 - Optimistic chat-title previews for `"New chat"` must have an explicit rollback on send failures; otherwise the sidebar can keep a title that was never persisted if the first request errors.
 - `hadInitialMessages` is an initial-load snapshot, not a live "first turn" signal; guard one-time optimistic UI (like first-message title previews) with a dedicated runtime ref/state that resets on send failure.
 - When session overlay maps are deleted after becoming empty, any later overlay writes in the same hook instance must re-register the map in the global registry, or optimistic overlays will not survive route transitions.
+- For resumed chat streams, `chat.stop()` alone is insufficient because reconnect fetches are not wired to the active abort signal; always pair stop with aborting the managed transport tied to that chat instance.
 
 ## GitHub App / PR Flows
 

--- a/docs/plans/completed/chat-stop-resume-regression-test-plan.md
+++ b/docs/plans/completed/chat-stop-resume-regression-test-plan.md
@@ -1,0 +1,72 @@
+# Chat Stop Resume Regression Test Plan
+
+This checklist covers the regression where Stop fails after switching chats while a resumable stream is active.
+
+## Scope
+
+- Session chat route: `apps/web/app/sessions/[sessionId]/chats/[chatId]`
+- Streaming + resumable stream reconnect behavior
+- Stop button behavior for active and resumed streams
+
+## Preconditions
+
+- A logged-in user with an active session
+- At least two chats in the same session
+- A prompt that reliably streams for at least 10-20 seconds
+
+## Manual Test Cases
+
+### 1. Baseline stop in current chat
+
+1. Open a chat.
+2. Send a long-running prompt.
+3. Click Stop while it is streaming.
+
+Expected:
+- Stream stops immediately.
+- Input returns to editable state.
+- No refresh required.
+
+### 2. Switch away and back during stream
+
+1. In Chat A, start a long-running prompt.
+2. Navigate to Chat B before Chat A finishes.
+3. Navigate back to Chat A.
+4. Click Stop.
+
+Expected:
+- Stream stops immediately.
+- Stop works on the first click.
+- No page refresh required.
+
+### 3. Resume path after hard refresh
+
+1. In Chat A, start a long-running prompt.
+2. Refresh the page while it is streaming.
+3. Wait for stream resume.
+4. Click Stop.
+
+Expected:
+- Resumed stream stops immediately.
+- No stuck streaming indicator.
+
+### 4. Rapid navigation stress test
+
+1. Start stream in Chat A.
+2. Rapidly switch A -> B -> A several times while streaming.
+3. Click Stop in Chat A.
+
+Expected:
+- Stop remains reliable.
+- No duplicate assistant messages are appended.
+- UI remains responsive.
+
+## Optional Observability Checks
+
+- Network tab should show the chat stream request canceled immediately after Stop.
+- No persistent hanging stream request should remain after navigating away.
+
+## Pass Criteria
+
+- All manual test cases pass without page refresh workarounds.
+- Stop works consistently for both in-place streams and resumed streams.


### PR DESCRIPTION
## Summary
- fix web chat stop handling so resumed streams are aborted through the managed chat instance transport, not only `chat.stop()`
- route the stop button and provider cleanup through a shared `stopChatStream` path to ensure stop works after switching chats and returning
- add a regression checklist for chat stop/resume behavior and document the lesson learned in agent docs

## Testing
- turbo typecheck --filter=web
- turbo lint --filter=web