### PR TITLE
Fix archived session guards and add unarchive support

### DIFF
--- a/apps/web/app/api/sessions/[sessionId]/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/route.ts
@@ -1,12 +1,12 @@
 import { connectSandbox } from "@open-harness/sandbox";
 import { after } from "next/server";
-import { getServerSession } from "@/lib/session/get-server-session";
 import {
   deleteSession,
   getSessionById,
   updateSession,
 } from "@/lib/db/sessions";
 import { canOperateOnSandbox, clearSandboxState } from "@/lib/sandbox/utils";
+import { getServerSession } from "@/lib/session/get-server-session";
 
 interface UpdateSessionRequest {
   title?: string;
@@ -70,9 +70,12 @@ export async function PATCH(
   const shouldStopSandboxAfterArchive =
     body.status === "archived" && existingSession.status !== "archived";
 
+  const shouldUnarchive =
+    body.status === "running" && existingSession.status === "archived";
+
   const updatePayload: UpdateSessionRequest &
     Partial<{
-      lifecycleState: "archived";
+      lifecycleState: "archived" | null;
       sandboxExpiresAt: null;
       hibernateAfter: null;
     }> = { ...body };
@@ -80,6 +83,11 @@ export async function PATCH(
     updatePayload.lifecycleState = "archived";
     updatePayload.sandboxExpiresAt = null;
     updatePayload.hibernateAfter = null;
+  }
+  if (shouldUnarchive) {
+    // Reset lifecycle state so the session can be resumed normally.
+    // If there is a snapshot the client will auto-restore it on entry.
+    updatePayload.lifecycleState = null;
   }
 
   const updatedSession = await updateSession(sessionId, updatePayload);

--- a/apps/web/app/api/sessions/[sessionId]/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/route.ts
@@ -76,6 +76,7 @@ export async function PATCH(
   const updatePayload: UpdateSessionRequest &
     Partial<{
       lifecycleState: "archived" | null;
+      lifecycleError: null;
       sandboxExpiresAt: null;
       hibernateAfter: null;
     }> = { ...body };
@@ -88,6 +89,7 @@ export async function PATCH(
     // Reset lifecycle state so the session can be resumed normally.
     // If there is a snapshot the client will auto-restore it on entry.
     updatePayload.lifecycleState = null;
+    updatePayload.lifecycleError = null;
   }
 
   const updatedSession = await updateSession(sessionId, updatePayload);

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -4,6 +4,7 @@ import type { AskUserQuestionInput, TaskToolUIPart } from "@open-harness/agent";
 import { isToolUIPart } from "ai";
 import {
   Archive,
+  ArchiveRestore,
   ArrowDown,
   ArrowLeft,
   ArrowUp,
@@ -332,6 +333,7 @@ function SandboxInputOverlay({
   isRestoring,
   isReconnecting,
   isHibernating,
+  isArchived,
   hasSnapshot,
   onRestore,
   onCreateNew,
@@ -341,10 +343,24 @@ function SandboxInputOverlay({
   isRestoring: boolean;
   isReconnecting: boolean;
   isHibernating: boolean;
+  isArchived: boolean;
   hasSnapshot: boolean;
   onRestore: () => void;
   onCreateNew: () => void;
 }) {
+  if (isArchived) {
+    return (
+      <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/60 backdrop-blur-[2px]">
+        <div className="flex items-center gap-3 rounded-full bg-background/90 px-4 py-2 text-muted-foreground shadow-sm">
+          <Archive className="h-4 w-4" />
+          <span className="text-sm">
+            This session is archived. Unarchive it to resume.
+          </span>
+        </div>
+      </div>
+    );
+  }
+
   if (isSandboxActive && !isCreating && !isRestoring) {
     return null;
   }
@@ -411,6 +427,7 @@ function ShareDialog({
     if (!baseUrl) {
       setBaseUrl(window.location.origin);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount; baseUrl never changes
   }, []);
 
   const shareUrl = shareId && baseUrl ? `${baseUrl}/shared/${shareId}` : null;
@@ -636,6 +653,7 @@ export function SessionChatContent() {
     sandboxInfo,
     setSandboxInfo,
     archiveSession,
+    unarchiveSession,
     updateSessionTitle,
     updateChatModel,
     hadInitialMessages,
@@ -1150,9 +1168,13 @@ export function SessionChatContent() {
   const hasAutoRestoredSnapshotRef = useRef(false);
   const shouldAutoResumeOnEntryRef = useRef(true);
 
+  const isArchived = session.status === "archived";
+
   // Attempt a single reconnect probe on entry to pick up authoritative server state
   // (connected sandbox, no sandbox, and snapshot availability).
+  // Skip for archived sessions -- they should never spin up a sandbox.
   useEffect(() => {
+    if (isArchived) return;
     if (
       !sandboxInfo &&
       !isCreatingSandbox &&
@@ -1162,6 +1184,7 @@ export function SessionChatContent() {
       void attemptReconnection();
     }
   }, [
+    isArchived,
     sandboxInfo,
     isCreatingSandbox,
     isRestoringSnapshot,
@@ -1178,7 +1201,9 @@ export function SessionChatContent() {
   }, [sandboxInfo, reconnectionStatus]);
 
   // Auto-resume paused sessions on entry once we know there is no active runtime sandbox.
+  // Skip for archived sessions.
   useEffect(() => {
+    if (isArchived) return;
     if (!hasSnapshot) {
       hasAutoRestoredSnapshotRef.current = false;
       return;
@@ -1193,6 +1218,7 @@ export function SessionChatContent() {
     shouldAutoResumeOnEntryRef.current = false;
     void handleRestoreSnapshot();
   }, [
+    isArchived,
     session.id,
     hasSnapshot,
     sandboxInfo,
@@ -1272,7 +1298,9 @@ export function SessionChatContent() {
   ]);
 
   // Auto-create sandbox right away for new sessions/chats.
+  // Skip for archived sessions.
   useEffect(() => {
+    if (isArchived) return;
     if (sandboxInfo || isCreatingSandbox || isRestoringSnapshot) return;
 
     // If we have stored sandbox state, wait for reconnect attempt first.
@@ -1293,6 +1321,7 @@ export function SessionChatContent() {
 
     void ensureSandboxReady();
   }, [
+    isArchived,
     session.sandboxState,
     hasSnapshot,
     reconnectionStatus,
@@ -1454,6 +1483,9 @@ export function SessionChatContent() {
   const isSandboxActive = isSandboxValid(sandboxInfo) && serverSaysActive;
 
   const sandboxUiStatus = (() => {
+    if (isArchived) {
+      return { label: "Archived", className: "bg-muted text-muted-foreground" };
+    }
     if (isCreatingSandbox) {
       return { label: "Creating", className: "bg-amber-500/15 text-amber-700" };
     }
@@ -1773,40 +1805,58 @@ export function SessionChatContent() {
                 sessionId={session.id}
                 initialShareId={session.shareId}
               />
-              <Dialog>
-                <DialogTrigger asChild>
-                  <Button variant="ghost" size="sm">
-                    <Archive className="h-4 w-4 md:mr-2" />
-                    <span className="hidden md:inline">Archive</span>
-                  </Button>
-                </DialogTrigger>
-                <DialogContent showCloseButton={false}>
-                  <DialogHeader>
-                    <DialogTitle>Archive session?</DialogTitle>
-                    <DialogDescription>
-                      This will stop the sandbox and archive the session. You
-                      can still view it in the archive tab.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogFooter>
-                    <DialogClose asChild>
-                      <Button variant="outline">Cancel</Button>
-                    </DialogClose>
-                    <DialogClose asChild>
-                      <Button
-                        onClick={() => {
-                          void archiveSession().catch((error: unknown) => {
-                            console.error("Failed to archive session:", error);
-                          });
-                          router.push("/");
-                        }}
-                      >
-                        Archive
-                      </Button>
-                    </DialogClose>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
+              {isArchived ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    void unarchiveSession().catch((error: unknown) => {
+                      console.error("Failed to unarchive session:", error);
+                    });
+                  }}
+                >
+                  <ArchiveRestore className="h-4 w-4 md:mr-2" />
+                  <span className="hidden md:inline">Unarchive</span>
+                </Button>
+              ) : (
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button variant="ghost" size="sm">
+                      <Archive className="h-4 w-4 md:mr-2" />
+                      <span className="hidden md:inline">Archive</span>
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent showCloseButton={false}>
+                    <DialogHeader>
+                      <DialogTitle>Archive session?</DialogTitle>
+                      <DialogDescription>
+                        This will stop the sandbox and archive the session. You
+                        can still view it in the archive tab.
+                      </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                      <DialogClose asChild>
+                        <Button variant="outline">Cancel</Button>
+                      </DialogClose>
+                      <DialogClose asChild>
+                        <Button
+                          onClick={() => {
+                            void archiveSession().catch((error: unknown) => {
+                              console.error(
+                                "Failed to archive session:",
+                                error,
+                              );
+                            });
+                            router.push("/");
+                          }}
+                        >
+                          Archive
+                        </Button>
+                      </DialogClose>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+              )}
               {!supportsDiff ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -2200,6 +2250,7 @@ export function SessionChatContent() {
                   isRestoring={isRestoringSnapshot}
                   isReconnecting={isReconnectingSandbox && !isHibernatingUi}
                   isHibernating={isHibernatingUi}
+                  isArchived={isArchived}
                   hasSnapshot={hasSnapshot}
                   onRestore={handleRestoreSnapshot}
                   onCreateNew={handleCreateNewSandbox}
@@ -2254,7 +2305,7 @@ export function SessionChatContent() {
                         }
                       }
                     }}
-                    disabled={status === "streaming"}
+                    disabled={isArchived || status === "streaming"}
                     className="w-full resize-none overflow-y-auto bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none"
                     style={{ minHeight: "24px" }}
                   />

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -427,7 +427,7 @@ function ShareDialog({
     if (!baseUrl) {
       setBaseUrl(window.location.origin);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount; baseUrl never changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
   }, []);
 
   const shareUrl = shareId && baseUrl ? `${baseUrl}/shared/${shareId}` : null;
@@ -2183,6 +2183,7 @@ export function SessionChatContent() {
               <form
                 onSubmit={async (e) => {
                   e.preventDefault();
+                  if (isArchived) return;
                   const hasContent = input.trim() || images.length > 0;
                   if (!hasContent) return;
 
@@ -2319,6 +2320,7 @@ export function SessionChatContent() {
                       variant="ghost"
                       size="icon"
                       onClick={openFilePicker}
+                      disabled={isArchived}
                       className="h-8 w-8 rounded-full text-muted-foreground hover:text-foreground"
                     >
                       <Paperclip className="h-4 w-4" />
@@ -2359,7 +2361,7 @@ export function SessionChatContent() {
                       variant="ghost"
                       size="icon"
                       onClick={handleMicClick}
-                      disabled={recordingState === "processing"}
+                      disabled={isArchived || recordingState === "processing"}
                       className={`relative h-8 w-8 rounded-full ${
                         recordingState === "recording"
                           ? "text-red-500"
@@ -2395,6 +2397,7 @@ export function SessionChatContent() {
                         type="submit"
                         size="icon"
                         disabled={
+                          isArchived ||
                           (!input.trim() && images.length === 0) ||
                           isUpdatingModel
                         }

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -563,6 +563,7 @@ export function SessionChatContent() {
   const [input, setInput] = useState("");
   const [isCreatingSandbox, setIsCreatingSandbox] = useState(false);
   const [isRestoringSnapshot, setIsRestoringSnapshot] = useState(false);
+  const [isUnarchiving, setIsUnarchiving] = useState(false);
   const [prDialogOpen, setPrDialogOpen] = useState(false);
   const [repoDialogOpen, setRepoDialogOpen] = useState(false);
   const [showDiffPanel, setShowDiffPanel] = useState(false);
@@ -1809,14 +1810,26 @@ export function SessionChatContent() {
                 <Button
                   variant="ghost"
                   size="sm"
+                  disabled={isUnarchiving}
                   onClick={() => {
-                    void unarchiveSession().catch((error: unknown) => {
-                      console.error("Failed to unarchive session:", error);
-                    });
+                    setIsUnarchiving(true);
+                    void unarchiveSession()
+                      .catch((error: unknown) => {
+                        console.error("Failed to unarchive session:", error);
+                      })
+                      .finally(() => {
+                        setIsUnarchiving(false);
+                      });
                   }}
                 >
-                  <ArchiveRestore className="h-4 w-4 md:mr-2" />
-                  <span className="hidden md:inline">Unarchive</span>
+                  {isUnarchiving ? (
+                    <Loader2 className="h-4 w-4 animate-spin md:mr-2" />
+                  ) : (
+                    <ArchiveRestore className="h-4 w-4 md:mr-2" />
+                  )}
+                  <span className="hidden md:inline">
+                    {isUnarchiving ? "Unarchiving..." : "Unarchive"}
+                  </span>
                 </Button>
               ) : (
                 <Dialog>

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -108,6 +108,7 @@ type SessionChatContextValue = {
   setSandboxInfo: (info: SandboxInfo) => void;
   clearSandboxInfo: () => void;
   archiveSession: () => Promise<void>;
+  unarchiveSession: () => Promise<void>;
   updateSessionTitle: (title: string) => Promise<void>;
   updateChatModel: (modelId: string) => Promise<void>;
   /** Whether the chat had persisted messages when it was loaded */
@@ -771,6 +772,68 @@ export function SessionChatProvider({
     );
   }, [sessionRecord, mutate]);
 
+  const unarchiveSession = useCallback(async () => {
+    const previousSession = sessionRecord;
+    const optimisticSession: Session = {
+      ...sessionRecord,
+      status: "running",
+    };
+
+    setSessionRecord(optimisticSession);
+    await mutate<SessionsResponse>(
+      "/api/sessions",
+      (current) =>
+        current
+          ? {
+              sessions: current.sessions.map((s) =>
+                s.id === sessionRecord.id ? optimisticSession : s,
+              ),
+            }
+          : current,
+      { revalidate: false },
+    );
+
+    const res = await fetch(`/api/sessions/${sessionRecord.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "running" }),
+    });
+
+    const data = (await res.json()) as { session?: Session; error?: string };
+
+    if (!res.ok) {
+      setSessionRecord(previousSession);
+      await mutate<SessionsResponse>(
+        "/api/sessions",
+        (current) =>
+          current
+            ? {
+                sessions: current.sessions.map((s) =>
+                  s.id === sessionRecord.id ? previousSession : s,
+                ),
+              }
+            : current,
+        { revalidate: false },
+      );
+      throw new Error(data.error ?? "Failed to unarchive session");
+    }
+
+    const nextSession = data.session ?? optimisticSession;
+    setSessionRecord(nextSession);
+    await mutate<SessionsResponse>(
+      "/api/sessions",
+      (current) =>
+        current
+          ? {
+              sessions: current.sessions.map((s) =>
+                s.id === sessionRecord.id ? nextSession : s,
+              ),
+            }
+          : current,
+      { revalidate: false },
+    );
+  }, [sessionRecord, mutate]);
+
   const updateSessionTitle = useCallback(
     async (title: string) => {
       const res = await fetch(`/api/sessions/${sessionRecord.id}`, {
@@ -824,6 +887,7 @@ export function SessionChatProvider({
         setSandboxInfo,
         clearSandboxInfo,
         archiveSession,
+        unarchiveSession,
         updateSessionTitle,
         updateChatModel,
         hadInitialMessages,

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -773,27 +773,9 @@ export function SessionChatProvider({
   }, [sessionRecord, mutate]);
 
   const unarchiveSession = useCallback(async () => {
-    const previousSession = sessionRecord;
-    const optimisticSession: Session = {
-      ...sessionRecord,
-      status: "running",
-      lifecycleState: null,
-    };
-
-    setSessionRecord(optimisticSession);
-    await mutate<SessionsResponse>(
-      "/api/sessions",
-      (current) =>
-        current
-          ? {
-              sessions: current.sessions.map((s) =>
-                s.id === sessionRecord.id ? optimisticSession : s,
-              ),
-            }
-          : current,
-      { revalidate: false },
-    );
-
+    // Wait for server confirmation before updating local state so that
+    // sandbox-related effects (reconnect probe, auto-restore, auto-create)
+    // don't fire until the server has actually reset the session.
     const res = await fetch(`/api/sessions/${sessionRecord.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -803,23 +785,14 @@ export function SessionChatProvider({
     const data = (await res.json()) as { session?: Session; error?: string };
 
     if (!res.ok) {
-      setSessionRecord(previousSession);
-      await mutate<SessionsResponse>(
-        "/api/sessions",
-        (current) =>
-          current
-            ? {
-                sessions: current.sessions.map((s) =>
-                  s.id === sessionRecord.id ? previousSession : s,
-                ),
-              }
-            : current,
-        { revalidate: false },
-      );
       throw new Error(data.error ?? "Failed to unarchive session");
     }
 
-    const nextSession = data.session ?? optimisticSession;
+    const nextSession: Session = data.session ?? {
+      ...sessionRecord,
+      status: "running",
+      lifecycleState: null,
+    };
     setSessionRecord(nextSession);
     await mutate<SessionsResponse>(
       "/api/sessions",

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -777,6 +777,7 @@ export function SessionChatProvider({
     const optimisticSession: Session = {
       ...sessionRecord,
       status: "running",
+      lifecycleState: null,
     };
 
     setSessionRecord(optimisticSession);


### PR DESCRIPTION
## Summary

- Disable sandbox auto-start, reconnect probes, and snapshot auto-restore for archived sessions so they never accidentally spin up resources
- Add an "Unarchive" button that resets session status server-side (clearing `lifecycleState` and `lifecycleError`) before updating client state, preventing race conditions
- Guard all interaction controls (input, file picker, mic, submit, form submit) against archived sessions with a clear overlay message