### PR TITLE
fix: refresh expired GitHub OAuth tokens instead of silently failing

### DIFF
--- a/apps/web/app/api/github/app/callback/route.ts
+++ b/apps/web/app/api/github/app/callback/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
 import { encrypt } from "@/lib/crypto";
 import { upsertGitHubAccount } from "@/lib/db/accounts";
 import { syncUserInstallations } from "@/lib/github/installations-sync";
@@ -74,6 +74,8 @@ async function exchangeOAuthCode(
     const tokenData = (await tokenResponse.json()) as {
       access_token?: string;
       scope?: string;
+      refresh_token?: string;
+      expires_in?: number;
       error_description?: string;
     };
 
@@ -104,6 +106,12 @@ async function exchangeOAuthCode(
       userId,
       externalUserId: `${githubUser.id}`,
       accessToken: encrypt(tokenData.access_token),
+      refreshToken: tokenData.refresh_token
+        ? encrypt(tokenData.refresh_token)
+        : undefined,
+      expiresAt: tokenData.expires_in
+        ? new Date(Date.now() + tokenData.expires_in * 1000)
+        : undefined,
       scope: tokenData.scope,
       username: githubUser.login,
     });

--- a/apps/web/lib/db/accounts.ts
+++ b/apps/web/lib/db/accounts.ts
@@ -1,12 +1,14 @@
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
 import { db } from "./client";
 import { accounts } from "./schema";
-import { eq, and } from "drizzle-orm";
-import { nanoid } from "nanoid";
 
 export async function upsertGitHubAccount(data: {
   userId: string;
   externalUserId: string;
   accessToken: string;
+  refreshToken?: string;
+  expiresAt?: Date;
   scope?: string;
   username: string;
 }): Promise<string> {
@@ -24,6 +26,8 @@ export async function upsertGitHubAccount(data: {
       .set({
         externalUserId: data.externalUserId,
         accessToken: data.accessToken,
+        refreshToken: data.refreshToken ?? null,
+        expiresAt: data.expiresAt ?? null,
         scope: data.scope,
         username: data.username,
         updatedAt: new Date(),
@@ -40,6 +44,8 @@ export async function upsertGitHubAccount(data: {
     provider: "github",
     externalUserId: data.externalUserId,
     accessToken: data.accessToken,
+    refreshToken: data.refreshToken,
+    expiresAt: data.expiresAt,
     scope: data.scope,
     username: data.username,
     createdAt: now,
@@ -50,12 +56,16 @@ export async function upsertGitHubAccount(data: {
 
 export async function getGitHubAccount(userId: string): Promise<{
   accessToken: string;
+  refreshToken: string | null;
+  expiresAt: Date | null;
   username: string;
   externalUserId: string;
 } | null> {
   const result = await db
     .select({
       accessToken: accounts.accessToken,
+      refreshToken: accounts.refreshToken,
+      expiresAt: accounts.expiresAt,
       username: accounts.username,
       externalUserId: accounts.externalUserId,
     })
@@ -64,6 +74,25 @@ export async function getGitHubAccount(userId: string): Promise<{
     .limit(1);
 
   return result[0] ?? null;
+}
+
+export async function updateGitHubAccountTokens(
+  userId: string,
+  data: {
+    accessToken: string;
+    refreshToken?: string;
+    expiresAt?: Date;
+  },
+): Promise<void> {
+  await db
+    .update(accounts)
+    .set({
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken ?? null,
+      expiresAt: data.expiresAt ?? null,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(accounts.userId, userId), eq(accounts.provider, "github")));
 }
 
 export async function deleteGitHubAccount(userId: string): Promise<void> {

--- a/apps/web/lib/github/user-token.ts
+++ b/apps/web/lib/github/user-token.ts
@@ -43,6 +43,13 @@ async function refreshGitHubToken(
       },
     );
 
+    if (!response.ok) {
+      console.error(
+        `GitHub token refresh returned HTTP ${response.status}: ${response.statusText}`,
+      );
+      return null;
+    }
+
     const data = (await response.json()) as
       | GitHubTokenRefreshResponse
       | { error: string; error_description?: string };
@@ -100,13 +107,23 @@ export async function getUserGitHubToken(): Promise<string | null> {
     const refreshed = await refreshGitHubToken(decryptedRefresh);
     if (!refreshed) return null;
 
-    // Persist the new tokens
+    // Persist the new tokens. If persistence fails, still return the token
+    // so the current request succeeds. The refresh token has already been
+    // consumed by GitHub (they rotate on use), so failing to persist would
+    // permanently break the user's connection on the next request.
     const newExpiresAt = new Date(Date.now() + refreshed.expires_in * 1000);
-    await updateGitHubAccountTokens(session.user.id, {
-      accessToken: encrypt(refreshed.access_token),
-      refreshToken: encrypt(refreshed.refresh_token),
-      expiresAt: newExpiresAt,
-    });
+    try {
+      await updateGitHubAccountTokens(session.user.id, {
+        accessToken: encrypt(refreshed.access_token),
+        refreshToken: encrypt(refreshed.refresh_token),
+        expiresAt: newExpiresAt,
+      });
+    } catch (persistError) {
+      console.error(
+        "Failed to persist refreshed GitHub tokens. The current request will succeed, but subsequent requests may fail:",
+        persistError,
+      );
+    }
 
     return refreshed.access_token;
   } catch (error) {

--- a/apps/web/lib/github/user-token.ts
+++ b/apps/web/lib/github/user-token.ts
@@ -1,18 +1,114 @@
 import "server-only";
+import { decrypt, encrypt } from "@/lib/crypto";
+import { getGitHubAccount, updateGitHubAccountTokens } from "@/lib/db/accounts";
 import { getServerSession } from "@/lib/session/get-server-session";
-import { getGitHubAccount } from "@/lib/db/accounts";
-import { decrypt } from "@/lib/crypto";
 
+interface GitHubTokenRefreshResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+  refresh_token_expires_in: number;
+  token_type: string;
+  scope: string;
+}
+
+/**
+ * Refresh an expired GitHub user token using the refresh token.
+ * GitHub's expiring user tokens last ~8 hours; refresh tokens last ~6 months.
+ * See: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens
+ */
+async function refreshGitHubToken(
+  refreshToken: string,
+): Promise<GitHubTokenRefreshResponse | null> {
+  const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) return null;
+
+  try {
+    const response = await fetch(
+      "https://github.com/login/oauth/access_token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          client_secret: clientSecret,
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+        }),
+      },
+    );
+
+    const data = (await response.json()) as
+      | GitHubTokenRefreshResponse
+      | { error: string; error_description?: string };
+
+    if ("error" in data) {
+      console.error(
+        "GitHub token refresh failed:",
+        data.error,
+        data.error_description,
+      );
+      return null;
+    }
+
+    return data;
+  } catch (error) {
+    console.error("GitHub token refresh error:", error);
+    return null;
+  }
+}
+
+/**
+ * Get a valid GitHub access token for the current user.
+ * If the token is expired and a refresh token exists, refreshes inline
+ * and updates the database (mirroring the Vercel token refresh flow).
+ */
 export async function getUserGitHubToken(): Promise<string | null> {
   const session = await getServerSession();
   if (!session?.user?.id) return null;
 
   try {
     const ghAccount = await getGitHubAccount(session.user.id);
-    if (ghAccount?.accessToken) {
+    if (!ghAccount?.accessToken) return null;
+
+    // If no expiration is set, the token is non-expiring (classic OAuth)
+    if (!ghAccount.expiresAt) {
       return decrypt(ghAccount.accessToken);
     }
-    return null;
+
+    // Check if the token is still valid (with 5-minute buffer)
+    const now = Date.now();
+    const bufferMs = 5 * 60 * 1000;
+    const isExpired = ghAccount.expiresAt.getTime() - bufferMs < now;
+
+    if (!isExpired) {
+      return decrypt(ghAccount.accessToken);
+    }
+
+    // Token is expired -- try to refresh
+    if (!ghAccount.refreshToken) {
+      console.error("GitHub token expired but no refresh token available");
+      return null;
+    }
+
+    const decryptedRefresh = decrypt(ghAccount.refreshToken);
+    const refreshed = await refreshGitHubToken(decryptedRefresh);
+    if (!refreshed) return null;
+
+    // Persist the new tokens
+    const newExpiresAt = new Date(Date.now() + refreshed.expires_in * 1000);
+    await updateGitHubAccountTokens(session.user.id, {
+      accessToken: encrypt(refreshed.access_token),
+      refreshToken: encrypt(refreshed.refresh_token),
+      expiresAt: newExpiresAt,
+    });
+
+    return refreshed.access_token;
   } catch (error) {
     console.error("Error fetching GitHub token:", error);
     return null;


### PR DESCRIPTION
## Summary

- **Problem**: GitHub connector page goes blank after ~8 hours because the GitHub App uses expiring user tokens, but the codebase never stored or used the `refresh_token`/`expires_in` from GitHub's OAuth response. Expired tokens caused silent 401s on all GitHub API calls, rendering the connector page without connection details (while still showing the Disconnect button).

- **Fix**: Store `refresh_token` and `expiresAt` during the OAuth token exchange, and add inline token refresh logic to `getUserGitHubToken()` -- mirroring the existing Vercel token refresh pattern in `lib/vercel/token.ts`. Tokens are refreshed transparently with a 5-minute buffer before expiration.

- **Note**: Existing users who connected GitHub before this fix won't have a `refresh_token` stored. They need to disconnect and reconnect GitHub once to pick up the refresh token. After that, tokens auto-refresh.

## Changes

- `apps/web/app/api/github/app/callback/route.ts` -- Parse `refresh_token` and `expires_in` from GitHub's OAuth response and pass to `upsertGitHubAccount`
- `apps/web/lib/db/accounts.ts` -- Accept and persist `refreshToken`/`expiresAt` in upsert, return them from `getGitHubAccount`, add `updateGitHubAccountTokens` for persisting refreshed tokens
- `apps/web/lib/github/user-token.ts` -- Check token expiration, refresh via GitHub's OAuth endpoint with `grant_type=refresh_token`, and persist new tokens

No schema or migration changes needed -- the `accounts` table already had `refresh_token` and `expires_at` columns that were unused.