### PR TITLE
Fix Streamdown rendering and assistant text width

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -1829,7 +1829,7 @@ export function SessionChatContent() {
                               </p>
                             </div>
                           ) : (
-                            <div className="min-w-0 max-w-[80%] overflow-hidden">
+                            <div className="min-w-0 w-full overflow-hidden">
                               <Streamdown
                                 animated={{
                                   animation: "fadeIn",

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -39,9 +39,9 @@ import type {
 } from "@/app/types";
 import { FileSuggestionsDropdown } from "@/components/file-suggestions-dropdown";
 import { ImageAttachmentsPreview } from "@/components/image-attachments-preview";
-import { SlashCommandDropdown } from "@/components/slash-command-dropdown";
 import { ModelSelectorCompact } from "@/components/model-selector-compact";
 import { QuestionPanel } from "@/components/question-panel";
+import { SlashCommandDropdown } from "@/components/slash-command-dropdown";
 import { TaskGroupView } from "@/components/task-group-view";
 import { ToolCall } from "@/components/tool-call";
 import { Button } from "@/components/ui/button";
@@ -55,6 +55,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
@@ -63,22 +64,17 @@ import {
 import { useAudioRecording } from "@/hooks/use-audio-recording";
 import { useFileSuggestions } from "@/hooks/use-file-suggestions";
 import { useImageAttachments } from "@/hooks/use-image-attachments";
-import { useSlashCommands } from "@/hooks/use-slash-commands";
 import { useScrollToBottom } from "@/hooks/use-scroll-to-bottom";
 import { useSessionChats } from "@/hooks/use-session-chats";
+import { useSlashCommands } from "@/hooks/use-slash-commands";
 import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
 import { DEFAULT_SANDBOX_TIMEOUT_MS } from "@/lib/sandbox/config";
+import { streamdownPlugins } from "@/lib/streamdown-config";
 import { cn } from "@/lib/utils";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import {
   type SandboxInfo,
   useSessionChatContext,
 } from "./session-chat-context";
-import {
-  customComponents,
-  shikiThemes,
-  streamdownPlugins,
-} from "@/lib/streamdown-config";
 import "streamdown/styles.css";
 
 const DiffViewer = dynamic(
@@ -1845,8 +1841,6 @@ export function SessionChatContent() {
                                 }
                                 isAnimating={isMessageStreaming}
                                 plugins={streamdownPlugins}
-                                shikiTheme={shikiThemes}
-                                components={customComponents}
                               >
                                 {p.text}
                               </Streamdown>

--- a/apps/web/app/shared/[shareId]/shared-chat-content.tsx
+++ b/apps/web/app/shared/[shareId]/shared-chat-content.tsx
@@ -176,7 +176,7 @@ export function SharedChatContent({
                                 </p>
                               </div>
                             ) : (
-                              <div className="min-w-0 max-w-[80%] overflow-hidden">
+                              <div className="min-w-0 w-full overflow-hidden">
                                 <Streamdown
                                   mode="static"
                                   isAnimating={false}

--- a/apps/web/app/shared/[shareId]/shared-chat-content.tsx
+++ b/apps/web/app/shared/[shareId]/shared-chat-content.tsx
@@ -12,11 +12,7 @@ import type {
 import { TaskGroupView } from "@/components/task-group-view";
 import { ToolCall } from "@/components/tool-call";
 import type { Chat } from "@/lib/db/schema";
-import {
-  customComponents,
-  shikiThemes,
-  streamdownPlugins,
-} from "@/lib/streamdown-config";
+import { streamdownPlugins } from "@/lib/streamdown-config";
 import { cn } from "@/lib/utils";
 import "streamdown/styles.css";
 
@@ -185,8 +181,6 @@ export function SharedChatContent({
                                   mode="static"
                                   isAnimating={false}
                                   plugins={streamdownPlugins}
-                                  shikiTheme={shikiThemes}
-                                  components={customComponents}
                                 >
                                   {p.text}
                                 </Streamdown>

--- a/apps/web/lib/streamdown-config.tsx
+++ b/apps/web/lib/streamdown-config.tsx
@@ -1,37 +1,8 @@
-import type { ComponentProps, ReactNode } from "react";
-import { Children, cloneElement, isValidElement } from "react";
-import type { BundledTheme } from "shiki";
 import { createCodePlugin } from "@streamdown/code";
-import { vercelLight, vercelDark } from "./vercel-themes";
+import { vercelDark, vercelLight } from "./vercel-themes";
 
 export const streamdownPlugins = {
   code: createCodePlugin({
     themes: [vercelLight, vercelDark],
   }),
-};
-
-export const shikiThemes = ["vercel-light", "vercel-dark"] as [
-  BundledTheme,
-  BundledTheme,
-];
-
-export const customComponents = {
-  pre: ({ children, ...props }: ComponentProps<"pre">) => {
-    const processChildren = (child: ReactNode): ReactNode => {
-      if (
-        isValidElement<{ children?: ReactNode; "data-block"?: string }>(child)
-      ) {
-        const codeContent = child.props.children;
-        if (typeof codeContent === "string") {
-          return cloneElement(child, {
-            "data-block": "true",
-            children: codeContent.trimEnd(),
-          });
-        }
-        return cloneElement(child, { "data-block": "true" });
-      }
-      return child;
-    };
-    return <pre {...props}>{Children.map(children, processChildren)}</pre>;
-  },
 };

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -83,6 +83,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 - `hadInitialMessages` is an initial-load snapshot, not a live "first turn" signal; guard one-time optimistic UI (like first-message title previews) with a dedicated runtime ref/state that resets on send failure.
 - When session overlay maps are deleted after becoming empty, any later overlay writes in the same hook instance must re-register the map in the global registry, or optimistic overlays will not survive route transitions.
 - For resumed chat streams, `chat.stop()` alone is insufficient because reconnect fetches are not wired to the active abort signal; always pair stop with aborting the managed transport tied to that chat instance.
+- In Streamdown, `plugins.code.getThemes()` overrides the `shikiTheme` prop; configure code themes in `createCodePlugin(...)` and pass actual custom theme objects for non-bundled themes (for example `vercelLight`/`vercelDark`) or highlighting can fall back to unstyled/plain tokens.
 
 ## GitHub App / PR Flows
 


### PR DESCRIPTION
## Summary
- Restore Streamdown syntax highlighting configuration by relying on code plugin themes and removing conflicting `shikiTheme` and custom component props.
- Make assistant text content use the full chat column width in both session and shared chat views.
- Keep user bubble and image attachment width constraints unchanged.
