### PR TITLE
fix: recover stalled chat streams after reconnect

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -101,6 +101,9 @@ const Streamdown = dynamic(
   { ssr: false },
 );
 
+const STREAM_RECOVERY_STALL_MS = 4_000;
+const STREAM_RECOVERY_MIN_INTERVAL_MS = 8_000;
+
 const emptySubscribe = () => () => {};
 function useHasMounted() {
   return useSyncExternalStore(
@@ -785,6 +788,8 @@ export function SessionChatContent() {
     lastChatId: null,
     inFlight: false,
   });
+  const inFlightStartedAtRef = useRef<number | null>(null);
+  const lastStreamRecoveryAtRef = useRef(0);
 
   const requestStatusSync = useCallback(
     async (mode: "normal" | "force" = "normal"): Promise<void> => {
@@ -888,30 +893,89 @@ export function SessionChatContent() {
     };
   }, [requestMarkChatRead]);
 
-  // Auto-recover from transient network errors (e.g. iOS "Load failed") when
-  // the tab becomes visible again or the device comes back online.  The server
-  // intentionally keeps the stream running on client disconnect, so we can
-  // clear the stale error and attempt to reconnect to the resumable stream.
+  const maybeRecoverStream = useCallback(() => {
+    const now = Date.now();
+    if (
+      now - lastStreamRecoveryAtRef.current <
+      STREAM_RECOVERY_MIN_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    if (status === "error") {
+      lastStreamRecoveryAtRef.current = now;
+      retryChatStream();
+      return;
+    }
+
+    if (!isChatInFlight || hasAssistantRenderableContent) {
+      return;
+    }
+
+    const startedAt = inFlightStartedAtRef.current;
+    if (startedAt === null || now - startedAt < STREAM_RECOVERY_STALL_MS) {
+      return;
+    }
+
+    lastStreamRecoveryAtRef.current = now;
+    retryChatStream();
+  }, [status, isChatInFlight, hasAssistantRenderableContent, retryChatStream]);
+
   useEffect(() => {
-    const recover = () => {
-      if (status === "error") {
-        retryChatStream();
+    if (isChatInFlight) {
+      if (inFlightStartedAtRef.current === null) {
+        inFlightStartedAtRef.current = Date.now();
+      }
+      return;
+    }
+
+    inFlightStartedAtRef.current = null;
+  }, [isChatInFlight, chatInfo.id]);
+
+  // Recover from transient connection drops when the tab regains visibility,
+  // the network comes back, or a stream remains in-flight without any visible
+  // assistant output for too long.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        maybeRecoverStream();
       }
     };
 
-    const onVisible = () => {
-      if (document.visibilityState === "visible") {
-        recover();
-      }
+    const onFocus = () => {
+      maybeRecoverStream();
     };
 
     document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("online", recover);
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("online", maybeRecoverStream);
     return () => {
       document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("online", recover);
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("online", maybeRecoverStream);
     };
-  }, [status, retryChatStream]);
+  }, [maybeRecoverStream]);
+
+  useEffect(() => {
+    if (!isChatInFlight || hasAssistantRenderableContent) {
+      return;
+    }
+    if (
+      typeof document !== "undefined" &&
+      document.visibilityState !== "visible"
+    ) {
+      return;
+    }
+
+    const startedAt = inFlightStartedAtRef.current;
+    const elapsed = startedAt === null ? 0 : Date.now() - startedAt;
+    const waitMs = Math.max(0, STREAM_RECOVERY_STALL_MS - elapsed);
+    const timeout = setTimeout(() => {
+      maybeRecoverStream();
+    }, waitMs);
+
+    return () => clearTimeout(timeout);
+  }, [isChatInFlight, hasAssistantRenderableContent, maybeRecoverStream]);
 
   const handleModelChange = useCallback(
     async (modelId: string) => {

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -290,10 +290,15 @@ export function SessionChatProvider({
     abortChatInstanceTransport(chatInfo.id);
   }, [chatInfo.id, chatInstance]);
 
-  // Only resume on fresh page load (new Chat instance + active stream in DB).
-  // If instance already existed, the stream is either still running or finished —
-  // no resume needed since the instance tracked it the whole time.
-  const shouldResume = !alreadyExisted && !!initialChat.activeStreamId;
+  // Resume whenever the server reports an active stream and the local instance
+  // is either new or currently idle/error. This covers stale instances that can
+  // survive route transitions while avoiding duplicate reconnect attempts for an
+  // already-streaming instance.
+  const shouldResume =
+    !!initialChat.activeStreamId &&
+    (!alreadyExisted ||
+      chatInstance.status === "ready" ||
+      chatInstance.status === "error");
 
   const chat = useChat<WebAgentUIMessage>({
     chat: chatInstance,
@@ -303,15 +308,19 @@ export function SessionChatProvider({
 
   /**
    * Clear a transient chat error (e.g. iOS "Load failed") and attempt to
-   * resume the server-side stream if one is still active.  This is safe to
+   * resume the server-side stream if one is still active. This is safe to
    * call from a visibility-change handler or a manual "Retry" button.
    */
   const retryChatStream = useCallback(() => {
+    // Tear down any stale local fetch before reconnecting.
+    void chatInstance.stop();
+    abortChatInstanceTransport(chatInfo.id);
+
     // Clear the error so the chat UI becomes visible again.
     chat.clearError();
     // If the server-side stream is still running, reconnect to it.
-    chat.resumeStream();
-  }, [chat]);
+    void chat.resumeStream();
+  }, [chat, chatInfo.id, chatInstance]);
 
   // Cleanup: always release chat instances when leaving a route.
   // If this chat is still streaming or submitted, stop local stream processing

--- a/docs/plans/incomplete/resumable-stream-replay-chunking-plan.md
+++ b/docs/plans/incomplete/resumable-stream-replay-chunking-plan.md
@@ -1,0 +1,87 @@
+# Plan: Chunk Resumable Stream Replay to Avoid Upstash 10 MB Limits
+
+## Status
+
+- Drafted
+- Scope: fast safety fix only ("fix #1")
+
+## Assumptions
+
+- Current resume failures are caused by replay backlog being published as one large Redis `PUBLISH` payload.
+- Upstash request size limits (10 MB) apply to this `PUBLISH` call and can reject oversized replay payloads.
+- We want a low-risk patch that preserves existing stream semantics and does not require a persistence model redesign yet.
+
+## Problem
+
+Resume replay currently builds a single large string (`chunks.join("")`) and publishes it once, which can exceed Upstash limits and cause resumed clients to receive no stream content.
+
+## Approach
+
+Patch replay delivery to publish backlog in bounded frames instead of one message, while keeping ordering and completion signaling identical from the client perspective.
+
+## Proposed Design
+
+### 1) Bound replay publish size
+
+- Introduce a conservative `MAX_REPLAY_PUBLISH_BYTES` for replay payload frames (recommended: `256 * 1024` to start).
+- During replay, slice buffered data into frames at or below that cap and publish each frame sequentially to the listener channel.
+- Keep existing live tail behavior unchanged (new chunks continue to publish as they are produced).
+
+### 2) Preserve resume handshake guarantees
+
+- If replay backlog is empty, still publish one empty frame (`""`) so the resume subscriber ack/timeout behavior remains intact.
+- If stream is already complete, publish `DONE_SENTINEL` only after replay frames are published.
+- Maintain strict ordering: replay frames first, then live frames, then done sentinel.
+
+### 3) Keep fix localized
+
+- Prefer patching upstream replay logic (`resumable-stream` runtime path) where `chunks.join("")` is currently used.
+- If upstream patch cannot be consumed immediately, add a local compatibility layer in `apps/web/lib/resumable-stream-context.ts` that chunks oversized replay publishes before sending.
+
+## File-Level Plan
+
+- `apps/web/lib/resumable-stream-context.ts`
+  - If needed for short-term mitigation, instantiate context with custom publisher/subscriber adapters and wrap `publish` with bounded replay frame logic.
+- Dependency update path (if upstream patch used)
+  - Bump `resumable-stream` in `apps/web/package.json` once patched release is available.
+
+## Rollout Strategy
+
+1. Implement chunked replay in one environment.
+2. Validate resume of very large streams (>10 MB total buffered output).
+3. Ship broadly after confirming no reconnect regressions.
+
+## Validation Checklist
+
+- Resume succeeds when buffered replay exceeds 10 MB total.
+- Replayed content arrives in correct order with no dropped/duplicated frames.
+- Empty replay still connects immediately (no timeout waiting for first ack).
+- Completed streams still terminate correctly with done sentinel.
+- Normal small replays continue to behave exactly as before.
+
+## Observability to Add
+
+- Replay backlog size estimate at resume time.
+- Number of replay frames emitted per listener.
+- Largest replay frame bytes published.
+- Replay publish failures with explicit error surface (including Upstash rejection details).
+
+## Risks and Mitigations
+
+- Risk: frame splitting could alter boundary assumptions.
+  - Mitigation: preserve byte-for-byte payload order and avoid transforming content.
+- Risk: too-large frame cap still occasionally exceeds provider envelope overhead.
+  - Mitigation: start conservative (`256 KB`) and increase only with measured headroom.
+- Risk: local mitigation diverges from upstream behavior.
+  - Mitigation: keep local wrapper minimal and remove after upstream adoption.
+
+## Out of Scope (for this plan)
+
+- Incremental durable event persistence for assistant output.
+- Cursor-based replay (`afterSeq`) and multi-source catch-up.
+- Any changes to client protocol shape.
+
+## Next Step After This Plan
+
+- Publish this plan as the implementation proposal.
+- Create a dedicated branch for implementation and tests.


### PR DESCRIPTION
## Summary
- Improve chat stream recovery so re-entering an in-flight chat can resume even when the local chat instance was reused and left in `ready`/`error` state.
- Retry recovery now tears down stale local transport before reconnecting, and adds guarded auto-recovery on visibility/focus/online events plus a short stalled-stream watchdog.
- This reduces the "Thinking + stop button but no visible output" state while server generation is still active.

## Notes
- There is a likely upstream constraint in `resumable-stream` replay behavior: reconnect can publish a very large buffered payload as one Redis request, which may hit Upstash max request size limits (10MB) and stall resume acknowledgements.
- This PR hardens client recovery behavior; follow-up should patch/fork `resumable-stream` to replay backlog in bounded chunk sizes.

## Testing
- `turbo typecheck --filter=web`
- `turbo lint --filter=web`