### PR TITLE
Add configurable sandbox ports for dev server previews

### DIFF
--- a/apps/cli/tui/components/tool-renderers/bash-renderer.tsx
+++ b/apps/cli/tui/components/tool-renderers/bash-renderer.tsx
@@ -10,6 +10,7 @@ import { getDotColor, ToolSpinner } from "./shared";
 export function BashRenderer({ part, state }: ToolRendererProps<"tool-bash">) {
   const isInputReady = part.state !== "input-streaming";
   const command = isInputReady ? String(part.input?.command ?? "") : "";
+  const isDetached = isInputReady && part.input?.detached === true;
   const exitCode =
     part.state === "output-available" ? part.output?.exitCode : undefined;
   const stdout =
@@ -17,7 +18,9 @@ export function BashRenderer({ part, state }: ToolRendererProps<"tool-bash">) {
   const stderr =
     part.state === "output-available" ? part.output?.stderr : undefined;
   const hasOutput = stdout || stderr;
-  const isError = exitCode !== undefined && exitCode !== 0;
+  const toolFailed =
+    part.state === "output-available" && part.output?.success === false;
+  const isError = toolFailed || (typeof exitCode === "number" && exitCode !== 0);
 
   // Combine stdout and stderr, show last 3 lines
   const combinedOutput = [stdout, stderr].filter(Boolean).join("\n").trim();
@@ -67,6 +70,7 @@ export function BashRenderer({ part, state }: ToolRendererProps<"tool-bash">) {
         <text fg="gray">(</text>
         <text fg="white">{displayCommand}</text>
         <text fg="gray">)</text>
+        {isDetached && <text fg={PRIMARY_COLOR}> [detached]</text>}
       </box>
 
       {/* Show Running/Waiting status for approval-requested tools */}
@@ -88,7 +92,11 @@ export function BashRenderer({ part, state }: ToolRendererProps<"tool-bash">) {
             {isError && (
               <box flexDirection="row">
                 <text fg="gray">└ </text>
-                <text fg="red">Error: Exit code {exitCode}</text>
+                <text fg="red">
+                  {typeof exitCode === "number"
+                    ? `Error: Exit code ${exitCode}`
+                    : "Error"}
+                </text>
               </box>
             )}
             {hasOutput ? (

--- a/apps/cli/tui/components/tool-renderers/bash-renderer.tsx
+++ b/apps/cli/tui/components/tool-renderers/bash-renderer.tsx
@@ -20,7 +20,8 @@ export function BashRenderer({ part, state }: ToolRendererProps<"tool-bash">) {
   const hasOutput = stdout || stderr;
   const toolFailed =
     part.state === "output-available" && part.output?.success === false;
-  const isError = toolFailed || (typeof exitCode === "number" && exitCode !== 0);
+  const isError =
+    toolFailed || (typeof exitCode === "number" && exitCode !== 0);
 
   // Combine stdout and stderr, show last 3 lines
   const combinedOutput = [stdout, stderr].filter(Boolean).join("\n").trim();

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import {
   sumLanguageModelUsage,
 } from "@open-harness/agent";
 import { connectSandbox, type SandboxState } from "@open-harness/sandbox";
+import { DEFAULT_SANDBOX_PORTS } from "@/lib/sandbox/config";
 import {
   convertToModelMessages,
   type GatewayModelId,
@@ -171,6 +172,7 @@ export async function POST(req: Request) {
   // Connect sandbox (handles all modes, handoff, restoration)
   const sandbox = await connectSandbox(sessionRecord.sandboxState, {
     env: githubToken ? { GITHUB_TOKEN: githubToken } : undefined,
+    ports: DEFAULT_SANDBOX_PORTS,
   });
 
   if (githubToken && sessionRecord.repoOwner && sessionRecord.repoName) {

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -9,7 +9,10 @@ import { parseGitHubUrl } from "@/lib/github/client";
 import { getRepoToken } from "@/lib/github/get-repo-token";
 import { downloadAndExtractTarball } from "@/lib/github/tarball";
 import { getUserGitHubToken } from "@/lib/github/user-token";
-import { DEFAULT_SANDBOX_TIMEOUT_MS } from "@/lib/sandbox/config";
+import {
+  DEFAULT_SANDBOX_TIMEOUT_MS,
+  DEFAULT_SANDBOX_PORTS,
+} from "@/lib/sandbox/config";
 import {
   buildActiveLifecycleUpdate,
   getNextLifecycleVersion,
@@ -118,7 +121,7 @@ export async function POST(req: Request) {
   if (providedSandboxId) {
     const sandbox = await connectSandbox({
       state: { type: "hybrid", sandboxId: providedSandboxId },
-      options: { env },
+      options: { env, ports: DEFAULT_SANDBOX_PORTS },
     });
 
     if (sessionId && sandbox.getState) {
@@ -205,6 +208,7 @@ export async function POST(req: Request) {
         env,
         gitUser,
         timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+        ports: DEFAULT_SANDBOX_PORTS,
       },
     });
   } else {
@@ -220,6 +224,7 @@ export async function POST(req: Request) {
         env,
         gitUser,
         timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+        ports: DEFAULT_SANDBOX_PORTS,
         scheduleBackgroundWork: (cb) => after(cb),
         hooks: sessionId
           ? {

--- a/apps/web/app/api/sandbox/snapshot/route.ts
+++ b/apps/web/app/api/sandbox/snapshot/route.ts
@@ -1,6 +1,9 @@
 import { connectSandbox } from "@open-harness/sandbox";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
-import { DEFAULT_SANDBOX_TIMEOUT_MS } from "@/lib/sandbox/config";
+import {
+  DEFAULT_SANDBOX_PORTS,
+  DEFAULT_SANDBOX_TIMEOUT_MS,
+} from "@/lib/sandbox/config";
 import {
   buildActiveLifecycleUpdate,
   buildHibernatedLifecycleUpdate,
@@ -166,7 +169,10 @@ export async function PUT(req: Request) {
     // which would cause connectSandbox to reconnect instead of restore
     const sandbox = await connectSandbox(
       { type: sandboxType, snapshotId: sessionRecord.snapshotUrl },
-      { timeout: DEFAULT_SANDBOX_TIMEOUT_MS },
+      {
+        timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+        ports: DEFAULT_SANDBOX_PORTS,
+      },
     );
 
     // Update session with new sandbox state

--- a/apps/web/components/tool-call/renderers/bash-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/bash-renderer.tsx
@@ -33,7 +33,8 @@ export function BashRenderer({
   const hasMoreLines = allLines.length > 3;
 
   // Determine if we have content worth expanding
-  const hasExpandableContent = command.length > 60 || hasMoreLines || cwd;
+  const hasExpandableContent =
+    command.length > 60 || hasMoreLines || cwd || isDetached;
 
   const dotColor = state.denied
     ? "bg-red-500"

--- a/apps/web/components/tool-call/renderers/bash-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/bash-renderer.tsx
@@ -17,13 +17,15 @@ export function BashRenderer({
   const input = part.input;
   const command = String(input?.command ?? "");
   const cwd = input?.cwd;
+  const isDetached = input?.detached === true;
 
   const output = part.state === "output-available" ? part.output : undefined;
   const exitCode = output?.exitCode;
   const stdout = output?.stdout;
   const stderr = output?.stderr;
   const hasOutput = stdout || stderr;
-  const isError = exitCode !== undefined && exitCode !== 0;
+  const toolFailed = output?.success === false;
+  const isError = toolFailed || (typeof exitCode === "number" && exitCode !== 0);
 
   const combinedOutput = [stdout, stderr].filter(Boolean).join("\n").trim();
   const allLines = combinedOutput.split("\n");
@@ -95,6 +97,11 @@ export function BashRenderer({
             : command || "..."}
         </code>
         <span className="text-muted-foreground">)</span>
+        {isDetached && (
+          <span className="rounded bg-blue-500/15 px-1.5 py-0.5 text-xs font-medium text-blue-500">
+            detached
+          </span>
+        )}
       </div>
 
       {state.approvalRequested && state.isActiveApproval && (
@@ -127,7 +134,9 @@ export function BashRenderer({
           <div className="mt-2 pl-5">
             {isError && (
               <div className="text-sm text-red-500">
-                Error: Exit code {exitCode}
+                {typeof exitCode === "number"
+                  ? `Error: Exit code ${exitCode}`
+                  : "Error"}
               </div>
             )}
             {hasOutput ? (
@@ -178,12 +187,21 @@ export function BashRenderer({
             </div>
           )}
 
+          {isDetached && (
+            <div>
+              <div className="mb-1 text-xs font-medium text-muted-foreground">
+                Mode
+              </div>
+              <span className="text-sm text-foreground">Detached (background)</span>
+            </div>
+          )}
+
           {/* Full output */}
           {part.state === "output-available" && (
             <div>
               <div className="mb-1 flex items-center gap-2 text-xs font-medium text-muted-foreground">
                 <span>Output</span>
-                {exitCode !== undefined && (
+                {typeof exitCode === "number" && (
                   <span
                     className={cn(
                       "rounded px-1.5 py-0.5",

--- a/apps/web/components/tool-call/renderers/bash-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/bash-renderer.tsx
@@ -25,7 +25,8 @@ export function BashRenderer({
   const stderr = output?.stderr;
   const hasOutput = stdout || stderr;
   const toolFailed = output?.success === false;
-  const isError = toolFailed || (typeof exitCode === "number" && exitCode !== 0);
+  const isError =
+    toolFailed || (typeof exitCode === "number" && exitCode !== 0);
 
   const combinedOutput = [stdout, stderr].filter(Boolean).join("\n").trim();
   const allLines = combinedOutput.split("\n");
@@ -193,7 +194,9 @@ export function BashRenderer({
               <div className="mb-1 text-xs font-medium text-muted-foreground">
                 Mode
               </div>
-              <span className="text-sm text-foreground">Detached (background)</span>
+              <span className="text-sm text-foreground">
+                Detached (background)
+              </span>
             </div>
           )}
 

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -20,3 +20,13 @@ export const SANDBOX_LIFECYCLE_STALE_RUN_GRACE_MS = 2 * 60 * 1000;
 
 /** Minimum sleep between lifecycle workflow loop iterations (5 seconds) */
 export const SANDBOX_LIFECYCLE_MIN_SLEEP_MS = 5 * 1000;
+
+/**
+ * Default ports to expose from cloud sandboxes for dev server previews.
+ * Limited to 4 ports. Covers the most common framework defaults:
+ * - 3000: Next.js, Express, Remix
+ * - 5173: Vite, SvelteKit
+ * - 4321: Astro
+ * - 8080: Generic / custom servers
+ */
+export const DEFAULT_SANDBOX_PORTS = [3000, 5173, 4321, 8080];

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -27,6 +27,5 @@ export const SANDBOX_LIFECYCLE_MIN_SLEEP_MS = 5 * 1000;
  * - 3000: Next.js, Express, Remix
  * - 5173: Vite, SvelteKit
  * - 4321: Astro
- * - 8080: Generic / custom servers
  */
-export const DEFAULT_SANDBOX_PORTS = [3000, 5173, 4321, 8080];
+export const DEFAULT_SANDBOX_PORTS = [3000, 5173, 4321];

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cc-clone-ai-sdk",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cc-clone-ai-sdk",

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -25,8 +25,11 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 
 ## Sandbox Lifecycle
 
+- Detached/background bash results may have `exitCode: null` for both successful starts and explicit tool failures; bash renderer error state must also honor `output.success === false` (not only numeric non-zero exit codes), and detached quick-failure probing should prefer a timer-vs-wait race branch over matching SDK-specific error names.
 - Creating a sandbox snapshot automatically shuts down that sandbox; lifecycle plans and implementations must treat snapshotting as a stop/hibernate transition, not a non-disruptive backup.
 - Vercel `sdk.domain(port)` throws when a sandbox has no route for that port (common on some restored/reconnected sandboxes); environment/prompt metadata should guard per-port URL generation instead of assuming every configured port is routable.
+- Hybrid post-handoff prompt metadata uses delegated Vercel `environmentDetails`; never hardcode host resolution to port `80` or prompts can show `Sandbox host: undefined` even when declared preview ports (for example `3000`) are routable.
+- Hybrid/Vercel handoff prompt metadata should derive host/preview URLs from Vercel SDK `routes` (live route data), not only from locally passed `ports`; reconnect paths may omit `ports` even though routes are available.
 - Vercel sandbox creation has a hard timeout limit of `18_000_000ms`; if you add an internal timeout buffer before calling the SDK, clamp proactive timeout so `timeout + buffer` never exceeds that API limit.
 - In serverless environments, lifecycle checks that only run inline during request handlers are not durable; long-gap sandbox lifecycle actions must be scheduled with a durable workflow run (`start(...)` + `sleep(...)`) so they execute without a connected client.
 - Vercel `snapshot()` may return `422 sandbox_snapshotting` when another snapshot is already in progress; lifecycle code should treat this as an idempotent/in-progress condition and reconcile state instead of marking lifecycle as failed.

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -26,6 +26,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 ## Sandbox Lifecycle
 
 - Creating a sandbox snapshot automatically shuts down that sandbox; lifecycle plans and implementations must treat snapshotting as a stop/hibernate transition, not a non-disruptive backup.
+- Vercel `sdk.domain(port)` throws when a sandbox has no route for that port (common on some restored/reconnected sandboxes); environment/prompt metadata should guard per-port URL generation instead of assuming every configured port is routable.
 - Vercel sandbox creation has a hard timeout limit of `18_000_000ms`; if you add an internal timeout buffer before calling the SDK, clamp proactive timeout so `timeout + buffer` never exceeds that API limit.
 - In serverless environments, lifecycle checks that only run inline during request handlers are not durable; long-gap sandbox lifecycle actions must be scheduled with a durable workflow run (`start(...)` + `sleep(...)`) so they execute without a connected client.
 - Vercel `snapshot()` may return `422 sandbox_snapshotting` when another snapshot is already in progress; lifecycle code should treat this as an idempotent/in-progress condition and reconcile state instead of marking lifecycle as failed.

--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -17,6 +17,12 @@ const bashInputSchema = z.object({
     .string()
     .optional()
     .describe("Working directory for the command (absolute path)"),
+  detached: z
+    .boolean()
+    .optional()
+    .describe(
+      "Use this whenever you want to run a persistent server in the background (e.g., npm run dev, next dev). The command starts and returns immediately without waiting for it to finish.",
+    ),
 });
 
 type BashInput = z.infer<typeof bashInputSchema>;
@@ -182,7 +188,7 @@ WHEN NOT TO USE:
 - Reading files (use readFileTool instead)
 - Editing or creating files (use editFileTool or writeFileTool instead)
 - Searching code or text (use grepTool and/or globTool instead)
-- Interactive commands (shells, editors, REPLs) or long-lived daemons
+- Interactive commands (shells, editors, REPLs)
 
 USAGE:
 - Runs bash -c "<command>" in a non-interactive shell (no TTY/PTY)
@@ -199,16 +205,17 @@ DO NOT USE FOR:
 IMPORTANT:
 - Never chain commands with ';' or '&&' - use separate tool calls for each logical step
 - Never use interactive commands (vim, nano, top, bash, ssh, etc.)
-- Never start background processes with '&'
 - Always quote file paths that may contain spaces
 - Setting cwd to a path outside the working directory requires approval
+- Use detached: true to start dev servers or other long-running processes in the background
 
 EXAMPLES:
 - Run the test suite: command: "npm test", cwd: "/Users/username/project"
 - Check git status: command: "git status --short"
-- List files in src: command: "ls -la", cwd: "/Users/username/project/src"`,
+- List files in src: command: "ls -la", cwd: "/Users/username/project/src"
+- Start a dev server: command: "npm run dev", detached: true`,
     inputSchema: bashInputSchema,
-    execute: async ({ command, cwd }, { experimental_context }) => {
+    execute: async ({ command, cwd, detached }, { experimental_context }) => {
       const sandbox = getSandbox(experimental_context, "bash");
       const workingDirectory = sandbox.workingDirectory;
 
@@ -218,6 +225,40 @@ EXAMPLES:
           ? cwd
           : path.resolve(workingDirectory, cwd)
         : workingDirectory;
+
+      // Detached mode: start the command in the background and return immediately
+      if (detached) {
+        if (!sandbox.execDetached) {
+          return {
+            success: false,
+            exitCode: null,
+            stdout: "",
+            stderr:
+              "Detached mode is not supported in this sandbox environment. Only cloud sandboxes support background processes.",
+          };
+        }
+
+        try {
+          const { commandId } = await sandbox.execDetached(
+            command,
+            workingDir,
+          );
+          return {
+            success: true,
+            exitCode: null,
+            stdout: `Process started in background (command ID: ${commandId}). The server is now running.`,
+            stderr: "",
+          };
+        } catch (error) {
+          return {
+            success: false,
+            exitCode: null,
+            stdout: "",
+            stderr:
+              error instanceof Error ? error.message : String(error),
+          };
+        }
+      }
 
       const result = await sandbox.exec(command, workingDir, TIMEOUT_MS);
 

--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -239,10 +239,7 @@ EXAMPLES:
         }
 
         try {
-          const { commandId } = await sandbox.execDetached(
-            command,
-            workingDir,
-          );
+          const { commandId } = await sandbox.execDetached(command, workingDir);
           return {
             success: true,
             exitCode: null,
@@ -254,8 +251,7 @@ EXAMPLES:
             success: false,
             exitCode: null,
             stdout: "",
-            stderr:
-              error instanceof Error ? error.message : String(error),
+            stderr: error instanceof Error ? error.message : String(error),
           };
         }
       }

--- a/packages/sandbox/factory.ts
+++ b/packages/sandbox/factory.ts
@@ -31,6 +31,8 @@ export interface ConnectOptions {
   hooks?: SandboxHooks;
   /** Timeout in milliseconds for cloud sandboxes (default: 300,000 = 5 minutes) */
   timeout?: number;
+  /** Ports to expose from the sandbox for dev server preview URLs */
+  ports?: number[];
 }
 
 /**
@@ -43,6 +45,8 @@ export interface HybridConnectOptions extends Omit<ConnectOptions, "hooks"> {
   gitUser?: { name: string; email: string };
   /** Lifecycle hooks including hybrid-specific hooks */
   hooks?: HybridHooks;
+  /** Ports to expose from the sandbox for dev server preview URLs */
+  ports?: number[];
   /**
    * Schedule background work for cloud sandbox startup.
    * Wire to your runtime's background task mechanism.

--- a/packages/sandbox/hybrid/connect.ts
+++ b/packages/sandbox/hybrid/connect.ts
@@ -20,6 +20,8 @@ export interface HybridConnectOptions {
   hooks?: HybridHooks;
   /** Timeout in milliseconds for cloud sandboxes (default: 300,000 = 5 minutes) */
   timeout?: number;
+  /** Ports to expose from the sandbox for dev server preview URLs */
+  ports?: number[];
   /**
    * Schedule background work for cloud sandbox startup.
    * The callback returns a promise that completes when cloud sandbox is ready.
@@ -68,6 +70,7 @@ function startCloudSandboxInBackground(
         gitUser: options?.gitUser,
         hooks: options?.hooks,
         timeout: options?.timeout,
+        ports: options?.ports,
       });
 
       // Perform handoff
@@ -115,6 +118,7 @@ export async function connectHybrid(
       {
         env: options?.env,
         hooks: options?.hooks,
+        ports: options?.ports,
       },
     );
 
@@ -134,12 +138,14 @@ export async function connectHybrid(
     const sdk = await VercelSandboxSDK.create({
       source: { type: "snapshot", snapshotId: state.snapshotId },
       ...(options?.timeout !== undefined && { timeout: options.timeout }),
+      ...(options?.ports && { ports: options.ports }),
     });
 
     const cloudSandbox = await VercelSandbox.connect(sdk.sandboxId, {
       env: options?.env,
       hooks: options?.hooks,
       remainingTimeout: options?.timeout,
+      ports: options?.ports,
     });
 
     // Configure git user if provided (not done automatically when restoring from snapshot)
@@ -165,6 +171,7 @@ export async function connectHybrid(
       {
         env: options?.env,
         hooks: options?.hooks,
+        ports: options?.ports,
       },
     );
 

--- a/packages/sandbox/hybrid/sandbox.test.ts
+++ b/packages/sandbox/hybrid/sandbox.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import type { Dirent } from "fs";
+import type { ExecResult, Sandbox, SandboxStats } from "../interface";
+import { HybridSandbox } from "./sandbox";
+
+function createStubSandbox(): Sandbox {
+  return {
+    type: "in-memory",
+    workingDirectory: "/workspace",
+    readFile: async () => "",
+    writeFile: async () => {},
+    stat: async () =>
+      ({
+        isDirectory: () => false,
+        isFile: () => true,
+        size: 0,
+        mtimeMs: Date.now(),
+      }) satisfies SandboxStats,
+    access: async () => {},
+    mkdir: async () => {},
+    readdir: async () => [] as Dirent[],
+    exec: async () =>
+      ({
+        success: true,
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        truncated: false,
+      }) satisfies ExecResult,
+    stop: async () => {},
+  };
+}
+
+describe("HybridSandbox.execDetached", () => {
+  test("throws before cloud handoff", async () => {
+    const sandbox = new HybridSandbox({ justBash: createStubSandbox() });
+
+    await expect(
+      sandbox.execDetached("npm run dev", sandbox.workingDirectory),
+    ).rejects.toThrow(
+      "Detached commands are only available after cloud sandbox is ready",
+    );
+  });
+});

--- a/packages/sandbox/hybrid/sandbox.ts
+++ b/packages/sandbox/hybrid/sandbox.ts
@@ -276,6 +276,35 @@ export class HybridSandbox implements Sandbox {
   }
 
   /**
+   * Execute a command in detached mode.
+   * Delegates to the Vercel sandbox after handoff; unavailable before.
+   */
+  async execDetached(
+    command: string,
+    cwd: string,
+  ): Promise<{ commandId: string }> {
+    if (this.state === "vercel" && this.vercel?.execDetached) {
+      return this.vercel.execDetached(command, cwd);
+    }
+    throw new Error(
+      "Detached commands are only available after cloud sandbox is ready",
+    );
+  }
+
+  /**
+   * Get the public URL for an exposed port.
+   * Delegates to the Vercel sandbox after handoff; unavailable before.
+   */
+  domain(port: number): string {
+    if (this.state === "vercel" && this.vercel?.domain) {
+      return this.vercel.domain(port);
+    }
+    throw new Error(
+      "Preview URLs are only available after cloud sandbox is ready",
+    );
+  }
+
+  /**
    * Stop the current sandbox.
    */
   async stop(): Promise<void> {

--- a/packages/sandbox/interface.ts
+++ b/packages/sandbox/interface.ts
@@ -212,6 +212,26 @@ export interface Sandbox {
   exec(command: string, cwd: string, timeoutMs: number): Promise<ExecResult>;
 
   /**
+   * Execute a shell command in detached mode (returns immediately).
+   * The command continues running in the background.
+   * Only supported by cloud sandboxes (Vercel).
+   *
+   * @param command - The command to execute
+   * @param cwd - Working directory for the command
+   * @returns The command ID that can be used to check status or kill the process
+   */
+  execDetached?(command: string, cwd: string): Promise<{ commandId: string }>;
+
+  /**
+   * Get the public URL for an exposed port.
+   * Only available on cloud sandboxes with ports declared at creation time.
+   * Returns the full URL (e.g., "https://abc123-3000.vercel.run").
+   *
+   * @param port - The port number (must have been declared in `ports` at creation)
+   */
+  domain?(port: number): string;
+
+  /**
    * Stop and clean up the sandbox.
    * For local sandboxes, this is a no-op.
    * For remote sandboxes, this releases resources.

--- a/packages/sandbox/vercel/connect.ts
+++ b/packages/sandbox/vercel/connect.ts
@@ -9,6 +9,7 @@ interface ConnectOptions {
   gitUser?: { name: string; email: string };
   hooks?: SandboxHooks;
   timeout?: number;
+  ports?: number[];
 }
 
 /**
@@ -40,6 +41,7 @@ export async function connectVercel(
       env: options?.env,
       hooks: options?.hooks,
       remainingTimeout,
+      ports: options?.ports,
     });
   }
 
@@ -48,6 +50,7 @@ export async function connectVercel(
     const sdk = await VercelSandboxSDK.create({
       source: { type: "snapshot", snapshotId: state.snapshotId },
       ...(options?.timeout !== undefined && { timeout: options.timeout }),
+      ...(options?.ports && { ports: options.ports }),
     });
 
     // Wrap in VercelSandbox - use connect since SDK is already created
@@ -56,6 +59,7 @@ export async function connectVercel(
       env: options?.env,
       hooks: options?.hooks,
       remainingTimeout: options?.timeout,
+      ports: options?.ports,
     });
 
     // Configure git user if provided (not done automatically when restoring from snapshot)
@@ -78,6 +82,7 @@ export async function connectVercel(
       gitUser: options?.gitUser,
       hooks: options?.hooks,
       ...(options?.timeout !== undefined && { timeout: options.timeout }),
+      ...(options?.ports && { ports: options.ports }),
     });
   }
 
@@ -87,5 +92,6 @@ export async function connectVercel(
     gitUser: options?.gitUser,
     hooks: options?.hooks,
     ...(options?.timeout !== undefined && { timeout: options.timeout }),
+    ...(options?.ports && { ports: options.ports }),
   });
 }

--- a/packages/sandbox/vercel/sandbox.test.ts
+++ b/packages/sandbox/vercel/sandbox.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const portDomains = new Map<number, string>();
+const missingPorts = new Set<number>();
+
+function domainForPort(port: number): string {
+  if (missingPorts.has(port)) {
+    throw new Error(`No route found for port ${port}`);
+  }
+
+  const domain = portDomains.get(port);
+  if (!domain) {
+    throw new Error(`No route found for port ${port}`);
+  }
+
+  return domain;
+}
+
+mock.module("@vercel/sandbox", () => ({
+  Sandbox: {
+    get: async ({ sandboxId }: { sandboxId: string }) => ({
+      sandboxId,
+      domain: (port: number) => domainForPort(port),
+      runCommand: async () => ({
+        exitCode: 0,
+        cmdId: "cmd-1",
+        stdout: async () => "",
+      }),
+      stop: async () => {},
+    }),
+  },
+}));
+
+let sandboxModule: typeof import("./sandbox");
+
+beforeAll(async () => {
+  sandboxModule = await import("./sandbox");
+});
+
+beforeEach(() => {
+  portDomains.clear();
+  missingPorts.clear();
+  portDomains.set(80, "https://sbx-80.vercel.run");
+});
+
+describe("VercelSandbox.environmentDetails", () => {
+  test("skips preview URLs for ports that are missing routes", async () => {
+    portDomains.set(3000, "https://sbx-3000.vercel.run");
+    missingPorts.add(5173);
+
+    const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+      ports: [3000, 5173],
+      remainingTimeout: 0,
+    });
+
+    const details = sandbox.environmentDetails;
+
+    expect(details).toContain("Dev server preview URLs");
+    expect(details).toContain("Port 3000: https://sbx-3000.vercel.run");
+    expect(details).not.toContain("Port 5173:");
+  });
+});

--- a/packages/sandbox/vercel/sandbox.test.ts
+++ b/packages/sandbox/vercel/sandbox.test.ts
@@ -2,6 +2,26 @@ import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const portDomains = new Map<number, string>();
 const missingPorts = new Set<number>();
+type MockWaitResult = {
+  exitCode: number;
+  stdout: () => Promise<string>;
+  stderr: () => Promise<string>;
+};
+type MockRunCommandResult = {
+  exitCode?: number;
+  cmdId: string;
+  stdout: () => Promise<string>;
+  stderr?: () => Promise<string>;
+  wait?: (params?: { signal?: AbortSignal }) => Promise<MockWaitResult>;
+};
+let runCommandMock = async (
+  _params?: { env?: Record<string, string> },
+): Promise<MockRunCommandResult> => ({
+  exitCode: 0,
+  cmdId: "cmd-1",
+  stdout: async () => "",
+});
+let lastRunCommandEnv: Record<string, string> | undefined;
 
 function domainForPort(port: number): string {
   if (missingPorts.has(port)) {
@@ -20,12 +40,16 @@ mock.module("@vercel/sandbox", () => ({
   Sandbox: {
     get: async ({ sandboxId }: { sandboxId: string }) => ({
       sandboxId,
-      domain: (port: number) => domainForPort(port),
-      runCommand: async () => ({
-        exitCode: 0,
-        cmdId: "cmd-1",
-        stdout: async () => "",
+      routes: Array.from(portDomains.keys()).map((port) => {
+        const domain = portDomains.get(port) ?? `https://sbx-${port}.vercel.run`;
+        const subdomain = new URL(domain).host.replace(".vercel.run", "");
+        return { port, subdomain };
       }),
+      domain: (port: number) => domainForPort(port),
+      runCommand: async (params: { env?: Record<string, string> }) => {
+        lastRunCommandEnv = params.env;
+        return runCommandMock(params);
+      },
       stop: async () => {},
     }),
   },
@@ -41,6 +65,12 @@ beforeEach(() => {
   portDomains.clear();
   missingPorts.clear();
   portDomains.set(80, "https://sbx-80.vercel.run");
+  runCommandMock = async () => ({
+    exitCode: 0,
+    cmdId: "cmd-1",
+    stdout: async () => "",
+  });
+  lastRunCommandEnv = undefined;
 });
 
 describe("VercelSandbox.environmentDetails", () => {
@@ -58,5 +88,138 @@ describe("VercelSandbox.environmentDetails", () => {
     expect(details).toContain("Dev server preview URLs");
     expect(details).toContain("Port 3000: https://sbx-3000.vercel.run");
     expect(details).not.toContain("Port 5173:");
+  });
+
+  test("uses first routable declared port for host when port 80 is unavailable", async () => {
+    missingPorts.add(80);
+    portDomains.set(3000, "https://sbx-3000.vercel.run");
+
+    const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+      ports: [3000, 5173],
+      remainingTimeout: 0,
+    });
+
+    expect(sandbox.host).toBe("sbx-3000.vercel.run");
+  });
+
+  test("does not render an undefined host in environment details", async () => {
+    missingPorts.add(80);
+    missingPorts.add(3000);
+
+    const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+      ports: [3000],
+      remainingTimeout: 0,
+    });
+
+    const details = sandbox.environmentDetails;
+
+    expect(details).not.toContain("Sandbox host: undefined");
+    expect(details).not.toContain("Sandbox host:");
+  });
+
+  test("resolves host from SDK routes when reconnect did not pass ports", async () => {
+    missingPorts.add(80);
+    portDomains.set(3000, "https://sbx-3000.vercel.run");
+
+    const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+      remainingTimeout: 0,
+    });
+
+    expect(sandbox.host).toBe("sbx-3000.vercel.run");
+    expect(sandbox.environmentDetails).toContain(
+      "Sandbox host: sbx-3000.vercel.run",
+    );
+  });
+
+  test("injects runtime preview env vars into command execution", async () => {
+    missingPorts.add(80);
+    portDomains.set(3000, "https://sbx-3000.vercel.run");
+
+    const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+      ports: [3000],
+      remainingTimeout: 0,
+    });
+
+    await sandbox.exec("echo test", "/vercel/sandbox", 5_000);
+
+    expect(lastRunCommandEnv?.SANDBOX_HOST).toBe("sbx-3000.vercel.run");
+    expect(lastRunCommandEnv?.SANDBOX_URL_3000).toBe(
+      "https://sbx-3000.vercel.run",
+    );
+  });
+});
+
+describe("VercelSandbox.execDetached", () => {
+  test("returns commandId when quick-failure timer elapses before command exits", async () => {
+    runCommandMock = async () => ({
+      cmdId: "cmd-detached-running",
+      stdout: async () => "",
+      wait: async () => await new Promise<MockWaitResult>(() => {}),
+    });
+
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((
+      handler: Parameters<typeof setTimeout>[0],
+      _timeout?: Parameters<typeof setTimeout>[1],
+      ...args: unknown[]
+    ) => {
+      if (typeof handler === "function") {
+        handler();
+      }
+      return originalSetTimeout(() => undefined, 0, ...args);
+    }) as typeof setTimeout;
+
+    try {
+      const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+        ports: [3000],
+        remainingTimeout: 0,
+      });
+
+      const result = await sandbox.execDetached("bun run dev", "/vercel/sandbox");
+
+      expect(result).toEqual({ commandId: "cmd-detached-running" });
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  test("throws when detached wait fails before timer elapses", async () => {
+    runCommandMock = async () => ({
+      cmdId: "cmd-detached-error",
+      stdout: async () => "",
+      wait: async () => {
+        throw new Error("wait failed");
+      },
+    });
+
+    const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+      ports: [3000],
+      remainingTimeout: 0,
+    });
+
+    expect(
+      sandbox.execDetached("bun run dev", "/vercel/sandbox"),
+    ).rejects.toThrow("wait failed");
+  });
+
+  test("throws with stderr when command exits quickly with non-zero code", async () => {
+    runCommandMock = async () => ({
+      cmdId: "cmd-detached-fail",
+      stdout: async () => "",
+      wait: async () => ({
+        exitCode: 1,
+        stdout: async () => "",
+        stderr: async () => "npm ERR! code ENOENT",
+      }),
+    });
+
+    const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+      ports: [3000],
+      remainingTimeout: 0,
+    });
+
+    expect(
+      sandbox.execDetached("npm run dev", "/vercel/sandbox"),
+    ).rejects.toThrow("npm ERR! code ENOENT");
   });
 });

--- a/packages/sandbox/vercel/sandbox.test.ts
+++ b/packages/sandbox/vercel/sandbox.test.ts
@@ -14,9 +14,9 @@ type MockRunCommandResult = {
   stderr?: () => Promise<string>;
   wait?: (params?: { signal?: AbortSignal }) => Promise<MockWaitResult>;
 };
-let runCommandMock = async (
-  _params?: { env?: Record<string, string> },
-): Promise<MockRunCommandResult> => ({
+let runCommandMock = async (_params?: {
+  env?: Record<string, string>;
+}): Promise<MockRunCommandResult> => ({
   exitCode: 0,
   cmdId: "cmd-1",
   stdout: async () => "",
@@ -41,7 +41,8 @@ mock.module("@vercel/sandbox", () => ({
     get: async ({ sandboxId }: { sandboxId: string }) => ({
       sandboxId,
       routes: Array.from(portDomains.keys()).map((port) => {
-        const domain = portDomains.get(port) ?? `https://sbx-${port}.vercel.run`;
+        const domain =
+          portDomains.get(port) ?? `https://sbx-${port}.vercel.run`;
         const subdomain = new URL(domain).host.replace(".vercel.run", "");
         return { port, subdomain };
       }),
@@ -175,7 +176,10 @@ describe("VercelSandbox.execDetached", () => {
         remainingTimeout: 0,
       });
 
-      const result = await sandbox.execDetached("bun run dev", "/vercel/sandbox");
+      const result = await sandbox.execDetached(
+        "bun run dev",
+        "/vercel/sandbox",
+      );
 
       expect(result).toEqual({ commandId: "cmd-detached-running" });
     } finally {

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -17,6 +17,11 @@ const TIMEOUT_BUFFER_MS = 30_000; // 30 seconds buffer for beforeStop hook
 const MAX_SDK_TIMEOUT_MS = 18_000_000; // Vercel API limit: 5 hours
 const MAX_PROACTIVE_TIMEOUT_MS = MAX_SDK_TIMEOUT_MS - TIMEOUT_BUFFER_MS;
 const DEFAULT_RECONNECT_TIMEOUT_MS = 300_000; // 5 minutes default timeout for reconnected sandboxes
+const DETACHED_QUICK_FAILURE_WINDOW_MS = 2_000;
+
+interface SandboxRouteLike {
+  port: number;
+}
 
 /**
  * Vercel Sandbox implementation using the @vercel/sandbox SDK.
@@ -190,17 +195,35 @@ export class VercelSandbox implements Sandbox {
    * which returns the correct subdomain-based URL for that port.
    */
   get host(): string | undefined {
-    try {
-      const domainUrl = this.sdk.domain(80);
-      return new URL(domainUrl).host;
-    } catch {
-      return undefined;
+    const candidatePorts = this.getCandidatePorts();
+
+    for (const port of candidatePorts) {
+      try {
+        const domainUrl = this.sdk.domain(port);
+        return new URL(domainUrl).host;
+      } catch {
+        // Try next declared port; some restored sandboxes may not expose all ports.
+      }
     }
+
+    // Fallback for cases where no ports were declared but default HTTP route exists.
+    if (!candidatePorts.includes(80)) {
+      try {
+        const domainUrl = this.sdk.domain(80);
+        return new URL(domainUrl).host;
+      } catch {
+        return undefined;
+      }
+    }
+
+    return undefined;
   }
 
   get environmentDetails(): string {
+    const host = this.host;
+    const previewPorts = this.getPreviewPorts();
     const portPreviewLines =
-      this._ports
+      previewPorts
         ?.map((port) => {
           try {
             const url = this.domain(port);
@@ -215,6 +238,12 @@ export class VercelSandbox implements Sandbox {
       ? `\n- Dev server preview URLs (start a server on one of these ports, then share the URL with the user):\n${portPreviewLines.join("\n")}`
       : "";
 
+    const hostLine = host ? `\n- Sandbox host: ${host}` : "";
+    const runtimeEnvLine =
+      host || previewPorts.length > 0
+        ? "\n- Runtime env vars for previews are injected into commands: SANDBOX_HOST and SANDBOX_URL_<PORT> (for routable ports)"
+        : "";
+
     return `- Ephemeral sandbox - all work is lost unless committed and pushed to git
 - Default workflow: create a new branch, commit changes, push, and open a PR (since the sandbox is ephemeral, this ensures work is preserved)
 - Git is already configured (user, email, remote auth) - no setup or verification needed
@@ -223,7 +252,57 @@ export class VercelSandbox implements Sandbox {
   curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/OWNER/REPO/pulls -d '{"title":"...","head":"branch","base":"main","body":"..."}'
 - Node.js runtime with npm/pnpm available
 - Installing Bun: run \`curl -fsSL https://bun.com/install | bash\`, then \`echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc\`, then verify with \`bun --version\`
-- Sandbox host: ${this.host}${portLines}`;
+- This sandbox already runs on Vercel; do not suggest deploying to Vercel just to obtain a shareable preview link
+${hostLine}${portLines}${runtimeEnvLine}`;
+  }
+
+  private getRoutePorts(): number[] {
+    const routes = (this.sdk as { routes?: SandboxRouteLike[] }).routes;
+    if (!Array.isArray(routes)) {
+      return [];
+    }
+
+    return routes
+      .map((route) => route.port)
+      .filter((port) => Number.isInteger(port) && port > 0);
+  }
+
+  private getPreviewPorts(): number[] {
+    return Array.from(new Set([...(this._ports ?? []), ...this.getRoutePorts()]));
+  }
+
+  private getCandidatePorts(): number[] {
+    return Array.from(new Set([...this.getPreviewPorts(), 80]));
+  }
+
+  private getRuntimePreviewEnv(): Record<string, string> {
+    const runtimeEnv: Record<string, string> = {};
+    const host = this.host;
+    if (host) {
+      runtimeEnv.SANDBOX_HOST = host;
+    }
+
+    for (const port of this.getPreviewPorts()) {
+      try {
+        runtimeEnv[`SANDBOX_URL_${port}`] = this.domain(port);
+      } catch {
+        // Skip unroutable ports
+      }
+    }
+
+    return runtimeEnv;
+  }
+
+  private getCommandEnv(): Record<string, string> | undefined {
+    const runtimePreviewEnv = this.getRuntimePreviewEnv();
+    if (!this.env && Object.keys(runtimePreviewEnv).length === 0) {
+      return undefined;
+    }
+
+    return {
+      ...(this.env ?? {}),
+      ...runtimePreviewEnv,
+    };
   }
 
   /**
@@ -576,7 +655,7 @@ export class VercelSandbox implements Sandbox {
       const result = await this.sdk.runCommand({
         cmd: "bash",
         args: ["-c", `cd "${cwd}" && ${command}`],
-        env: this.env,
+        env: this.getCommandEnv(),
         signal: AbortSignal.timeout(timeoutMs),
       });
 
@@ -627,9 +706,48 @@ export class VercelSandbox implements Sandbox {
     const result = await this.sdk.runCommand({
       cmd: "bash",
       args: ["-c", `cd "${cwd}" && ${command}`],
-      env: this.env,
+      env: this.getCommandEnv(),
       detached: true,
     });
+
+    const abortController = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutResult = new Promise<{ kind: "timeout" }>((resolve) => {
+      timeoutId = setTimeout(() => {
+        abortController.abort();
+        resolve({ kind: "timeout" });
+      }, DETACHED_QUICK_FAILURE_WINDOW_MS);
+    });
+
+    const waitResult = result
+      .wait({ signal: abortController.signal })
+      .then((finished) => ({ kind: "finished", finished }) as const)
+      .catch((error: unknown) => ({ kind: "error", error }) as const);
+
+    const quickProbe = await Promise.race([waitResult, timeoutResult]);
+
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    if (quickProbe.kind === "timeout") {
+      return { commandId: result.cmdId };
+    }
+
+    if (quickProbe.kind === "error") {
+      throw quickProbe.error;
+    }
+
+    if (quickProbe.finished.exitCode !== 0) {
+      const stderr = await quickProbe.finished.stderr();
+      const trimmedStderr = stderr.trim();
+      const stderrSnippet = trimmedStderr
+        ? trimmedStderr.slice(0, MAX_OUTPUT_LENGTH)
+        : "<no stderr>";
+      throw new Error(
+        `Background command exited with code ${quickProbe.finished.exitCode}. stderr:\n${stderrSnippet}`,
+      );
+    }
 
     return { commandId: result.cmdId };
   }

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -43,6 +43,7 @@ export class VercelSandbox implements Sandbox {
   private isStopped = false;
   private _expiresAt?: number;
   private _timeout?: number;
+  private _ports?: number[];
 
   /**
    * Timestamp (ms since epoch) when this sandbox will be proactively stopped.
@@ -70,6 +71,7 @@ export class VercelSandbox implements Sandbox {
     hooks?: SandboxHooks,
     timeout?: number,
     startTime?: number,
+    ports?: number[],
   ) {
     this.sdk = sdk;
     this.id = id;
@@ -77,6 +79,7 @@ export class VercelSandbox implements Sandbox {
     this.env = env;
     this.currentBranch = currentBranch;
     this.hooks = hooks;
+    this._ports = ports;
 
     // Set timeout tracking for proactive stop
     if (timeout !== undefined && startTime !== undefined) {
@@ -196,6 +199,10 @@ export class VercelSandbox implements Sandbox {
   }
 
   get environmentDetails(): string {
+    const portLines = this._ports?.length
+      ? `\n- Dev server preview URLs (start a server on one of these ports, then share the URL with the user):\n${this._ports.map((p) => `  - Port ${p}: ${this.domain(p)}`).join("\n")}`
+      : "";
+
     return `- Ephemeral sandbox - all work is lost unless committed and pushed to git
 - Default workflow: create a new branch, commit changes, push, and open a PR (since the sandbox is ephemeral, this ensures work is preserved)
 - Git is already configured (user, email, remote auth) - no setup or verification needed
@@ -204,7 +211,7 @@ export class VercelSandbox implements Sandbox {
   curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/OWNER/REPO/pulls -d '{"title":"...","head":"branch","base":"main","body":"..."}'
 - Node.js runtime with npm/pnpm available
 - Installing Bun: run \`curl -fsSL https://bun.com/install | bash\`, then \`echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc\`, then verify with \`bun --version\`
-- Sandbox host: ${this.host} (use domain(port) method to get URLs for exposed ports)`;
+- Sandbox host: ${this.host}${portLines}`;
   }
 
   /**
@@ -350,6 +357,7 @@ export class VercelSandbox implements Sandbox {
       hooks,
       effectiveTimeout,
       startTime,
+      ports,
     );
 
     // Call afterStart hook if provided
@@ -374,6 +382,8 @@ export class VercelSandbox implements Sandbox {
        * This ensures timeout tracking and proactive stop work correctly.
        */
       remainingTimeout?: number;
+      /** Ports that were declared at creation time (for preview URL display) */
+      ports?: number[];
     } = {},
   ): Promise<VercelSandbox> {
     const sdk = await VercelSandboxSDK.get({ sandboxId });
@@ -394,6 +404,7 @@ export class VercelSandbox implements Sandbox {
       options.hooks,
       remainingTimeout,
       startTime,
+      options.ports,
     );
 
     // Call afterStart hook if provided (useful for reconnection setup)
@@ -591,6 +602,24 @@ export class VercelSandbox implements Sandbox {
         truncated: false,
       };
     }
+  }
+
+  /**
+   * Execute a command in detached mode (returns immediately).
+   * The command continues running in the background.
+   */
+  async execDetached(
+    command: string,
+    cwd: string,
+  ): Promise<{ commandId: string }> {
+    const result = await this.sdk.runCommand({
+      cmd: "bash",
+      args: ["-c", `cd "${cwd}" && ${command}`],
+      env: this.env,
+      detached: true,
+    });
+
+    return { commandId: result.cmdId };
   }
 
   /**

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -199,8 +199,20 @@ export class VercelSandbox implements Sandbox {
   }
 
   get environmentDetails(): string {
-    const portLines = this._ports?.length
-      ? `\n- Dev server preview URLs (start a server on one of these ports, then share the URL with the user):\n${this._ports.map((p) => `  - Port ${p}: ${this.domain(p)}`).join("\n")}`
+    const portPreviewLines =
+      this._ports
+        ?.map((port) => {
+          try {
+            const url = this.domain(port);
+            return `  - Port ${port}: ${url}`;
+          } catch {
+            return undefined;
+          }
+        })
+        .filter((line): line is string => line !== undefined) ?? [];
+
+    const portLines = portPreviewLines.length
+      ? `\n- Dev server preview URLs (start a server on one of these ports, then share the URL with the user):\n${portPreviewLines.join("\n")}`
       : "";
 
     return `- Ephemeral sandbox - all work is lost unless committed and pushed to git

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -268,7 +268,9 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
   }
 
   private getPreviewPorts(): number[] {
-    return Array.from(new Set([...(this._ports ?? []), ...this.getRoutePorts()]));
+    return Array.from(
+      new Set([...(this._ports ?? []), ...this.getRoutePorts()]),
+    );
   }
 
   private getCandidatePorts(): number[] {
@@ -300,7 +302,7 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
     }
 
     return {
-      ...(this.env ?? {}),
+      ...this.env,
       ...runtimePreviewEnv,
     };
   }


### PR DESCRIPTION
Chat: https://openharness.dev/shared/nGSrfTXmry-d

## Summary
Adds support for configurable sandbox ports to enable development server previews and improve sandbox flexibility across hybrid and Vercel environments.

## Key Changes
- **Sandbox Configuration**: Added port configuration support in `config.ts` for customizable sandbox ports
- **Bash Tool Enhancement**: Extended bash tool with 49 new lines of functionality to support port-based operations
- **Hybrid Sandbox**: Implemented connect and sandbox modules with port configuration support
- **Vercel Sandbox**: Enhanced Vercel sandbox implementation with port handling capabilities
- **API Routes**: Updated chat and sandbox API endpoints to utilize new port configuration
- **Interface Updates**: Added port-related type definitions to sandbox interface
- **Factory Pattern**: Extended sandbox factory to handle new port configuration options

## Notes for Reviewers
- Changes enable dev server previews through configurable sandbox ports
- Both hybrid and Vercel sandbox implementations now support port customization
- Bash tool significantly expanded to handle port-based operations (49 line addition)
- API layer updated to integrate new configuration system