### PR TITLE
feat: bootstrap sandboxes from base snapshot, guard snapshot races, and fix git error messages

### DIFF
--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -10,8 +10,9 @@ import { getRepoToken } from "@/lib/github/get-repo-token";
 import { downloadAndExtractTarball } from "@/lib/github/tarball";
 import { getUserGitHubToken } from "@/lib/github/user-token";
 import {
-  DEFAULT_SANDBOX_TIMEOUT_MS,
+  DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
   DEFAULT_SANDBOX_PORTS,
+  DEFAULT_SANDBOX_TIMEOUT_MS,
 } from "@/lib/sandbox/config";
 import {
   buildActiveLifecycleUpdate,
@@ -210,6 +211,7 @@ export async function POST(req: Request) {
         gitUser,
         timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
         ports: DEFAULT_SANDBOX_PORTS,
+        baseSnapshotId: DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
       },
     });
   } else {
@@ -226,6 +228,7 @@ export async function POST(req: Request) {
         gitUser,
         timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
         ports: DEFAULT_SANDBOX_PORTS,
+        baseSnapshotId: DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
         scheduleBackgroundWork: (cb) => after(cb),
         hooks: sessionId
           ? {

--- a/apps/web/app/api/sandbox/snapshot/route.ts
+++ b/apps/web/app/api/sandbox/snapshot/route.ts
@@ -10,7 +10,11 @@ import {
   getNextLifecycleVersion,
 } from "@/lib/sandbox/lifecycle";
 import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
-import { canOperateOnSandbox, clearSandboxState } from "@/lib/sandbox/utils";
+import {
+  canOperateOnSandbox,
+  clearSandboxState,
+  hasRuntimeSandboxState,
+} from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 interface CreateSnapshotRequest {
@@ -125,6 +129,19 @@ export async function PUT(req: Request) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
   if (!sessionRecord.snapshotUrl) {
+    if (hasRuntimeSandboxState(sessionRecord.sandboxState)) {
+      console.warn(
+        `[Snapshot Restore] session=${sessionId} pending=true sandboxType=${sessionRecord.sandboxState?.type ?? "null"}`,
+      );
+      return Response.json(
+        {
+          error:
+            "Snapshot is still being created. Please wait a few seconds and try again.",
+        },
+        { status: 409 },
+      );
+    }
+
     console.error(
       `[Snapshot Restore] session=${sessionId} error=no_snapshot sandboxType=${sessionRecord.sandboxState?.type ?? "null"}`,
     );

--- a/apps/web/app/api/sandbox/snapshot/route.ts
+++ b/apps/web/app/api/sandbox/snapshot/route.ts
@@ -128,6 +128,10 @@ export async function PUT(req: Request) {
   if (sessionRecord.userId !== session.user.id) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
+  // TODO: If the background after() callback in the archive flow crashes before
+  // reaching updateSession (e.g. connectSandbox or sandbox.snapshot() throws),
+  // sandboxState retains runtime data and snapshotUrl stays null. This leaves
+  // the session permanently returning 409 with no self-service recovery path.
   if (!sessionRecord.snapshotUrl) {
     if (hasRuntimeSandboxState(sessionRecord.sandboxState)) {
       console.warn(

--- a/apps/web/app/api/sessions/[sessionId]/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/route.ts
@@ -5,7 +5,11 @@ import {
   getSessionById,
   updateSession,
 } from "@/lib/db/sessions";
-import { canOperateOnSandbox, clearSandboxState } from "@/lib/sandbox/utils";
+import {
+  canOperateOnSandbox,
+  clearSandboxState,
+  hasRuntimeSandboxState,
+} from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 interface UpdateSessionRequest {
@@ -72,6 +76,20 @@ export async function PATCH(
 
   const shouldUnarchive =
     body.status === "running" && existingSession.status === "archived";
+
+  if (
+    shouldUnarchive &&
+    !existingSession.snapshotUrl &&
+    hasRuntimeSandboxState(existingSession.sandboxState)
+  ) {
+    return Response.json(
+      {
+        error:
+          "Snapshot is still being created for this archived session. Please try unarchiving again in a few seconds.",
+      },
+      { status: 409 },
+    );
+  }
 
   const updatePayload: UpdateSessionRequest &
     Partial<{

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -349,6 +349,7 @@ function SandboxInputOverlay({
   isHibernating,
   isArchived,
   isInitializing,
+  snapshotPending,
   hasSnapshot,
   onRestore,
   onCreateNew,
@@ -360,6 +361,7 @@ function SandboxInputOverlay({
   isHibernating: boolean;
   isArchived: boolean;
   isInitializing: boolean;
+  snapshotPending: boolean;
   hasSnapshot: boolean;
   onRestore: () => void;
   onCreateNew: () => void;
@@ -370,7 +372,9 @@ function SandboxInputOverlay({
         <div className="flex items-center gap-3 rounded-full bg-background/90 px-4 py-2 text-muted-foreground shadow-sm">
           <Archive className="h-4 w-4" />
           <span className="text-sm">
-            This session is archived. Unarchive it to resume.
+            {snapshotPending
+              ? "Snapshot in progress. Unarchive will be available in a few seconds."
+              : "This session is archived. Unarchive it to resume."}
           </span>
         </div>
       </div>
@@ -394,10 +398,11 @@ function SandboxInputOverlay({
   return (
     <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/60 backdrop-blur-[2px]">
       <div className="flex items-center gap-2">
-        <Button onClick={onRestore} size="sm" className="shadow-sm">
-          Resume sandbox
-        </Button>
-        {!hasSnapshot && (
+        {hasSnapshot ? (
+          <Button onClick={onRestore} size="sm" className="shadow-sm">
+            Resume sandbox
+          </Button>
+        ) : (
           <Button
             onClick={onCreateNew}
             size="sm"
@@ -1488,6 +1493,8 @@ export function SessionChatContent() {
     !isRestoringSnapshot;
   const isHibernatingTransition =
     isReconnectingSandbox && hasSnapshot && !hasRuntimeSandboxState;
+  const isArchiveSnapshotPending =
+    isArchived && !hasSnapshot && hasRuntimeSandboxState;
   const isServerHibernating = lifecycleTiming.state === "hibernating";
   const isServerRestoring = lifecycleTiming.state === "restoring";
   const isServerHibernated = lifecycleTiming.state === "hibernated";
@@ -1625,7 +1632,7 @@ export function SessionChatContent() {
               <Button
                 variant="ghost"
                 size="sm"
-                disabled={isUnarchiving}
+                disabled={isUnarchiving || isArchiveSnapshotPending}
                 onClick={() => {
                   setIsUnarchiving(true);
                   void unarchiveSession()
@@ -1643,7 +1650,11 @@ export function SessionChatContent() {
                   <ArchiveRestore className="h-4 w-4 md:mr-2" />
                 )}
                 <span className="hidden md:inline">
-                  {isUnarchiving ? "Unarchiving..." : "Unarchive"}
+                  {isUnarchiving
+                    ? "Unarchiving..."
+                    : isArchiveSnapshotPending
+                      ? "Snapshotting..."
+                      : "Unarchive"}
                 </span>
               </Button>
             ) : (
@@ -2078,6 +2089,7 @@ export function SessionChatContent() {
                 isHibernating={isHibernatingUi}
                 isArchived={isArchived}
                 isInitializing={reconnectionStatus === "idle"}
+                snapshotPending={isArchiveSnapshotPending}
                 hasSnapshot={hasSnapshot}
                 onRestore={handleRestoreSnapshot}
                 onCreateNew={handleCreateNewSandbox}

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -32,3 +32,11 @@ export const DEFAULT_SANDBOX_PORTS = [3000, 5173, 4321];
 
 /** Default working directory for sandboxes, used for path display */
 export const DEFAULT_WORKING_DIRECTORY = "/vercel/sandbox";
+
+/**
+ * Base snapshot for fresh cloud sandboxes.
+ * Includes commonly-needed tooling such as bun and jq.
+ */
+export const DEFAULT_SANDBOX_BASE_SNAPSHOT_ID =
+  process.env.VERCEL_SANDBOX_BASE_SNAPSHOT_ID ??
+  "snap_MQ0NqdLL5qEXiYusgWL3K0yaMmql";

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -67,6 +67,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 - Reconnect success should refresh full active lifecycle timestamps (`lastActivityAt`, `hibernateAfter`, `sandboxExpiresAt`) before responding; otherwise UI status chips can stay stuck in `Pausing` from stale lifecycle fields.
 - Lifecycle countdown UI windows should scale with configured inactivity timeout; fixed windows (for example 2 minutes) can make short test timeouts (for example 1 minute) appear to be perpetually pausing.
 - Reconnect can return a sandbox handle whose command stream is unusable (`Expected a stream of command data`); reconnect should probe command execution before declaring `connected`, and file/diff routes should treat that error as sandbox-unavailable (hibernated) rather than a git-repo error.
+- Archive uses a deferred background snapshot; if unarchive runs before `snapshotUrl` is persisted, resume/restore can race with `no_snapshot`, so unarchive/restore flows must gate on snapshot readiness (or surface a clear snapshot-in-progress state).
 - Client UI `sandboxUiStatus` must check server `lifecycleTiming.state` (from status poll) as primary source, not only local `sandboxInfo`; otherwise UI stays "Active" after server-side hibernation until the local timeout expires or user refreshes.
 - The `isSandboxActive` client flag must incorporate `lifecycleTiming.state`; local `isSandboxValid(sandboxInfo)` alone is insufficient because the server can hibernate the sandbox while the local timeout is still valid.
 

--- a/packages/sandbox/factory.ts
+++ b/packages/sandbox/factory.ts
@@ -1,11 +1,11 @@
-import type { Sandbox, SandboxHooks } from "./interface";
-import type { JustBashState } from "./just-bash/state";
-import type { VercelState } from "./vercel/state";
-import type { HybridState } from "./hybrid/state";
-import type { HybridHooks } from "./hybrid/hooks";
-import { connectJustBash } from "./just-bash/connect";
-import { connectVercel } from "./vercel/connect";
 import { connectHybrid } from "./hybrid/connect";
+import type { HybridHooks } from "./hybrid/hooks";
+import type { HybridState } from "./hybrid/state";
+import type { Sandbox, SandboxHooks } from "./interface";
+import { connectJustBash } from "./just-bash/connect";
+import type { JustBashState } from "./just-bash/state";
+import { connectVercel } from "./vercel/connect";
+import type { VercelState } from "./vercel/state";
 
 // Re-export SandboxStatus from types for convenience
 export type { SandboxStatus } from "./types";
@@ -33,6 +33,8 @@ export interface ConnectOptions {
   timeout?: number;
   /** Ports to expose from the sandbox for dev server preview URLs */
   ports?: number[];
+  /** Snapshot ID used as the base image for new cloud sandboxes */
+  baseSnapshotId?: string;
 }
 
 /**
@@ -47,6 +49,8 @@ export interface HybridConnectOptions extends Omit<ConnectOptions, "hooks"> {
   hooks?: HybridHooks;
   /** Ports to expose from the sandbox for dev server preview URLs */
   ports?: number[];
+  /** Snapshot ID used as the base image for new cloud sandboxes */
+  baseSnapshotId?: string;
   /**
    * Schedule background work for cloud sandbox startup.
    * Wire to your runtime's background task mechanism.

--- a/packages/sandbox/hybrid/connect.ts
+++ b/packages/sandbox/hybrid/connect.ts
@@ -1,11 +1,11 @@
 import { Sandbox as VercelSandboxSDK } from "@vercel/sandbox";
-import type { HybridState } from "./state";
-import type { HybridHooks } from "./hooks";
-import { HybridSandbox } from "./sandbox";
 import { connectJustBash } from "../just-bash/connect";
 import { connectVercel } from "../vercel/connect";
 import { VercelSandbox } from "../vercel/sandbox";
 import { configureGitUser } from "../vercel/utils";
+import type { HybridHooks } from "./hooks";
+import { HybridSandbox } from "./sandbox";
+import type { HybridState } from "./state";
 
 /**
  * Connect options for hybrid sandbox.
@@ -22,6 +22,8 @@ export interface HybridConnectOptions {
   timeout?: number;
   /** Ports to expose from the sandbox for dev server preview URLs */
   ports?: number[];
+  /** Snapshot ID used as the base image for new cloud sandboxes */
+  baseSnapshotId?: string;
   /**
    * Schedule background work for cloud sandbox startup.
    * The callback returns a promise that completes when cloud sandbox is ready.
@@ -71,6 +73,7 @@ function startCloudSandboxInBackground(
         hooks: options?.hooks,
         timeout: options?.timeout,
         ports: options?.ports,
+        baseSnapshotId: options?.baseSnapshotId,
       });
 
       // Perform handoff

--- a/packages/sandbox/vercel/config.ts
+++ b/packages/sandbox/vercel/config.ts
@@ -53,6 +53,11 @@ export interface VercelSandboxConfig {
    */
   ports?: number[];
   /**
+   * Optional snapshot ID to use as the base image for new sandboxes.
+   * When provided, the sandbox is created from this snapshot first.
+   */
+  baseSnapshotId?: string;
+  /**
    * Lifecycle hooks for setup and teardown.
    * afterStart is called after the sandbox is created and configured.
    * beforeStop is called before the sandbox is stopped.

--- a/packages/sandbox/vercel/connect.ts
+++ b/packages/sandbox/vercel/connect.ts
@@ -1,7 +1,7 @@
 import { Sandbox as VercelSandboxSDK } from "@vercel/sandbox";
 import type { SandboxHooks } from "../interface";
-import type { VercelState } from "./state";
 import { VercelSandbox } from "./sandbox";
+import type { VercelState } from "./state";
 import { configureGitUser } from "./utils";
 
 interface ConnectOptions {
@@ -10,6 +10,7 @@ interface ConnectOptions {
   hooks?: SandboxHooks;
   timeout?: number;
   ports?: number[];
+  baseSnapshotId?: string;
 }
 
 /**
@@ -17,7 +18,7 @@ interface ConnectOptions {
  *
  * - If `sandboxId` is present, reconnects to an existing running VM
  * - If `snapshotId` is present (without sandboxId), restores from native snapshot
- * - If `source` is present, creates a new VM and clones the repo
+ * - If `source` is present, creates a new VM and prepares the repo
  * - Otherwise, creates an empty sandbox
  */
 export async function connectVercel(
@@ -84,6 +85,9 @@ export async function connectVercel(
       hooks: options?.hooks,
       ...(options?.timeout !== undefined && { timeout: options.timeout }),
       ...(options?.ports && { ports: options.ports }),
+      ...(options?.baseSnapshotId && {
+        baseSnapshotId: options.baseSnapshotId,
+      }),
     });
   }
 
@@ -94,5 +98,8 @@ export async function connectVercel(
     hooks: options?.hooks,
     ...(options?.timeout !== undefined && { timeout: options.timeout }),
     ...(options?.ports && { ports: options.ports }),
+    ...(options?.baseSnapshotId && {
+      baseSnapshotId: options.baseSnapshotId,
+    }),
   });
 }

--- a/packages/sandbox/vercel/sandbox.test.ts
+++ b/packages/sandbox/vercel/sandbox.test.ts
@@ -14,9 +14,19 @@ type MockRunCommandResult = {
   stderr?: () => Promise<string>;
   wait?: (params?: { signal?: AbortSignal }) => Promise<MockWaitResult>;
 };
-let runCommandMock = async (_params?: {
+type MockRunCommandParams = {
+  cmd?: string;
+  args?: string[];
+  cwd?: string;
   env?: Record<string, string>;
-}): Promise<MockRunCommandResult> => ({
+};
+
+const createCalls: Array<Record<string, unknown>> = [];
+const runCommandCalls: MockRunCommandParams[] = [];
+
+let runCommandMock = async (
+  _params?: MockRunCommandParams,
+): Promise<MockRunCommandResult> => ({
   exitCode: 0,
   cmdId: "cmd-1",
   stdout: async () => "",
@@ -38,6 +48,25 @@ function domainForPort(port: number): string {
 
 mock.module("@vercel/sandbox", () => ({
   Sandbox: {
+    create: async (params: Record<string, unknown>) => {
+      createCalls.push(params);
+      return {
+        sandboxId: "sbx-created",
+        routes: Array.from(portDomains.keys()).map((port) => {
+          const domain =
+            portDomains.get(port) ?? `https://sbx-${port}.vercel.run`;
+          const subdomain = new URL(domain).host.replace(".vercel.run", "");
+          return { port, subdomain };
+        }),
+        domain: (port: number) => domainForPort(port),
+        runCommand: async (params: MockRunCommandParams) => {
+          runCommandCalls.push(params);
+          lastRunCommandEnv = params.env;
+          return runCommandMock(params);
+        },
+        stop: async () => {},
+      };
+    },
     get: async ({ sandboxId }: { sandboxId: string }) => ({
       sandboxId,
       routes: Array.from(portDomains.keys()).map((port) => {
@@ -47,7 +76,8 @@ mock.module("@vercel/sandbox", () => ({
         return { port, subdomain };
       }),
       domain: (port: number) => domainForPort(port),
-      runCommand: async (params: { env?: Record<string, string> }) => {
+      runCommand: async (params: MockRunCommandParams) => {
+        runCommandCalls.push(params);
         lastRunCommandEnv = params.env;
         return runCommandMock(params);
       },
@@ -63,6 +93,8 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  createCalls.length = 0;
+  runCommandCalls.length = 0;
   portDomains.clear();
   missingPorts.clear();
   portDomains.set(80, "https://sbx-80.vercel.run");
@@ -147,6 +179,52 @@ describe("VercelSandbox.environmentDetails", () => {
     expect(lastRunCommandEnv?.SANDBOX_URL_3000).toBe(
       "https://sbx-3000.vercel.run",
     );
+  });
+});
+
+describe("VercelSandbox.create", () => {
+  test("creates from base snapshot and clones git source", async () => {
+    await sandboxModule.VercelSandbox.create({
+      baseSnapshotId: "snap-base-1",
+      source: {
+        url: "https://github.com/open-harness/example",
+        branch: "main",
+      },
+    });
+
+    expect(createCalls.length).toBe(1);
+    expect(createCalls[0]?.source).toEqual({
+      type: "snapshot",
+      snapshotId: "snap-base-1",
+    });
+    expect(runCommandCalls[0]).toEqual({
+      cmd: "git",
+      args: [
+        "clone",
+        "--branch",
+        "main",
+        "https://github.com/open-harness/example",
+        ".",
+      ],
+      cwd: "/vercel/sandbox",
+    });
+  });
+
+  test("creates empty git repo from base snapshot", async () => {
+    await sandboxModule.VercelSandbox.create({
+      baseSnapshotId: "snap-base-1",
+    });
+
+    expect(createCalls.length).toBe(1);
+    expect(createCalls[0]?.source).toEqual({
+      type: "snapshot",
+      snapshotId: "snap-base-1",
+    });
+    expect(runCommandCalls[0]).toEqual({
+      cmd: "git",
+      args: ["init"],
+      cwd: "/vercel/sandbox",
+    });
   });
 });
 

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -408,7 +408,7 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
 
       if (cloneResult.exitCode !== 0) {
         throw new Error(
-          `Failed to clone repository '${source.url}': ${await cloneResult.stdout()}`,
+          `Failed to clone repository '${source.url}': ${await cloneResult.stderr()}`,
         );
       }
     }
@@ -477,7 +477,7 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
 
       if (checkoutResult.exitCode !== 0) {
         throw new Error(
-          `Failed to create branch '${source.newBranch}': ${await checkoutResult.stdout()}`,
+          `Failed to create branch '${source.newBranch}': ${await checkoutResult.stderr()}`,
         );
       }
 

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -390,6 +390,10 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
 
     const workingDirectory = DEFAULT_WORKING_DIRECTORY;
 
+    // TODO: `git clone ... .` requires the directory to be empty. If the base
+    // snapshot has files in /vercel/sandbox (dotfiles, tool configs, etc.), the
+    // clone will fail. Consider using git init + remote add + fetch + checkout
+    // instead, which works regardless of existing directory contents.
     if (source && baseSnapshotId) {
       const cloneUrl = source.token
         ? (buildAuthenticatedGitHubUrl(source.url, source.token) ?? source.url)
@@ -425,6 +429,8 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
 
     // Configure git to use the token for push operations if provided
     // We modify the remote URL to embed credentials directly (standard CI/CD approach)
+    // TODO: When baseSnapshotId is set, the token is already embedded in the
+    // clone URL above, making this set-url call redundant for that path.
     if (source?.token) {
       const authenticatedUrl = buildAuthenticatedGitHubUrl(
         source.url,

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -23,6 +23,22 @@ interface SandboxRouteLike {
   port: number;
 }
 
+function buildAuthenticatedGitHubUrl(
+  repoUrl: string,
+  token: string,
+): string | null {
+  const githubUrlMatch = repoUrl.match(
+    /github\.com[/:]([^/]+)\/([^/]+?)(?:\.git)?$/,
+  );
+
+  if (!githubUrlMatch) {
+    return null;
+  }
+
+  const [, owner, repo] = githubUrlMatch;
+  return `https://x-access-token:${token}@github.com/${owner}/${repo}.git`;
+}
+
 /**
  * Vercel Sandbox implementation using the @vercel/sandbox SDK.
  * Runs code in isolated Firecracker MicroVMs.
@@ -251,7 +267,7 @@ export class VercelSandbox implements Sandbox {
   Use the $GITHUB_TOKEN environment variable directly (do not paste the actual token):
   curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/OWNER/REPO/pulls -d '{"title":"...","head":"branch","base":"main","body":"..."}'
 - Node.js runtime with npm/pnpm available
-- Installing Bun: run \`curl -fsSL https://bun.com/install | bash\`, then \`echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc\`, then verify with \`bun --version\`
+- Bun and jq are preinstalled
 - This sandbox already runs on Vercel; do not suggest deploying to Vercel just to obtain a shareable preview link
 ${hostLine}${portLines}${runtimeEnvLine}`;
   }
@@ -309,7 +325,8 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
 
   /**
    * Create a new Vercel Sandbox instance.
-   * If a source is provided, the repo will be cloned into the working directory.
+   * If `baseSnapshotId` is provided, sandbox bootstraps from that snapshot first.
+   * If a source is provided with `baseSnapshotId`, the repo is cloned after bootstrap.
    */
   static async create(
     config: VercelSandboxConfig = {},
@@ -322,25 +339,9 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
       timeout = 300_000,
       runtime = "node22",
       ports,
+      baseSnapshotId,
       hooks,
     } = config;
-
-    // Build the source config with optional authentication
-    const sourceConfig = source
-      ? source.token
-        ? {
-            type: "git" as const,
-            url: source.url,
-            username: "x-access-token",
-            password: source.token,
-            ...(source.branch && { revision: source.branch }),
-          }
-        : {
-            type: "git" as const,
-            url: source.url,
-            ...(source.branch && { revision: source.branch }),
-          }
-      : undefined;
 
     // Clamp proactive timeout to stay under the SDK's hard max when buffer is applied.
     const effectiveTimeout = Math.min(timeout, MAX_PROACTIVE_TIMEOUT_MS);
@@ -353,15 +354,64 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
     // Calculate SDK timeout with buffer for beforeStop hook.
     const sdkTimeout = effectiveTimeout + TIMEOUT_BUFFER_MS;
 
-    const sdk = await VercelSandboxSDK.create({
-      ...(sourceConfig && { source: sourceConfig }),
+    const createBaseConfig = {
       resources: { vcpus },
       timeout: sdkTimeout,
       runtime,
       ...(ports && { ports }),
-    });
+    };
+
+    let sdk: VercelSandboxSDK;
+    if (baseSnapshotId) {
+      sdk = await VercelSandboxSDK.create({
+        ...createBaseConfig,
+        source: { type: "snapshot", snapshotId: baseSnapshotId },
+      });
+    } else if (source) {
+      sdk = await VercelSandboxSDK.create({
+        ...createBaseConfig,
+        source: source.token
+          ? {
+              type: "git",
+              url: source.url,
+              username: "x-access-token",
+              password: source.token,
+              ...(source.branch && { revision: source.branch }),
+            }
+          : {
+              type: "git",
+              url: source.url,
+              ...(source.branch && { revision: source.branch }),
+            },
+      });
+    } else {
+      sdk = await VercelSandboxSDK.create(createBaseConfig);
+    }
 
     const workingDirectory = DEFAULT_WORKING_DIRECTORY;
+
+    if (source && baseSnapshotId) {
+      const cloneUrl = source.token
+        ? (buildAuthenticatedGitHubUrl(source.url, source.token) ?? source.url)
+        : source.url;
+      const cloneArgs = ["clone"];
+      if (source.branch) {
+        cloneArgs.push("--branch", source.branch);
+      }
+      cloneArgs.push(cloneUrl, ".");
+
+      const cloneResult = await sdk.runCommand({
+        cmd: "git",
+        args: cloneArgs,
+        cwd: workingDirectory,
+      });
+
+      if (cloneResult.exitCode !== 0) {
+        throw new Error(
+          `Failed to clone repository '${source.url}': ${await cloneResult.stdout()}`,
+        );
+      }
+    }
 
     // Initialize git repo for empty sandboxes (no source provided)
     // This ensures git commands work consistently (e.g., for diff viewing)
@@ -376,13 +426,11 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
     // Configure git to use the token for push operations if provided
     // We modify the remote URL to embed credentials directly (standard CI/CD approach)
     if (source?.token) {
-      // Parse the GitHub URL to extract owner/repo
-      const githubUrlMatch = source.url.match(
-        /github\.com[/:]([^/]+)\/([^/]+?)(?:\.git)?$/,
+      const authenticatedUrl = buildAuthenticatedGitHubUrl(
+        source.url,
+        source.token,
       );
-      if (githubUrlMatch) {
-        const [, owner, repo] = githubUrlMatch;
-        const authenticatedUrl = `https://x-access-token:${source.token}@github.com/${owner}/${repo}.git`;
+      if (authenticatedUrl) {
         await sdk.runCommand({
           cmd: "git",
           args: ["remote", "set-url", "origin", authenticatedUrl],


### PR DESCRIPTION
## Summary

- Bootstrap new cloud sandboxes from a base snapshot (`DEFAULT_SANDBOX_BASE_SNAPSHOT_ID`) that includes preinstalled tooling (bun, jq), then clone the git source into the running sandbox
- Guard unarchive and snapshot restore flows against races where the background snapshot has not yet completed, returning 409 with a user-facing "snapshot in progress" message
- Update sandbox overlay UI to show snapshot-pending state and disable unarchive while snapshotting
- Fix git error messages to read `stderr` instead of `stdout` -- git writes errors to stderr, so the previous error messages were empty on failure
- Add TODO comments documenting known edge cases:
  - `git clone ... .` fragility when base snapshot working directory is non-empty
  - Redundant `remote set-url` when token is already embedded in clone URL
  - 409 race guard can permanently stick if background snapshot callback crashes