### PR TITLE
Fix snapshot failure during archive to fall back to stop

### DIFF
--- a/apps/web/app/api/sessions/[sessionId]/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/route.ts
@@ -109,9 +109,25 @@ export async function PATCH(
         }
 
         const sandbox = await connectSandbox(archivedSession.sandboxState);
-        await sandbox.stop();
+
+        // Snapshot before stopping so the sandbox can be restored on unarchive.
+        // snapshot() automatically stops the sandbox, so no separate stop() needed.
+        let snapshotFields: {
+          snapshotUrl?: string;
+          snapshotCreatedAt?: Date;
+        } = {};
+        if (sandbox.snapshot) {
+          const result = await sandbox.snapshot();
+          snapshotFields = {
+            snapshotUrl: result.snapshotId,
+            snapshotCreatedAt: new Date(),
+          };
+        } else {
+          await sandbox.stop();
+        }
 
         await updateSession(sessionId, {
+          ...snapshotFields,
           sandboxState: clearSandboxState(archivedSession.sandboxState),
           lifecycleState: "archived",
           sandboxExpiresAt: null,

--- a/apps/web/app/api/sessions/[sessionId]/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/route.ts
@@ -117,11 +117,19 @@ export async function PATCH(
           snapshotCreatedAt?: Date;
         } = {};
         if (sandbox.snapshot) {
-          const result = await sandbox.snapshot();
-          snapshotFields = {
-            snapshotUrl: result.snapshotId,
-            snapshotCreatedAt: new Date(),
-          };
+          try {
+            const result = await sandbox.snapshot();
+            snapshotFields = {
+              snapshotUrl: result.snapshotId,
+              snapshotCreatedAt: new Date(),
+            };
+          } catch (snapshotError) {
+            console.error(
+              `[Sessions] Snapshot failed for session ${sessionId}, falling back to stop:`,
+              snapshotError,
+            );
+            await sandbox.stop();
+          }
         } else {
           await sandbox.stop();
         }


### PR DESCRIPTION
## Summary

- Wraps `sandbox.snapshot()` in a try/catch during the archive flow so that if snapshotting fails, the code falls back to `sandbox.stop()` instead of bubbling up to the outer catch
- Previously, a snapshot failure would leave the session in an inconsistent state: `lifecycleState: "archived"` but `sandboxState` never cleared and no snapshot saved
- The subsequent `updateSession` call now always executes, properly clearing sandbox state and completing the archive