### PR TITLE
Add session sharing with public read-only links

### DIFF
--- a/apps/web/app/api/sessions/[sessionId]/share/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/share/route.ts
@@ -1,0 +1,74 @@
+import { nanoid } from "nanoid";
+import { getSessionById, updateSession } from "@/lib/db/sessions";
+import { getServerSession } from "@/lib/session/get-server-session";
+
+/**
+ * POST /api/sessions/:sessionId/share
+ * Generates a shareId for the session, making it publicly accessible.
+ */
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { sessionId } = await params;
+  const existingSession = await getSessionById(sessionId);
+
+  if (!existingSession) {
+    return Response.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (existingSession.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // If already shared, return the existing shareId
+  if (existingSession.shareId) {
+    return Response.json({ shareId: existingSession.shareId });
+  }
+
+  const shareId = nanoid(12);
+  const updated = await updateSession(sessionId, { shareId });
+
+  if (!updated) {
+    return Response.json(
+      { error: "Failed to update session" },
+      { status: 500 },
+    );
+  }
+
+  return Response.json({ shareId });
+}
+
+/**
+ * DELETE /api/sessions/:sessionId/share
+ * Removes the shareId, revoking public access.
+ */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { sessionId } = await params;
+  const existingSession = await getSessionById(sessionId);
+
+  if (!existingSession) {
+    return Response.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (existingSession.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await updateSession(sessionId, { shareId: null });
+
+  return Response.json({ success: true });
+}

--- a/apps/web/app/api/sessions/[sessionId]/share/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/share/route.ts
@@ -1,4 +1,7 @@
+import { and, eq, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
+import { db } from "@/lib/db/client";
+import { sessions } from "@/lib/db/schema";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { getServerSession } from "@/lib/session/get-server-session";
 
@@ -31,10 +34,21 @@ export async function POST(
     return Response.json({ shareId: existingSession.shareId });
   }
 
+  // Use conditional update to avoid race condition where two concurrent
+  // requests both see shareId as null and overwrite each other
   const shareId = nanoid(12);
-  const updated = await updateSession(sessionId, { shareId });
+  const [updated] = await db
+    .update(sessions)
+    .set({ shareId, updatedAt: new Date() })
+    .where(and(eq(sessions.id, sessionId), isNull(sessions.shareId)))
+    .returning();
 
   if (!updated) {
+    // Another request already set a shareId -- fetch and return it
+    const refreshed = await getSessionById(sessionId);
+    if (refreshed?.shareId) {
+      return Response.json({ shareId: refreshed.shareId });
+    }
     return Response.json(
       { error: "Failed to update session" },
       { status: 500 },

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -396,15 +396,23 @@ function ShareDialog({
   sessionId: string;
   initialShareId: string | null;
 }) {
+  const baseUrlFromEnv = process.env.NEXT_PUBLIC_VERCEL_URL
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+    : null;
   const [open, setOpen] = useState(false);
   const [shareId, setShareId] = useState(initialShareId);
   const [isLoading, setIsLoading] = useState(false);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [baseUrl, setBaseUrl] = useState<string | null>(baseUrlFromEnv);
 
-  const shareUrl = shareId
-    ? `${window.location.origin}/shared/${shareId}`
-    : null;
+  useEffect(() => {
+    if (!baseUrlFromEnv) {
+      setBaseUrl(window.location.origin);
+    }
+  }, [baseUrlFromEnv]);
+
+  const shareUrl = shareId && baseUrl ? `${baseUrl}/shared/${shareId}` : null;
 
   async function enableSharing() {
     setIsLoading(true);

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -396,21 +396,22 @@ function ShareDialog({
   sessionId: string;
   initialShareId: string | null;
 }) {
-  const baseUrlFromEnv = process.env.NEXT_PUBLIC_VERCEL_URL
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-    : null;
   const [open, setOpen] = useState(false);
   const [shareId, setShareId] = useState(initialShareId);
   const [isLoading, setIsLoading] = useState(false);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [baseUrl, setBaseUrl] = useState<string | null>(baseUrlFromEnv);
+  const [baseUrl, setBaseUrl] = useState<string | null>(
+    process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL
+      ? `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
+      : null,
+  );
 
   useEffect(() => {
-    if (!baseUrlFromEnv) {
+    if (!baseUrl) {
       setBaseUrl(window.location.origin);
     }
-  }, [baseUrlFromEnv]);
+  }, []);
 
   const shareUrl = shareId && baseUrl ? `${baseUrl}/shared/${shareId}` : null;
 

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -8,10 +8,12 @@ import {
   ArrowLeft,
   ArrowUp,
   Check,
+  Copy,
   ExternalLink,
   FolderGit2,
   GitCompare,
   GitPullRequest,
+  Link2,
   Loader2,
   Menu,
   MessageSquare,
@@ -19,6 +21,7 @@ import {
   Paperclip,
   Pencil,
   Plus,
+  Share2,
   Square,
   Trash2,
   X,
@@ -383,6 +386,134 @@ function SandboxInputOverlay({
         )}
       </div>
     </div>
+  );
+}
+
+function ShareDialog({
+  sessionId,
+  initialShareId,
+}: {
+  sessionId: string;
+  initialShareId: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const [shareId, setShareId] = useState(initialShareId);
+  const [isLoading, setIsLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const shareUrl = shareId
+    ? `${window.location.origin}/shared/${shareId}`
+    : null;
+
+  async function enableSharing() {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/share`, {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error("Failed to enable sharing");
+      const data = (await res.json()) as { shareId: string };
+      setShareId(data.shareId);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function disableSharing() {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/share`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to disable sharing");
+      setShareId(null);
+      setCopied(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function copyLink() {
+    if (!shareUrl) return;
+    navigator.clipboard.writeText(shareUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm">
+          <Share2 className="h-4 w-4 md:mr-2" />
+          <span className="hidden md:inline">Share</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Share session</DialogTitle>
+          <DialogDescription>
+            Anyone with the link can view the conversation in read-only mode.
+          </DialogDescription>
+        </DialogHeader>
+        {shareId ? (
+          <>
+            <div className="flex items-center gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-2 rounded-md border bg-muted px-3 py-2 text-sm">
+                <Link2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="truncate">{shareUrl}</span>
+              </div>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={copyLink}
+                className="shrink-0"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+            <DialogFooter className="flex-row justify-between sm:justify-between">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                onClick={() => void disableSharing()}
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : null}
+                Revoke link
+              </Button>
+              <DialogClose asChild>
+                <Button variant="outline" size="sm">
+                  Close
+                </Button>
+              </DialogClose>
+            </DialogFooter>
+          </>
+        ) : (
+          <DialogFooter>
+            <Button
+              onClick={() => void enableSharing()}
+              disabled={isLoading}
+              className="w-full"
+            >
+              {isLoading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Link2 className="mr-2 h-4 w-4" />
+              )}
+              Create share link
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -1615,6 +1746,10 @@ export function SessionChatContent() {
               </span>
             </div>
             <div className="flex items-center gap-1 md:gap-2">
+              <ShareDialog
+                sessionId={session.id}
+                initialShareId={session.shareId}
+              />
               <Dialog>
                 <DialogTrigger asChild>
                   <Button variant="ghost" size="sm">

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -400,6 +400,7 @@ function ShareDialog({
   const [shareId, setShareId] = useState(initialShareId);
   const [isLoading, setIsLoading] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const shareUrl = shareId
     ? `${window.location.origin}/shared/${shareId}`
@@ -407,13 +408,19 @@ function ShareDialog({
 
   async function enableSharing() {
     setIsLoading(true);
+    setError(null);
     try {
       const res = await fetch(`/api/sessions/${sessionId}/share`, {
         method: "POST",
       });
-      if (!res.ok) throw new Error("Failed to enable sharing");
+      if (!res.ok) {
+        setError("Failed to enable sharing");
+        return;
+      }
       const data = (await res.json()) as { shareId: string };
       setShareId(data.shareId);
+    } catch {
+      setError("Failed to enable sharing");
     } finally {
       setIsLoading(false);
     }
@@ -421,13 +428,19 @@ function ShareDialog({
 
   async function disableSharing() {
     setIsLoading(true);
+    setError(null);
     try {
       const res = await fetch(`/api/sessions/${sessionId}/share`, {
         method: "DELETE",
       });
-      if (!res.ok) throw new Error("Failed to disable sharing");
+      if (!res.ok) {
+        setError("Failed to disable sharing");
+        return;
+      }
       setShareId(null);
       setCopied(false);
+    } catch {
+      setError("Failed to disable sharing");
     } finally {
       setIsLoading(false);
     }
@@ -456,6 +469,7 @@ function ShareDialog({
             Anyone with the link can view the conversation in read-only mode.
           </DialogDescription>
         </DialogHeader>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
         {shareId ? (
           <>
             <div className="flex items-center gap-2">

--- a/apps/web/app/shared/[shareId]/page.tsx
+++ b/apps/web/app/shared/[shareId]/page.tsx
@@ -50,11 +50,12 @@ export default async function SharedPage({ params }: SharedPageProps) {
   // Sort chats oldest-first for reading order
   chatsWithMessages.reverse();
 
+  const { title, repoOwner, repoName, branch, cloneUrl } = session;
+
   return (
     <SharedChatContent
-      session={session}
+      session={{ title, repoOwner, repoName, branch, cloneUrl }}
       chats={chatsWithMessages}
-      shareId={shareId}
     />
   );
 }

--- a/apps/web/app/shared/[shareId]/page.tsx
+++ b/apps/web/app/shared/[shareId]/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { WebAgentUIMessage } from "@/app/types";
+import {
+  getChatMessages,
+  getChatsBySessionId,
+  getSessionByShareId,
+} from "@/lib/db/sessions";
+import { SharedChatContent } from "./shared-chat-content";
+
+interface SharedPageProps {
+  params: Promise<{ shareId: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: SharedPageProps): Promise<Metadata> {
+  const { shareId } = await params;
+  const session = await getSessionByShareId(shareId);
+
+  return {
+    title: session?.title ?? "Shared Session",
+    description: "A shared Open Harness session.",
+  };
+}
+
+export default async function SharedPage({ params }: SharedPageProps) {
+  const { shareId } = await params;
+
+  const session = await getSessionByShareId(shareId);
+  if (!session) {
+    notFound();
+  }
+
+  // Get all chats for this session (newest first)
+  const sessionChats = await getChatsBySessionId(session.id);
+  if (sessionChats.length === 0) {
+    notFound();
+  }
+
+  // Load messages for all chats
+  const chatsWithMessages = await Promise.all(
+    sessionChats.map(async (chat) => {
+      const dbMessages = await getChatMessages(chat.id);
+      const messages = dbMessages.map((m) => m.parts as WebAgentUIMessage);
+      return { chat, messages };
+    }),
+  );
+
+  // Sort chats oldest-first for reading order
+  chatsWithMessages.reverse();
+
+  return (
+    <SharedChatContent
+      session={session}
+      chats={chatsWithMessages}
+      shareId={shareId}
+    />
+  );
+}

--- a/apps/web/app/shared/[shareId]/shared-chat-content.tsx
+++ b/apps/web/app/shared/[shareId]/shared-chat-content.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import type { TaskToolUIPart } from "@open-harness/agent";
+import { isToolUIPart } from "ai";
+import { ExternalLink } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+import { Children, cloneElement, isValidElement } from "react";
+import type { BundledTheme } from "shiki";
+import { Streamdown } from "streamdown";
+import type {
+  WebAgentUIMessage,
+  WebAgentUIMessagePart,
+  WebAgentUIToolPart,
+} from "@/app/types";
+import { TaskGroupView } from "@/components/task-group-view";
+import { ToolCall } from "@/components/tool-call";
+import type { Chat, Session } from "@/lib/db/schema";
+import { cn } from "@/lib/utils";
+import "streamdown/styles.css";
+
+const customComponents = {
+  pre: ({ children, ...props }: ComponentProps<"pre">) => {
+    const processChildren = (child: ReactNode): ReactNode => {
+      if (isValidElement<{ children?: ReactNode }>(child)) {
+        const codeContent = child.props.children;
+        if (typeof codeContent === "string") {
+          return cloneElement(child, {
+            children: codeContent.trimEnd(),
+          });
+        }
+      }
+      return child;
+    };
+    return <pre {...props}>{Children.map(children, processChildren)}</pre>;
+  },
+};
+
+const shikiThemes = ["github-dark", "github-dark"] as [
+  BundledTheme,
+  BundledTheme,
+];
+
+type ChatWithMessages = {
+  chat: Chat;
+  messages: WebAgentUIMessage[];
+};
+
+export function SharedChatContent({
+  session,
+  chats,
+}: {
+  session: Session;
+  chats: ChatWithMessages[];
+  shareId: string;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      {/* Header */}
+      <header className="sticky top-0 z-10 border-b border-border bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="mx-auto flex max-w-3xl items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2 text-sm">
+            {session.repoName ? (
+              <>
+                {session.cloneUrl ? (
+                  /* oxlint-disable-next-line nextjs/no-html-link-for-pages */
+                  <a
+                    href={`https://github.com/${session.repoOwner}/${session.repoName}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 truncate font-medium text-foreground hover:underline"
+                  >
+                    {session.repoOwner}/{session.repoName}
+                    <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
+                  </a>
+                ) : (
+                  <span className="truncate font-medium text-foreground">
+                    {session.repoName}
+                  </span>
+                )}
+                {session.branch && (
+                  <>
+                    <span className="text-muted-foreground/40">/</span>
+                    <span className="text-muted-foreground">
+                      {session.branch}
+                    </span>
+                  </>
+                )}
+              </>
+            ) : (
+              <span className="truncate font-medium text-foreground">
+                {session.title}
+              </span>
+            )}
+          </div>
+          <span className="shrink-0 text-xs text-muted-foreground">
+            Shared session
+          </span>
+        </div>
+      </header>
+
+      {/* Messages */}
+      <div className="flex-1">
+        <div className="mx-auto max-w-3xl px-4 py-8">
+          <div className="space-y-6">
+            {chats.map(({ chat, messages }) => (
+              <div key={chat.id}>
+                {chats.length > 1 && (
+                  <div className="mb-4 flex items-center gap-2 text-xs text-muted-foreground">
+                    <div className="h-px flex-1 bg-border" />
+                    <span>{chat.title}</span>
+                    <div className="h-px flex-1 bg-border" />
+                  </div>
+                )}
+                <div className="space-y-6">
+                  {messages.map((m) => {
+                    type RenderGroup =
+                      | {
+                          type: "part";
+                          part: WebAgentUIMessagePart;
+                          index: number;
+                        }
+                      | {
+                          type: "task-group";
+                          tasks: TaskToolUIPart[];
+                          startIndex: number;
+                        };
+
+                    const renderGroups: RenderGroup[] = [];
+                    let currentTaskGroup: TaskToolUIPart[] = [];
+                    let taskGroupStartIndex = 0;
+
+                    m.parts.forEach((part, index) => {
+                      if (isToolUIPart(part) && part.type === "tool-task") {
+                        if (currentTaskGroup.length === 0) {
+                          taskGroupStartIndex = index;
+                        }
+                        currentTaskGroup.push(part as TaskToolUIPart);
+                      } else {
+                        if (currentTaskGroup.length > 0) {
+                          renderGroups.push({
+                            type: "task-group",
+                            tasks: currentTaskGroup,
+                            startIndex: taskGroupStartIndex,
+                          });
+                          currentTaskGroup = [];
+                        }
+                        renderGroups.push({ type: "part", part, index });
+                      }
+                    });
+
+                    if (currentTaskGroup.length > 0) {
+                      renderGroups.push({
+                        type: "task-group",
+                        tasks: currentTaskGroup,
+                        startIndex: taskGroupStartIndex,
+                      });
+                    }
+
+                    return renderGroups.map((group) => {
+                      if (group.type === "task-group") {
+                        return (
+                          <div
+                            key={`${m.id}-task-group-${group.startIndex}`}
+                            className="max-w-full"
+                          >
+                            <TaskGroupView
+                              taskParts={group.tasks}
+                              activeApprovalId={null}
+                              isStreaming={false}
+                            />
+                          </div>
+                        );
+                      }
+
+                      const p = group.part;
+                      const i = group.index;
+
+                      if (p.type === "text") {
+                        return (
+                          <div
+                            key={`${m.id}-${i}`}
+                            className={cn(
+                              "flex",
+                              m.role === "user"
+                                ? "justify-end"
+                                : "justify-start",
+                            )}
+                          >
+                            {m.role === "user" ? (
+                              <div className="max-w-[80%] rounded-3xl bg-secondary px-4 py-2">
+                                <p className="whitespace-pre-wrap">{p.text}</p>
+                              </div>
+                            ) : (
+                              <div className="max-w-[80%]">
+                                <Streamdown
+                                  mode="static"
+                                  isAnimating={false}
+                                  shikiTheme={shikiThemes}
+                                  components={customComponents}
+                                >
+                                  {p.text}
+                                </Streamdown>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      }
+
+                      if (isToolUIPart(p)) {
+                        return (
+                          <div key={`${m.id}-${i}`} className="max-w-full">
+                            <ToolCall
+                              part={p as WebAgentUIToolPart}
+                              isStreaming={false}
+                            />
+                          </div>
+                        );
+                      }
+
+                      if (
+                        p.type === "file" &&
+                        p.mediaType?.startsWith("image/")
+                      ) {
+                        return (
+                          <div
+                            key={`${m.id}-${i}`}
+                            className="flex justify-end"
+                          >
+                            <div className="max-w-[80%]">
+                              {/* eslint-disable-next-line @next/next/no-img-element -- Data URLs not supported by next/image */}
+                              <img
+                                src={p.url}
+                                alt={p.filename ?? "Attached image"}
+                                className="max-h-64 rounded-lg"
+                              />
+                            </div>
+                          </div>
+                        );
+                      }
+
+                      return null;
+                    });
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/shared/[shareId]/shared-chat-content.tsx
+++ b/apps/web/app/shared/[shareId]/shared-chat-content.tsx
@@ -14,7 +14,7 @@ import type {
 } from "@/app/types";
 import { TaskGroupView } from "@/components/task-group-view";
 import { ToolCall } from "@/components/tool-call";
-import type { Chat, Session } from "@/lib/db/schema";
+import type { Chat } from "@/lib/db/schema";
 import { cn } from "@/lib/utils";
 import "streamdown/styles.css";
 
@@ -45,13 +45,20 @@ type ChatWithMessages = {
   messages: WebAgentUIMessage[];
 };
 
+type SharedSession = {
+  title: string;
+  repoOwner: string | null;
+  repoName: string | null;
+  branch: string | null;
+  cloneUrl: string | null;
+};
+
 export function SharedChatContent({
   session,
   chats,
 }: {
-  session: Session;
+  session: SharedSession;
   chats: ChatWithMessages[];
-  shareId: string;
 }) {
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -3,8 +3,8 @@ import {
   boolean,
   integer,
   jsonb,
-  primaryKey,
   pgTable,
+  primaryKey,
   text,
   timestamp,
   uniqueIndex,
@@ -151,6 +151,8 @@ export const sessions = pgTable("sessions", {
   // Cached diff for offline viewing
   cachedDiff: jsonb("cached_diff"),
   cachedDiffUpdatedAt: timestamp("cached_diff_updated_at"),
+  // Sharing
+  shareId: text("share_id").unique(),
   // Timestamps
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/apps/web/lib/db/sessions.ts
+++ b/apps/web/lib/db/sessions.ts
@@ -1,12 +1,12 @@
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { db } from "./client";
 import {
-  chatReads,
   chatMessages,
+  chatReads,
   chats,
   type NewChat,
-  type NewChatRead,
   type NewChatMessage,
+  type NewChatRead,
   type NewSession,
   sessions,
 } from "./schema";
@@ -56,6 +56,12 @@ export async function createSessionWithInitialChat(
 export async function getSessionById(sessionId: string) {
   return db.query.sessions.findFirst({
     where: eq(sessions.id, sessionId),
+  });
+}
+
+export async function getSessionByShareId(shareId: string) {
+  return db.query.sessions.findFirst({
+    where: eq(sessions.shareId, shareId),
   });
 }
 


### PR DESCRIPTION
## Summary

- Add share dialog to session header that generates a unique share link for read-only public access
- Add API routes (`POST`/`DELETE`) for enabling/disabling sharing with race-condition-safe conditional updates
- Add shared session page (`/shared/[shareId]`) that renders the full conversation in a clean read-only view
- Add `shareId` column to sessions schema and `getSessionByShareId` query helper
- Use `NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL` for share link base URL (falls back to `window.location.origin` in local dev)