### PR TITLE
Fix stale chat in-flight UI after navigation

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -1191,6 +1191,7 @@ export function SessionChatContent() {
         shouldRefreshAfterReadyTransition({
           prevStatus,
           status,
+          hasAssistantRenderableContent,
         })
       ) {
         router.refresh();
@@ -1205,6 +1206,7 @@ export function SessionChatContent() {
     requestMarkChatRead,
     refreshChats,
     router,
+    hasAssistantRenderableContent,
   ]);
 
   // Track whether we've auto-attempted sandbox startup for this page load.

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -68,6 +68,11 @@ import { useImageAttachments } from "@/hooks/use-image-attachments";
 import { useScrollToBottom } from "@/hooks/use-scroll-to-bottom";
 import { useSessionChats } from "@/hooks/use-session-chats";
 import { useSlashCommands } from "@/hooks/use-slash-commands";
+import {
+  isChatInFlight as isChatInFlightStatus,
+  shouldRefreshAfterReadyTransition,
+  shouldShowThinkingIndicator,
+} from "@/lib/chat-streaming-state";
 import { ACCEPT_IMAGE_TYPES, isValidImageType } from "@/lib/image-utils";
 import { DEFAULT_SANDBOX_TIMEOUT_MS } from "@/lib/sandbox/config";
 import { streamdownPlugins } from "@/lib/streamdown-config";
@@ -695,22 +700,28 @@ export function SessionChatContent() {
     () => (hasMounted ? messages : initialMessages),
     [hasMounted, messages, initialMessages],
   );
+  const isChatInFlight = isChatInFlightStatus(status);
   const lastMessage = useMemo(
     () => renderMessages[renderMessages.length - 1],
     [renderMessages],
   );
-  const showThinkingIndicator = useMemo(
-    () =>
-      status === "submitted" ||
-      (status === "streaming" &&
-        lastMessage?.role === "assistant" &&
-        !lastMessage.parts.some(
+  const hasAssistantRenderableContent =
+    lastMessage?.role === "assistant"
+      ? lastMessage.parts.some(
           (p) =>
             (p.type === "text" && p.text.length > 0) ||
             isToolUIPart(p) ||
             isReasoningUIPart(p),
-        )),
-    [status, lastMessage],
+        )
+      : false;
+  const showThinkingIndicator = useMemo(
+    () =>
+      shouldShowThinkingIndicator({
+        status,
+        hasAssistantRenderableContent,
+        lastMessageRole: lastMessage?.role,
+      }),
+    [status, hasAssistantRenderableContent, lastMessage?.role],
   );
   const groupedRenderMessages = useMemo<GroupedRenderMessage[]>(() => {
     return renderMessages.map((message, messageIndex) => {
@@ -751,10 +762,10 @@ export function SessionChatContent() {
         message,
         groups,
         isStreaming:
-          status === "streaming" && messageIndex === renderMessages.length - 1,
+          isChatInFlight && messageIndex === renderMessages.length - 1,
       };
     });
-  }, [renderMessages, status]);
+  }, [renderMessages, isChatInFlight]);
   const [isUpdatingModel, setIsUpdatingModel] = useState(false);
   const lastStatusSyncAtRef = useRef(0);
   const statusSyncInFlightRef = useRef(false);
@@ -1127,10 +1138,10 @@ export function SessionChatContent() {
   }, [messages, isAtBottom, scrollToBottom]);
 
   useEffect(() => {
-    if (status !== "streaming") {
+    if (!isChatInFlight) {
       inputRef.current?.focus();
     }
-  }, [status]);
+  }, [isChatInFlight]);
 
   // After a chat turn completes, immediately sync status from the server.
   // If the sandbox was hibernated during the turn (tool calls failed), this
@@ -1144,6 +1155,7 @@ export function SessionChatContent() {
   useEffect(() => {
     const prevStatus = prevStatusRef.current;
     const wasStreaming = prevStatus === "streaming";
+    const wasSubmitted = prevStatus === "submitted";
     const becameReady = status === "ready" && prevStatus !== "ready";
     const becameError = status === "error" && prevStatus !== "error";
     const shouldClearStreaming = status === "error" || becameReady;
@@ -1167,10 +1179,22 @@ export function SessionChatContent() {
     if (becameReady) {
       pendingOptimisticTitleChatIdRef.current = null;
     }
-    if (wasStreaming && status === "ready" && isMountedRef.current) {
+    if (
+      (wasStreaming || wasSubmitted) &&
+      status === "ready" &&
+      isMountedRef.current
+    ) {
       void requestStatusSync("force");
       void requestMarkChatRead("force");
       void refreshChats();
+      if (
+        shouldRefreshAfterReadyTransition({
+          prevStatus,
+          status,
+        })
+      ) {
+        router.refresh();
+      }
     }
   }, [
     status,
@@ -1180,6 +1204,7 @@ export function SessionChatContent() {
     requestStatusSync,
     requestMarkChatRead,
     refreshChats,
+    router,
   ]);
 
   // Track whether we've auto-attempted sandbox startup for this page load.
@@ -2134,7 +2159,7 @@ export function SessionChatContent() {
                       }
                     }
                   }}
-                  disabled={isArchived || status === "streaming"}
+                  disabled={isArchived || isChatInFlight}
                   className="w-full resize-none overflow-y-auto bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none"
                   style={{ minHeight: "24px" }}
                 />
@@ -2156,7 +2181,7 @@ export function SessionChatContent() {
                   {renderMessages.length === 0 && chatInfo.modelId ? (
                     <div
                       className={
-                        status === "streaming" || isUpdatingModel
+                        isChatInFlight || isUpdatingModel
                           ? "pointer-events-none opacity-60"
                           : undefined
                       }
@@ -2206,7 +2231,7 @@ export function SessionChatContent() {
                     )}
                   </Button>
 
-                  {status === "streaming" ? (
+                  {isChatInFlight ? (
                     <Button
                       type="button"
                       size="icon"
@@ -2229,6 +2254,7 @@ export function SessionChatContent() {
                             size="icon"
                             disabled={
                               isArchived ||
+                              isChatInFlight ||
                               (!input.trim() && images.length === 0) ||
                               isUpdatingModel ||
                               !isSandboxActive

--- a/apps/web/lib/chat-streaming-state.test.ts
+++ b/apps/web/lib/chat-streaming-state.test.ts
@@ -46,6 +46,7 @@ describe("chat streaming state", () => {
       shouldRefreshAfterReadyTransition({
         prevStatus: "submitted",
         status: "ready",
+        hasAssistantRenderableContent: true,
       }),
     ).toBe(true);
 
@@ -53,6 +54,7 @@ describe("chat streaming state", () => {
       shouldRefreshAfterReadyTransition({
         prevStatus: "streaming",
         status: "ready",
+        hasAssistantRenderableContent: true,
       }),
     ).toBe(false);
 
@@ -60,6 +62,15 @@ describe("chat streaming state", () => {
       shouldRefreshAfterReadyTransition({
         prevStatus: "ready",
         status: "ready",
+        hasAssistantRenderableContent: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRefreshAfterReadyTransition({
+        prevStatus: "submitted",
+        status: "ready",
+        hasAssistantRenderableContent: false,
       }),
     ).toBe(false);
   });

--- a/apps/web/lib/chat-streaming-state.test.ts
+++ b/apps/web/lib/chat-streaming-state.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isChatInFlight,
+  shouldRefreshAfterReadyTransition,
+  shouldShowThinkingIndicator,
+} from "./chat-streaming-state";
+
+describe("chat streaming state", () => {
+  test("treats submitted and streaming as in-flight", () => {
+    expect(isChatInFlight("submitted")).toBe(true);
+    expect(isChatInFlight("streaming")).toBe(true);
+    expect(isChatInFlight("ready")).toBe(false);
+    expect(isChatInFlight("error")).toBe(false);
+  });
+
+  test("does not show thinking when submitted already has assistant output", () => {
+    expect(
+      shouldShowThinkingIndicator({
+        status: "submitted",
+        hasAssistantRenderableContent: true,
+        lastMessageRole: "assistant",
+      }),
+    ).toBe(false);
+  });
+
+  test("shows thinking while in-flight without assistant output", () => {
+    expect(
+      shouldShowThinkingIndicator({
+        status: "submitted",
+        hasAssistantRenderableContent: false,
+        lastMessageRole: "user",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldShowThinkingIndicator({
+        status: "streaming",
+        hasAssistantRenderableContent: false,
+        lastMessageRole: "assistant",
+      }),
+    ).toBe(true);
+  });
+
+  test("refreshes route only for submitted to ready transition", () => {
+    expect(
+      shouldRefreshAfterReadyTransition({
+        prevStatus: "submitted",
+        status: "ready",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRefreshAfterReadyTransition({
+        prevStatus: "streaming",
+        status: "ready",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRefreshAfterReadyTransition({
+        prevStatus: "ready",
+        status: "ready",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/chat-streaming-state.ts
+++ b/apps/web/lib/chat-streaming-state.ts
@@ -24,7 +24,12 @@ export function shouldShowThinkingIndicator(options: {
 export function shouldRefreshAfterReadyTransition(options: {
   prevStatus: ChatUiStatus | null;
   status: ChatUiStatus;
+  hasAssistantRenderableContent: boolean;
 }): boolean {
-  const { prevStatus, status } = options;
-  return prevStatus === "submitted" && status === "ready";
+  const { prevStatus, status, hasAssistantRenderableContent } = options;
+  return (
+    prevStatus === "submitted" &&
+    status === "ready" &&
+    hasAssistantRenderableContent
+  );
 }

--- a/apps/web/lib/chat-streaming-state.ts
+++ b/apps/web/lib/chat-streaming-state.ts
@@ -1,0 +1,30 @@
+export type ChatUiStatus = "submitted" | "streaming" | "ready" | "error";
+
+export function isChatInFlight(status: ChatUiStatus): boolean {
+  return status === "submitted" || status === "streaming";
+}
+
+export function shouldShowThinkingIndicator(options: {
+  status: ChatUiStatus;
+  hasAssistantRenderableContent: boolean;
+  lastMessageRole: "assistant" | "user" | "system" | undefined;
+}): boolean {
+  const { status, hasAssistantRenderableContent, lastMessageRole } = options;
+  if (!isChatInFlight(status)) {
+    return false;
+  }
+
+  if (lastMessageRole !== "assistant") {
+    return true;
+  }
+
+  return !hasAssistantRenderableContent;
+}
+
+export function shouldRefreshAfterReadyTransition(options: {
+  prevStatus: ChatUiStatus | null;
+  status: ChatUiStatus;
+}): boolean {
+  const { prevStatus, status } = options;
+  return prevStatus === "submitted" && status === "ready";
+}

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -83,6 +83,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 - `hadInitialMessages` is an initial-load snapshot, not a live "first turn" signal; guard one-time optimistic UI (like first-message title previews) with a dedicated runtime ref/state that resets on send failure.
 - When session overlay maps are deleted after becoming empty, any later overlay writes in the same hook instance must re-register the map in the global registry, or optimistic overlays will not survive route transitions.
 - For resumed chat streams, `chat.stop()` alone is insufficient because reconnect fetches are not wired to the active abort signal; always pair stop with aborting the managed transport tied to that chat instance.
+- In chat UI rendering, treat both `submitted` and `streaming` as in-flight. If only `streaming` is considered active, task/tool parts can be marked interrupted too early and stale `Thinking...` indicators can linger until a full page refresh.
 - In Streamdown, `plugins.code.getThemes()` overrides the `shikiTheme` prop; configure code themes in `createCodePlugin(...)` and pass actual custom theme objects for non-bundled themes (for example `vercelLight`/`vercelDark`) or highlighting can fall back to unstyled/plain tokens.
 
 ## GitHub App / PR Flows


### PR DESCRIPTION
## Summary
- treat both `submitted` and `streaming` as in-flight in the session chat UI so returning to an active chat no longer shows stale interrupted/thinking state
- refresh client/server state when a resumed run transitions `submitted -> ready`, which fixes cases that only resolved after a manual page refresh
- add regression tests for chat streaming state transitions and document the submitted-vs-streaming pitfall in lessons learned

## Testing
- bun test apps/web/lib/chat-streaming-state.test.ts
- turbo typecheck --filter=web
- turbo lint --filter=web