### PR TITLE
feat: detect existing PRs and persist branch info after message completion

### DIFF
--- a/apps/web/app/api/check-pr/route.ts
+++ b/apps/web/app/api/check-pr/route.ts
@@ -1,0 +1,132 @@
+import { connectSandbox } from "@open-harness/sandbox";
+import { getSessionById, updateSession } from "@/lib/db/sessions";
+import { findPullRequestByBranch } from "@/lib/github/client";
+import { getRepoToken } from "@/lib/github/get-repo-token";
+import { isSandboxActive } from "@/lib/sandbox/utils";
+import { getServerSession } from "@/lib/session/get-server-session";
+
+interface CheckPrRequest {
+  sessionId: string;
+}
+
+/**
+ * POST /api/check-pr
+ *
+ * Checks the current branch in the sandbox, looks for an existing PR on that
+ * branch, and persists the branch + PR info to the session record.
+ *
+ * Called automatically after each agent message completes.
+ */
+export async function POST(req: Request) {
+  const session = await getServerSession();
+  if (!session?.user) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  let body: CheckPrRequest;
+  try {
+    body = (await req.json()) as CheckPrRequest;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { sessionId } = body;
+  if (!sessionId) {
+    return Response.json({ error: "sessionId is required" }, { status: 400 });
+  }
+
+  const sessionRecord = await getSessionById(sessionId);
+  if (!sessionRecord) {
+    return Response.json({ error: "Session not found" }, { status: 404 });
+  }
+  if (sessionRecord.userId !== session.user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Need an active sandbox to check branch, and repo info to check PRs
+  if (!isSandboxActive(sessionRecord.sandboxState)) {
+    return Response.json({ error: "Sandbox not active" }, { status: 400 });
+  }
+  if (!sessionRecord.repoOwner || !sessionRecord.repoName) {
+    return Response.json({ error: "No repo info on session" }, { status: 400 });
+  }
+
+  try {
+    // 1. Get current branch from sandbox
+    const sandbox = await connectSandbox(sessionRecord.sandboxState);
+    const cwd = sandbox.workingDirectory;
+    const symbolicRefResult = await sandbox.exec(
+      "git symbolic-ref --short HEAD",
+      cwd,
+      10000,
+    );
+
+    let branch: string | null = null;
+    if (symbolicRefResult.success && symbolicRefResult.stdout.trim()) {
+      branch = symbolicRefResult.stdout.trim();
+    }
+
+    // If we cannot determine the branch (detached HEAD), nothing to check
+    if (!branch) {
+      return Response.json({ branch: null, prNumber: null, prStatus: null });
+    }
+
+    // 2. Persist the branch to the session if it changed
+    const branchChanged = branch !== sessionRecord.branch;
+    if (branchChanged) {
+      await updateSession(sessionId, { branch });
+    }
+
+    // 3. If session already has a PR recorded, just return current state
+    // (the PR was created through our flow -- no need to re-check)
+    if (sessionRecord.prNumber) {
+      return Response.json({
+        branch,
+        prNumber: sessionRecord.prNumber,
+        prStatus: sessionRecord.prStatus,
+      });
+    }
+
+    // 4. Check GitHub for an existing PR on this branch
+    let token: string | undefined;
+    try {
+      const tokenResult = await getRepoToken(
+        session.user.id,
+        sessionRecord.repoOwner,
+      );
+      token = tokenResult.token;
+    } catch {
+      // No token available -- skip PR check
+      return Response.json({ branch, prNumber: null, prStatus: null });
+    }
+
+    const prResult = await findPullRequestByBranch({
+      owner: sessionRecord.repoOwner,
+      repo: sessionRecord.repoName,
+      branchName: branch,
+      token,
+    });
+
+    if (prResult.found && prResult.prNumber && prResult.prStatus) {
+      // Persist PR info to session
+      await updateSession(sessionId, {
+        prNumber: prResult.prNumber,
+        prStatus: prResult.prStatus,
+      });
+
+      return Response.json({
+        branch,
+        prNumber: prResult.prNumber,
+        prStatus: prResult.prStatus,
+      });
+    }
+
+    return Response.json({ branch, prNumber: null, prStatus: null });
+  } catch (error) {
+    console.error("Failed to check PR status:", error);
+    return Response.json(
+      { error: "Failed to check PR status" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -688,6 +688,7 @@ export function SessionChatContent() {
     attemptReconnection,
     updateSessionRepo,
     updateSessionPullRequest,
+    checkBranchAndPr,
   } = useSessionChatContext();
   const {
     messages,
@@ -1274,6 +1275,8 @@ export function SessionChatContent() {
       void requestStatusSync("force");
       void requestMarkChatRead("force");
       void refreshChats();
+      // After a message completes, check branch and detect existing PRs
+      void checkBranchAndPr();
       if (
         shouldRefreshAfterReadyTransition({
           prevStatus,
@@ -1293,6 +1296,7 @@ export function SessionChatContent() {
     requestStatusSync,
     requestMarkChatRead,
     refreshChats,
+    checkBranchAndPr,
     router,
   ]);
 

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -181,6 +181,8 @@ type SessionChatContextValue = {
     prNumber: number;
     prStatus: "open" | "merged" | "closed";
   }) => void;
+  /** Check sandbox branch and look for existing PRs, persisting to DB */
+  checkBranchAndPr: () => Promise<void>;
 };
 
 const SessionChatContext = createContext<SessionChatContextValue | undefined>(
@@ -701,6 +703,71 @@ export function SessionChatProvider({
     [mutate, sessionId],
   );
 
+  const checkBranchAndPr = useCallback(async () => {
+    // Only check if the session has repo info. The API will return a 400
+    // if the sandbox is not active, which we silently ignore.
+    if (!sessionRecord.repoOwner || !sessionRecord.repoName) return;
+
+    try {
+      const res = await fetch("/api/check-pr", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: sessionRecord.id }),
+      });
+      if (!res.ok) return;
+
+      const data = (await res.json()) as {
+        branch: string | null;
+        prNumber: number | null;
+        prStatus: "open" | "merged" | "closed" | null;
+      };
+
+      // Update local session state with branch and PR info
+      setSessionRecord((prev) => ({
+        ...prev,
+        ...(data.branch ? { branch: data.branch } : {}),
+        ...(data.prNumber && data.prStatus
+          ? { prNumber: data.prNumber, prStatus: data.prStatus }
+          : {}),
+      }));
+
+      // Optimistically update the sessions list cache so sidebar reflects changes
+      if (data.branch || data.prNumber) {
+        void mutate<SessionsResponse>(
+          "/api/sessions",
+          (current) =>
+            current
+              ? {
+                  sessions: current.sessions.map((s) =>
+                    s.id === sessionId
+                      ? {
+                          ...s,
+                          ...(data.branch ? { branch: data.branch } : {}),
+                          ...(data.prNumber && data.prStatus
+                            ? {
+                                prNumber: data.prNumber,
+                                prStatus: data.prStatus,
+                              }
+                            : {}),
+                        }
+                      : s,
+                  ),
+                }
+              : current,
+          { revalidate: false },
+        );
+      }
+    } catch (error) {
+      console.error("Failed to check branch/PR:", error);
+    }
+  }, [
+    sessionRecord.id,
+    sessionRecord.repoOwner,
+    sessionRecord.repoName,
+    mutate,
+    sessionId,
+  ]);
+
   const updateSessionSnapshot = useCallback(
     (snapshotUrl: string, snapshotCreatedAt: Date) => {
       setHasSnapshotState(true);
@@ -985,6 +1052,7 @@ export function SessionChatProvider({
       attemptReconnection,
       updateSessionRepo,
       updateSessionPullRequest,
+      checkBranchAndPr,
     }),
     [
       sessionRecord,
@@ -1028,6 +1096,7 @@ export function SessionChatProvider({
       attemptReconnection,
       updateSessionRepo,
       updateSessionPullRequest,
+      checkBranchAndPr,
     ],
   );
 

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -193,6 +193,69 @@ export async function getPullRequestStatus(params: {
   }
 }
 
+/**
+ * Find an open pull request for a given branch name.
+ * Returns the first open PR whose head ref matches `branchName`.
+ */
+export async function findPullRequestByBranch(params: {
+  owner: string;
+  repo: string;
+  branchName: string;
+  token?: string;
+}): Promise<{
+  found: boolean;
+  prNumber?: number;
+  prStatus?: "open" | "closed" | "merged";
+  prUrl?: string;
+  prTitle?: string;
+  error?: string;
+}> {
+  const { owner, repo, branchName, token } = params;
+
+  try {
+    const result = await getOctokit(token);
+
+    if (!result.authenticated) {
+      return { found: false, error: "GitHub account not connected" };
+    }
+
+    // Search for PRs with this head branch (any state)
+    const response = await result.octokit.rest.pulls.list({
+      owner,
+      repo,
+      head: `${owner}:${branchName}`,
+      state: "all",
+      per_page: 1,
+      sort: "updated",
+      direction: "desc",
+    });
+
+    const pr = response.data[0];
+    if (!pr) {
+      return { found: false };
+    }
+
+    let prStatus: "open" | "closed" | "merged";
+    if (pr.merged_at) {
+      prStatus = "merged";
+    } else if (pr.state === "closed") {
+      prStatus = "closed";
+    } else {
+      prStatus = "open";
+    }
+
+    return {
+      found: true,
+      prNumber: pr.number,
+      prStatus,
+      prUrl: pr.html_url,
+      prTitle: pr.title,
+    };
+  } catch {
+    return { found: false, error: "Failed to search pull requests" };
+  }
+}
+
 export async function createRepository(params: {
   name: string;
   description?: string;


### PR DESCRIPTION
Add automatic branch and PR detection that runs after each agent message completes, replacing the previous approach of only checking when the Create PR dialog was opened. The branch name and any existing PR info are now persisted to the session DB and reflected in the nav/sidebar.