### PR TITLE
feat: add commit-first git workflow and PR gating

### DIFF
--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -3,8 +3,8 @@ import { gateway, generateText, NoObjectGeneratedError, Output } from "ai";
 import { z } from "zod";
 import { getGitHubAccount } from "@/lib/db/accounts";
 import {
-  getChatsBySessionId,
   getChatMessages,
+  getChatsBySessionId,
   getSessionById,
   updateSession,
 } from "@/lib/db/sessions";
@@ -270,6 +270,8 @@ interface GeneratePRRequest {
   branchName: string;
   createBranchOnly?: boolean;
   commitOnly?: boolean;
+  commitTitle?: string;
+  commitBody?: string;
 }
 
 export async function POST(req: Request) {
@@ -294,6 +296,8 @@ export async function POST(req: Request) {
     branchName,
     createBranchOnly,
     commitOnly,
+    commitTitle,
+    commitBody,
   } = body;
 
   if (!sessionId) {
@@ -504,6 +508,7 @@ export async function POST(req: Request) {
   const gitActions: {
     committed?: boolean;
     commitMessage?: string;
+    commitSha?: string;
     pushed?: boolean;
     pushedToFork?: boolean;
   } = {};
@@ -529,9 +534,15 @@ export async function POST(req: Request) {
 
     const fallbackCommitMessage = "chore: update repository changes";
 
+    const normalizedManualTitle = commitTitle?.trim() ?? "";
+    const normalizedManualBody = commitBody?.trim() ?? "";
+    const useManualCommitMessage = normalizedManualTitle.length > 0;
+
     // 4c. Generate commit message with AI
     let commitMessage = fallbackCommitMessage;
-    if (diffForCommit.trim()) {
+    if (useManualCommitMessage) {
+      commitMessage = normalizedManualTitle.slice(0, 72);
+    } else if (diffForCommit.trim()) {
       const commitMsgResult = await generateText({
         model: gateway("anthropic/claude-haiku-4.5"),
         prompt: `Generate a concise git commit message for these changes. Use conventional commit format (e.g., "feat:", "fix:", "refactor:"). One line only, max 72 characters.
@@ -575,11 +586,11 @@ Respond with ONLY the commit message, nothing else.`,
     }
 
     const escapedMessage = commitMessage.replace(/'/g, "'\\''");
-    const commitResult = await sandbox.exec(
-      `git commit -m '${escapedMessage}'`,
-      cwd,
-      10000,
-    );
+    const commitCommand =
+      useManualCommitMessage && normalizedManualBody.length > 0
+        ? `git commit -m '${escapedMessage}' -m '${normalizedManualBody.replace(/'/g, "'\\''")}'`
+        : `git commit -m '${escapedMessage}'`;
+    const commitResult = await sandbox.exec(commitCommand, cwd, 10000);
 
     if (!commitResult.success) {
       return Response.json(
@@ -596,6 +607,10 @@ Respond with ONLY the commit message, nothing else.`,
 
     gitActions.committed = true;
     gitActions.commitMessage = commitMessage;
+    const commitSha = postCommitHead.stdout.trim();
+    if (commitSha.length > 0) {
+      gitActions.commitSha = commitSha;
+    }
   }
 
   // 5. Check if branch needs to be pushed

--- a/apps/web/app/api/git-status/route.ts
+++ b/apps/web/app/api/git-status/route.ts
@@ -7,6 +7,61 @@ interface GitStatusRequest {
   sessionId: string;
 }
 
+function parsePorcelainStatus(output: string): {
+  stagedCount: number;
+  unstagedCount: number;
+  untrackedCount: number;
+  uncommittedFiles: number;
+} {
+  const stagedFiles = new Set<string>();
+  const unstagedFiles = new Set<string>();
+  const untrackedFiles = new Set<string>();
+
+  for (const line of output.trim().split("\n")) {
+    if (!line || line.length < 3) continue;
+
+    const indexStatus = line[0];
+    const worktreeStatus = line[1];
+    const filePath = line.slice(3).trim();
+    if (!filePath) continue;
+
+    if (indexStatus === "?" && worktreeStatus === "?") {
+      untrackedFiles.add(filePath);
+      continue;
+    }
+
+    if (indexStatus !== " " && indexStatus !== "?") {
+      stagedFiles.add(filePath);
+    }
+
+    if (worktreeStatus !== " " && worktreeStatus !== "?") {
+      unstagedFiles.add(filePath);
+    }
+  }
+
+  const uncommitted = new Set<string>([
+    ...stagedFiles,
+    ...unstagedFiles,
+    ...untrackedFiles,
+  ]);
+
+  return {
+    stagedCount: stagedFiles.size,
+    unstagedCount: unstagedFiles.size,
+    untrackedCount: untrackedFiles.size,
+    uncommittedFiles: uncommitted.size,
+  };
+}
+
+function parseRemoteRef(output: string): string | null {
+  const trimmed = output.trim();
+  const match = trimmed.match(/^refs\/remotes\/(.+)$/);
+  if (!match || !match[1]) {
+    return null;
+  }
+  return match[1];
+}
+
 export async function POST(req: Request) {
   const session = await getServerSession();
   if (!session?.user) {
@@ -71,18 +126,49 @@ export async function POST(req: Request) {
       cwd,
       10000,
     );
-    const hasUncommittedChanges = statusResult.stdout.trim().length > 0;
+    const { stagedCount, unstagedCount, untrackedCount, uncommittedFiles } =
+      parsePorcelainStatus(statusResult.stdout);
+    const hasUncommittedChanges = uncommittedFiles > 0;
 
-    // Count uncommitted files
-    const uncommittedFiles = statusResult.stdout
-      .trim()
-      .split("\n")
-      .filter((line) => line.length > 0).length;
+    // Check for commits ahead of upstream or default remote branch
+    let hasUnpushedCommits = false;
+    const upstreamRefResult = await sandbox.exec(
+      "git rev-parse --abbrev-ref --symbolic-full-name @{upstream}",
+      cwd,
+      10000,
+    );
+
+    let aheadBaseRef: string | null = null;
+    if (upstreamRefResult.success && upstreamRefResult.stdout.trim()) {
+      aheadBaseRef = upstreamRefResult.stdout.trim();
+    } else {
+      const defaultRemoteRefResult = await sandbox.exec(
+        "git symbolic-ref refs/remotes/origin/HEAD",
+        cwd,
+        10000,
+      );
+      aheadBaseRef = parseRemoteRef(defaultRemoteRefResult.stdout);
+    }
+
+    if (aheadBaseRef) {
+      const aheadResult = await sandbox.exec(
+        `git rev-list ${aheadBaseRef}..HEAD`,
+        cwd,
+        10000,
+      );
+      if (aheadResult.success) {
+        hasUnpushedCommits = aheadResult.stdout.trim().length > 0;
+      }
+    }
 
     return Response.json({
       branch,
       isDetachedHead,
       hasUncommittedChanges,
+      hasUnpushedCommits,
+      stagedCount,
+      unstagedCount,
+      untrackedCount,
       uncommittedFiles: hasUncommittedChanges ? uncommittedFiles : 0,
     });
   } catch (error) {

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -11,6 +11,7 @@ import {
   Copy,
   ExternalLink,
   FolderGit2,
+  GitCommit,
   GitCompare,
   GitPullRequest,
   Link2,
@@ -89,6 +90,10 @@ const DiffViewer = dynamic(
 );
 const CreatePRDialog = dynamic(
   () => import("@/components/create-pr-dialog").then((m) => m.CreatePRDialog),
+  { ssr: false },
+);
+const CommitDialog = dynamic(
+  () => import("@/components/commit-dialog").then((m) => m.CommitDialog),
   { ssr: false },
 );
 const CreateRepoDialog = dynamic(
@@ -583,6 +588,7 @@ export function SessionChatContent() {
   const [isCreatingSandbox, setIsCreatingSandbox] = useState(false);
   const [isRestoringSnapshot, setIsRestoringSnapshot] = useState(false);
   const [isUnarchiving, setIsUnarchiving] = useState(false);
+  const [commitDialogOpen, setCommitDialogOpen] = useState(false);
   const [prDialogOpen, setPrDialogOpen] = useState(false);
   const [repoDialogOpen, setRepoDialogOpen] = useState(false);
   const [showDiffPanel, setShowDiffPanel] = useState(false);
@@ -671,6 +677,8 @@ export function SessionChatContent() {
     hadInitialMessages,
     diff,
     refreshDiff,
+    gitStatus,
+    refreshGitStatus,
     files,
     filesLoading,
     refreshFiles,
@@ -1272,6 +1280,7 @@ export function SessionChatContent() {
       isMountedRef.current
     ) {
       void requestStatusSync("force");
+      void refreshGitStatus().catch(() => {});
       void requestMarkChatRead("force");
       void refreshChats();
       if (
@@ -1291,6 +1300,7 @@ export function SessionChatContent() {
     setChatStreaming,
     clearChatTitle,
     requestStatusSync,
+    refreshGitStatus,
     requestMarkChatRead,
     refreshChats,
     router,
@@ -1518,9 +1528,16 @@ export function SessionChatContent() {
       // Fire-and-forget with error handling - SWR updates error state internally,
       // but we catch here to prevent unhandled rejection warnings.
       refreshDiff().catch(() => {});
+      refreshGitStatus().catch(() => {});
       refreshFiles().catch(() => {});
     }
-  }, [currentToolStates, messages, refreshDiff, refreshFiles]);
+  }, [
+    currentToolStates,
+    messages,
+    refreshDiff,
+    refreshGitStatus,
+    refreshFiles,
+  ]);
 
   // Note: SWR handles automatic fetching when sandbox becomes available
   // and caching/deduplication of requests
@@ -1674,6 +1691,29 @@ export function SessionChatContent() {
     isSandboxActive,
     reconnectionStatus,
   ]);
+
+  const hasRepo = Boolean(session.cloneUrl);
+  const hasExistingPr = session.prNumber != null;
+  const hasUncommittedGitChanges = gitStatus?.hasUncommittedChanges ?? false;
+  const hasUnpushedCommits = gitStatus?.hasUnpushedCommits ?? false;
+  const hasBranchDiff =
+    diff != null
+      ? diff.summary.totalAdditions > 0 || diff.summary.totalDeletions > 0
+      : (session.linesAdded ?? 0) > 0 || (session.linesRemoved ?? 0) > 0;
+  const isCreatePrBranchReady = Boolean(session?.branch);
+  const canCreatePr =
+    hasRepo && !hasExistingPr && !hasUncommittedGitChanges && hasBranchDiff;
+  const createPrDisabledReason = !isCreatePrBranchReady
+    ? "Waiting for branch info to sync"
+    : hasUncommittedGitChanges
+      ? "Commit and push changes before creating a pull request"
+      : !hasBranchDiff
+        ? "No committed branch changes yet"
+        : null;
+  const showCommitAction =
+    hasRepo &&
+    (hasUncommittedGitChanges || (hasExistingPr && hasUnpushedCommits));
+  const commitActionLabel = hasExistingPr ? "Commit & Push" : "Commit Changes";
 
   return (
     <>
@@ -1837,34 +1877,77 @@ export function SessionChatContent() {
                       </span>
                     </span>
                   )}
+                {hasUncommittedGitChanges && (
+                  <span
+                    className="ml-1 inline-block h-2 w-2 rounded-full bg-orange-500"
+                    aria-label="Uncommitted changes"
+                  />
+                )}
               </Button>
             )}
-            {session?.cloneUrl ? (
-              // Session has a repo - show PR buttons
-              session?.prNumber ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    const prUrl = `https://github.com/${session.repoOwner}/${session.repoName}/pull/${session.prNumber}`;
-                    window.open(prUrl, "_blank", "noopener,noreferrer");
-                  }}
-                >
-                  <GitPullRequest className="h-4 w-4 md:mr-2" />
-                  <span className="hidden md:inline">
-                    View PR #{session.prNumber}
-                  </span>
-                </Button>
+            {hasRepo ? (
+              hasExistingPr ? (
+                showCommitAction ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCommitDialogOpen(true)}
+                  >
+                    <GitCommit className="h-4 w-4 md:mr-2" />
+                    <span className="hidden md:inline">
+                      {commitActionLabel}
+                    </span>
+                  </Button>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      const prUrl = `https://github.com/${session.repoOwner}/${session.repoName}/pull/${session.prNumber}`;
+                      window.open(prUrl, "_blank", "noopener,noreferrer");
+                    }}
+                  >
+                    <GitPullRequest className="h-4 w-4 md:mr-2" />
+                    <span className="hidden md:inline">
+                      View PR #{session.prNumber}
+                    </span>
+                  </Button>
+                )
               ) : (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setPrDialogOpen(true)}
-                  disabled={!session?.branch}
-                >
-                  <GitPullRequest className="h-4 w-4 md:mr-2" />
-                  <span className="hidden md:inline">Create PR</span>
-                </Button>
+                <>
+                  {showCommitAction && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCommitDialogOpen(true)}
+                    >
+                      <GitCommit className="h-4 w-4 md:mr-2" />
+                      <span className="hidden md:inline">
+                        {commitActionLabel}
+                      </span>
+                    </Button>
+                  )}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setPrDialogOpen(true)}
+                          disabled={!canCreatePr || !isCreatePrBranchReady}
+                        >
+                          <GitPullRequest className="h-4 w-4 md:mr-2" />
+                          <span className="hidden md:inline">Create PR</span>
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    {createPrDisabledReason && (
+                      <TooltipContent side="bottom" sideOffset={8}>
+                        {createPrDisabledReason}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                </>
               )
             ) : !supportsRepoCreation ? null : (
               // Session has no repo - show Create Repo button (not available for in-memory sandboxes)
@@ -2396,6 +2479,24 @@ export function SessionChatContent() {
           hasSandbox={sandboxInfo !== null}
           onPrDetected={(pr) => {
             updateSessionPullRequest(pr);
+          }}
+        />
+      )}
+
+      {/* Commit Dialog */}
+      {session && (
+        <CommitDialog
+          open={commitDialogOpen}
+          onOpenChange={setCommitDialogOpen}
+          session={session}
+          hasSandbox={sandboxInfo !== null}
+          gitStatus={gitStatus}
+          refreshGitStatus={refreshGitStatus}
+          onOpenCreatePr={() => setPrDialogOpen(true)}
+          onCommitted={() => {
+            refreshGitStatus().catch(() => {});
+            refreshDiff().catch(() => {});
+            refreshFiles().catch(() => {});
           }}
         />
       )}

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -22,6 +22,10 @@ import type { SkillSuggestion } from "@/app/api/sessions/[sessionId]/skills/rout
 import type { WebAgentUIMessage } from "@/app/types";
 import { useSessionDiff } from "@/hooks/use-session-diff";
 import { useSessionFiles } from "@/hooks/use-session-files";
+import {
+  type SessionGitStatus,
+  useSessionGitStatus,
+} from "@/hooks/use-session-git-status";
 import { useSessionSkills } from "@/hooks/use-session-skills";
 import { AbortableChatTransport } from "@/lib/abortable-chat-transport";
 import {
@@ -129,6 +133,14 @@ type SessionChatContextValue = {
   diffCachedAt: Date | null;
   /** Trigger a diff refresh */
   refreshDiff: () => Promise<void>;
+  /** Git status for the current session workspace */
+  gitStatus: SessionGitStatus | null;
+  /** Whether git status is loading */
+  gitStatusLoading: boolean;
+  /** Git status error message */
+  gitStatusError: string | null;
+  /** Trigger a git status refresh */
+  refreshGitStatus: () => Promise<SessionGitStatus | undefined>;
   /** File suggestions from sandbox */
   files: FileSuggestion[] | null;
   /** Whether files are loading */
@@ -757,6 +769,13 @@ export function SessionChatProvider({
   });
 
   const {
+    gitStatus,
+    isLoading: gitStatusLoading,
+    error: gitStatusError,
+    refresh: refreshGitStatusSWR,
+  } = useSessionGitStatus(sessionRecord.id, sandboxConnected);
+
+  const {
     files,
     isLoading: filesLoading,
     error: filesError,
@@ -785,6 +804,10 @@ export function SessionChatProvider({
   const refreshDiff = useCallback(async () => {
     await refreshDiffSWR();
   }, [refreshDiffSWR]);
+
+  const refreshGitStatus = useCallback(async () => {
+    return refreshGitStatusSWR();
+  }, [refreshGitStatusSWR]);
 
   const refreshFiles = useCallback(async () => {
     await refreshFilesSWR();
@@ -964,6 +987,10 @@ export function SessionChatProvider({
       diffIsStale,
       diffCachedAt,
       refreshDiff,
+      gitStatus,
+      gitStatusLoading,
+      gitStatusError,
+      refreshGitStatus,
       files,
       filesLoading,
       filesError,
@@ -1007,6 +1034,10 @@ export function SessionChatProvider({
       diffIsStale,
       diffCachedAt,
       refreshDiff,
+      gitStatus,
+      gitStatusLoading,
+      gitStatusError,
+      refreshGitStatus,
       files,
       filesLoading,
       filesError,

--- a/apps/web/components/commit-dialog.tsx
+++ b/apps/web/components/commit-dialog.tsx
@@ -1,0 +1,648 @@
+"use client";
+
+import {
+  AlertCircle,
+  Check,
+  ExternalLink,
+  GitCommit,
+  Loader2,
+  Sparkles,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { type SessionGitStatus } from "@/hooks/use-session-git-status";
+import type { Session } from "@/lib/db/schema";
+
+interface CommitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  session: Session;
+  hasSandbox: boolean;
+  gitStatus: SessionGitStatus | null;
+  refreshGitStatus: () => Promise<SessionGitStatus | undefined>;
+  onCommitted?: () => void;
+  onOpenCreatePr?: () => void;
+}
+
+interface GitActions {
+  committed?: boolean;
+  commitMessage?: string;
+  commitSha?: string;
+  pushed?: boolean;
+  pushedToFork?: boolean;
+}
+
+type CommitStep = "loading" | "create-branch" | "commit" | "success";
+type CommitMode = "ai" | "manual";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function readBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+export function CommitDialog({
+  open,
+  onOpenChange,
+  session,
+  hasSandbox,
+  gitStatus,
+  refreshGitStatus,
+  onCommitted,
+  onOpenCreatePr,
+}: CommitDialogProps) {
+  const [baseBranch, setBaseBranch] = useState("main");
+  const [branches, setBranches] = useState<string[]>([]);
+  const [isLoadingBranches, setIsLoadingBranches] = useState(false);
+  const [isCheckingStatus, setIsCheckingStatus] = useState(false);
+  const [isCreatingBranch, setIsCreatingBranch] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [gitActions, setGitActions] = useState<GitActions | null>(null);
+  const [resolvedBranch, setResolvedBranch] = useState<string | null>(null);
+  const [isDetachedHead, setIsDetachedHead] = useState(false);
+  const [step, setStep] = useState<CommitStep>("loading");
+  const [mode, setMode] = useState<CommitMode>("ai");
+  const [manualTitle, setManualTitle] = useState("");
+  const [manualBody, setManualBody] = useState("");
+  const [prHeadOwner, setPrHeadOwner] = useState<string | null>(null);
+  const [statusSnapshot, setStatusSnapshot] = useState<SessionGitStatus | null>(
+    null,
+  );
+  const statusRequestIdRef = useRef(0);
+  const wasOpenRef = useRef(false);
+
+  const fetchBranches = useCallback(async () => {
+    if (!session.repoOwner || !session.repoName) return;
+    setIsLoadingBranches(true);
+
+    try {
+      const res = await fetch(
+        `/api/github/branches?owner=${session.repoOwner}&repo=${session.repoName}`,
+      );
+      if (!res.ok) {
+        throw new Error("Failed to fetch branches");
+      }
+
+      const data: unknown = await res.json();
+      if (!isRecord(data)) {
+        setBranches(["main"]);
+        return;
+      }
+
+      const nextBranches = Array.isArray(data.branches)
+        ? data.branches.filter(
+            (branch): branch is string => typeof branch === "string",
+          )
+        : [];
+      setBranches(nextBranches);
+
+      const defaultBranch = readString(data.defaultBranch);
+      if (defaultBranch) {
+        setBaseBranch(defaultBranch);
+      }
+    } catch (err) {
+      console.error("Failed to fetch branches:", err);
+      setBranches(["main"]);
+    } finally {
+      setIsLoadingBranches(false);
+    }
+  }, [session.repoName, session.repoOwner]);
+
+  const syncGitStatus = useCallback(async () => {
+    if (!hasSandbox) {
+      setStatusSnapshot(gitStatus);
+      setIsDetachedHead(false);
+      setIsCheckingStatus(false);
+      return;
+    }
+
+    const requestId = statusRequestIdRef.current + 1;
+    statusRequestIdRef.current = requestId;
+    setIsCheckingStatus(true);
+    setStep("loading");
+
+    try {
+      const latest = await refreshGitStatus();
+      if (requestId !== statusRequestIdRef.current) return;
+
+      const nextStatus = latest ?? gitStatus;
+      setStatusSnapshot(nextStatus);
+      if (nextStatus?.branch && nextStatus.branch !== "HEAD") {
+        setResolvedBranch(nextStatus.branch);
+      }
+      setIsDetachedHead(nextStatus?.isDetachedHead ?? false);
+    } catch (err) {
+      if (requestId !== statusRequestIdRef.current) return;
+      setError(
+        err instanceof Error ? err.message : "Failed to check git status",
+      );
+    } finally {
+      if (requestId === statusRequestIdRef.current) {
+        setIsCheckingStatus(false);
+      }
+    }
+  }, [gitStatus, hasSandbox, refreshGitStatus]);
+
+  useEffect(() => {
+    if (!open) {
+      wasOpenRef.current = false;
+      return;
+    }
+
+    if (wasOpenRef.current) {
+      return;
+    }
+
+    wasOpenRef.current = true;
+
+    setError(null);
+    setGitActions(null);
+    setResolvedBranch(null);
+    setIsDetachedHead(false);
+    setStep("loading");
+    setMode("ai");
+    setManualTitle("");
+    setManualBody("");
+    setPrHeadOwner(null);
+    setStatusSnapshot(gitStatus);
+
+    void fetchBranches();
+    void syncGitStatus();
+  }, [open, fetchBranches, gitStatus, syncGitStatus]);
+
+  const effectiveStatus = statusSnapshot ?? gitStatus;
+  const branchFromStatus =
+    resolvedBranch ??
+    (effectiveStatus?.branch && effectiveStatus.branch !== "HEAD"
+      ? effectiveStatus.branch
+      : null);
+  const currentBranch = branchFromStatus ?? session.branch ?? baseBranch;
+  const displayBranch = currentBranch === "HEAD" ? baseBranch : currentBranch;
+  const needsNewBranch = displayBranch === baseBranch || isDetachedHead;
+  const hasUncommittedChanges = effectiveStatus?.hasUncommittedChanges ?? false;
+  const hasUnpushedCommits = effectiveStatus?.hasUnpushedCommits ?? false;
+  const stagedCount = effectiveStatus?.stagedCount ?? 0;
+  const unstagedCount = effectiveStatus?.unstagedCount ?? 0;
+  const untrackedCount = effectiveStatus?.untrackedCount ?? 0;
+  const hasPendingGitWork = hasUncommittedChanges || hasUnpushedCommits;
+
+  useEffect(() => {
+    if (!open) return;
+    if (isCheckingStatus) {
+      setStep("loading");
+      return;
+    }
+    if (gitActions?.committed || gitActions?.pushed) {
+      setStep("success");
+      return;
+    }
+    if (needsNewBranch) {
+      setStep("create-branch");
+      return;
+    }
+    setStep("commit");
+  }, [open, isCheckingStatus, gitActions, needsNewBranch]);
+
+  const handleCreateBranch = async () => {
+    if (!hasSandbox) {
+      setError("Sandbox not active. Please wait for sandbox to start.");
+      return;
+    }
+
+    setIsCreatingBranch(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/generate-pr", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: session.id,
+          sessionTitle: session.title,
+          baseBranch,
+          branchName: displayBranch,
+          createBranchOnly: true,
+        }),
+      });
+
+      const data: unknown = await res.json();
+      const response = isRecord(data) ? data : null;
+      if (!res.ok) {
+        const message = response ? readString(response.error) : null;
+        throw new Error(message || "Failed to create branch");
+      }
+
+      const branchName = response ? readString(response.branchName) : null;
+      if (branchName && branchName !== "HEAD") {
+        setResolvedBranch(branchName);
+      }
+
+      setIsDetachedHead(false);
+      await syncGitStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create branch");
+    } finally {
+      setIsCreatingBranch(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!hasSandbox) {
+      setError("Sandbox not active. Please wait for sandbox to start.");
+      return;
+    }
+    if (!hasPendingGitWork) {
+      onOpenChange(false);
+      return;
+    }
+    if (mode === "manual" && hasUncommittedChanges && !manualTitle.trim()) {
+      setError("Commit title is required when using manual commit mode.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/generate-pr", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: session.id,
+          sessionTitle: session.title,
+          baseBranch,
+          branchName: displayBranch,
+          commitOnly: true,
+          ...(mode === "manual" && hasUncommittedChanges
+            ? {
+                commitTitle: manualTitle,
+                commitBody: manualBody,
+              }
+            : {}),
+        }),
+      });
+
+      const data: unknown = await res.json();
+      const response = isRecord(data) ? data : null;
+
+      if (!res.ok) {
+        const message = response ? readString(response.error) : null;
+        throw new Error(message || "Failed to commit and push changes");
+      }
+
+      const responseGitActions = response?.gitActions;
+      if (isRecord(responseGitActions)) {
+        setGitActions({
+          committed: readBoolean(responseGitActions.committed) ?? undefined,
+          commitMessage:
+            readString(responseGitActions.commitMessage) ?? undefined,
+          commitSha: readString(responseGitActions.commitSha) ?? undefined,
+          pushed: readBoolean(responseGitActions.pushed) ?? undefined,
+          pushedToFork:
+            readBoolean(responseGitActions.pushedToFork) ?? undefined,
+        });
+      }
+
+      const branchName = response ? readString(response.branchName) : null;
+      if (branchName && branchName !== "HEAD") {
+        setResolvedBranch(branchName);
+      }
+
+      const nextHeadOwner = response ? readString(response.prHeadOwner) : null;
+      if (nextHeadOwner) {
+        setPrHeadOwner(nextHeadOwner);
+      }
+
+      await syncGitStatus();
+      setStep("success");
+      onCommitted?.();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to commit and push changes",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const shouldEmphasizePush = Boolean(session.prNumber) || hasUnpushedCommits;
+  const submitLabel = hasUncommittedChanges
+    ? shouldEmphasizePush
+      ? "Commit & Push"
+      : "Commit changes"
+    : "Push commits";
+  const isDisabled = isCheckingStatus || isCreatingBranch || isSubmitting;
+
+  const commitOwner =
+    gitActions?.pushedToFork && prHeadOwner ? prHeadOwner : session.repoOwner;
+  const commitUrl =
+    gitActions?.commitSha && commitOwner && session.repoName
+      ? `https://github.com/${commitOwner}/${session.repoName}/commit/${gitActions.commitSha}`
+      : null;
+  const prUrl =
+    session.prNumber && session.repoOwner && session.repoName
+      ? `https://github.com/${session.repoOwner}/${session.repoName}/pull/${session.prNumber}`
+      : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Commit Changes</DialogTitle>
+          <DialogDescription>
+            {session.repoOwner}/{session.repoName} - {displayBranch}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {step === "loading" && (
+            <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 p-3 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Checking current git changes...
+            </div>
+          )}
+
+          {step === "create-branch" && (
+            <>
+              <div className="grid gap-2">
+                <Label htmlFor="base-branch">Base branch</Label>
+                <Select
+                  value={baseBranch}
+                  onValueChange={setBaseBranch}
+                  disabled={isDisabled || isLoadingBranches}
+                >
+                  <SelectTrigger id="base-branch" className="w-full">
+                    <SelectValue placeholder="Select base branch" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {isLoadingBranches ? (
+                      <SelectItem value="loading" disabled>
+                        Loading branches...
+                      </SelectItem>
+                    ) : (
+                      branches.map((branch) => (
+                        <SelectItem key={branch} value={branch}>
+                          {branch}
+                        </SelectItem>
+                      ))
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="rounded-md border border-border bg-muted/40 p-3 text-sm text-muted-foreground">
+                {isDetachedHead
+                  ? "You are in detached HEAD state. Create a branch before committing."
+                  : "You are on the base branch. Create a new branch before committing."}
+              </div>
+            </>
+          )}
+
+          {step === "commit" && (
+            <>
+              <div
+                className={
+                  hasPendingGitWork
+                    ? "flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm"
+                    : "flex items-start gap-2 rounded-md border border-border bg-muted/40 p-3 text-sm"
+                }
+              >
+                <AlertCircle
+                  className={
+                    hasPendingGitWork
+                      ? "mt-0.5 h-4 w-4 text-amber-500"
+                      : "mt-0.5 h-4 w-4 text-muted-foreground"
+                  }
+                />
+                <div className="space-y-1">
+                  <p
+                    className={
+                      hasPendingGitWork
+                        ? "font-medium text-amber-700 dark:text-amber-400"
+                        : "font-medium text-foreground"
+                    }
+                  >
+                    {hasPendingGitWork
+                      ? hasUncommittedChanges
+                        ? "Uncommitted changes detected"
+                        : "Unpushed commits detected"
+                      : "No pending git changes"}
+                  </p>
+                  <p className="text-muted-foreground">
+                    {`Unstaged: ${unstagedCount}, staged: ${stagedCount}, untracked: ${untrackedCount}`}
+                  </p>
+                </div>
+              </div>
+
+              {hasUncommittedChanges && (
+                <Tabs
+                  value={mode}
+                  onValueChange={(value) =>
+                    setMode(value === "manual" ? "manual" : "ai")
+                  }
+                  className="gap-3"
+                >
+                  <div className="grid gap-2">
+                    <Label>Commit mode</Label>
+                    <TabsList className="grid w-full grid-cols-2">
+                      <TabsTrigger value="ai">
+                        <Sparkles className="h-4 w-4" />
+                        AI message
+                      </TabsTrigger>
+                      <TabsTrigger value="manual">
+                        <GitCommit className="h-4 w-4" />
+                        Manual message
+                      </TabsTrigger>
+                    </TabsList>
+                  </div>
+
+                  <TabsContent value="ai" className="mt-0">
+                    <p className="text-sm text-muted-foreground">
+                      AI will generate a concise commit message from staged
+                      changes.
+                    </p>
+                  </TabsContent>
+
+                  <TabsContent value="manual" className="mt-0 grid gap-3">
+                    <div className="grid gap-2">
+                      <Label htmlFor="commit-title">Commit title</Label>
+                      <Input
+                        id="commit-title"
+                        placeholder="feat: add git panel improvements"
+                        value={manualTitle}
+                        onChange={(e) => setManualTitle(e.target.value)}
+                        disabled={isDisabled}
+                        maxLength={72}
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="commit-body">Commit description</Label>
+                      <Textarea
+                        id="commit-body"
+                        placeholder="Optional details for commit body"
+                        value={manualBody}
+                        onChange={(e) => setManualBody(e.target.value)}
+                        disabled={isDisabled}
+                        rows={4}
+                        className="resize-y max-h-48 overflow-y-auto field-sizing-fixed"
+                      />
+                    </div>
+                  </TabsContent>
+                </Tabs>
+              )}
+            </>
+          )}
+
+          {step === "success" && (
+            <div className="flex flex-col items-center gap-4 py-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10">
+                <Check className="h-6 w-6 text-green-500" />
+              </div>
+
+              <div className="space-y-2 text-center text-sm">
+                <p className="font-medium">Git changes updated successfully.</p>
+
+                {gitActions?.committed && gitActions.commitMessage && (
+                  <p>
+                    <span className="font-medium">Committed:</span>{" "}
+                    <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                      {gitActions.commitMessage}
+                    </code>
+                  </p>
+                )}
+
+                {gitActions?.pushed && (
+                  <p className="text-muted-foreground">
+                    {gitActions.pushedToFork
+                      ? "Pushed to fork remote"
+                      : "Pushed to origin"}
+                  </p>
+                )}
+
+                {commitUrl && (
+                  /* oxlint-disable-next-line nextjs/no-html-link-for-pages */
+                  <a
+                    href={commitUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm text-blue-500 hover:underline"
+                  >
+                    View commit
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                )}
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {step === "create-branch" && (
+            <Button
+              onClick={handleCreateBranch}
+              disabled={isDisabled || !hasSandbox}
+            >
+              {isCreatingBranch ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating branch...
+                </>
+              ) : (
+                "Create new branch"
+              )}
+            </Button>
+          )}
+
+          {step === "commit" && (
+            <>
+              {!hasPendingGitWork ? (
+                <Button variant="outline" onClick={() => onOpenChange(false)}>
+                  Close
+                </Button>
+              ) : (
+                <Button
+                  onClick={handleSubmit}
+                  disabled={isDisabled || !hasSandbox}
+                >
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      {hasUncommittedChanges ? "Committing..." : "Pushing..."}
+                    </>
+                  ) : (
+                    submitLabel
+                  )}
+                </Button>
+              )}
+            </>
+          )}
+
+          {step === "success" && (
+            <>
+              {!session.prNumber && onOpenCreatePr && (
+                <Button
+                  onClick={() => {
+                    onOpenChange(false);
+                    onOpenCreatePr();
+                  }}
+                >
+                  Create PR
+                </Button>
+              )}
+
+              {session.prNumber && prUrl && (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    window.open(prUrl, "_blank", "noopener,noreferrer");
+                  }}
+                >
+                  View PR
+                </Button>
+              )}
+
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/create-pr-dialog.tsx
+++ b/apps/web/components/create-pr-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  AlertCircle,
   Check,
   ExternalLink,
   GitCommit,
@@ -48,7 +47,7 @@ interface GitActions {
   pushedToFork?: boolean;
 }
 
-type WizardStep = "create-branch" | "commit" | "generate";
+type WizardStep = "create-branch" | "generate";
 
 function buildCompareUrl(params: {
   owner: string;
@@ -103,8 +102,6 @@ export function CreatePRDialog({
   const [isDetachedHead, setIsDetachedHead] = useState(false);
   const [isCheckingStatus, setIsCheckingStatus] = useState(false);
   const [step, setStep] = useState<WizardStep>("generate");
-  const [isCommitting, setIsCommitting] = useState(false);
-  const [uncommittedFileCount, setUncommittedFileCount] = useState(0);
   const [hasGenerated, setHasGenerated] = useState(false);
   const [prHeadOwner, setPrHeadOwner] = useState<string | null>(null);
 
@@ -121,7 +118,6 @@ export function CreatePRDialog({
       setHasUncommittedChanges(false);
       setIsDetachedHead(false);
       setStep("generate");
-      setUncommittedFileCount(0);
       setHasGenerated(false);
       setPrHeadOwner(null);
     }
@@ -141,7 +137,6 @@ export function CreatePRDialog({
         const data = await res.json();
         setHasUncommittedChanges(data.hasUncommittedChanges ?? false);
         setIsDetachedHead(data.isDetachedHead ?? false);
-        setUncommittedFileCount(data.uncommittedFiles ?? 0);
         if (data.branch && data.branch !== "HEAD") {
           setResolvedBranch(data.branch);
         }
@@ -177,13 +172,11 @@ export function CreatePRDialog({
     if (!isCheckingStatus && open) {
       if (needsNewBranch) {
         setStep("create-branch");
-      } else if (hasUncommittedChanges) {
-        setStep("commit");
       } else {
         setStep("generate");
       }
     }
-  }, [isCheckingStatus, open, needsNewBranch, hasUncommittedChanges]);
+  }, [isCheckingStatus, open, needsNewBranch]);
 
   const fetchBranches = useCallback(async () => {
     setIsLoadingBranches(true);
@@ -246,62 +239,13 @@ export function CreatePRDialog({
         setResolvedBranch(data.branchName as string);
         // Branch created successfully, no longer in detached HEAD state
         setIsDetachedHead(false);
-        // Advance to next step
-        if (hasUncommittedChanges) {
-          setStep("commit");
-        } else {
-          setStep("generate");
-        }
+        // Advance to PR generation step
+        setStep("generate");
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create branch");
     } finally {
       setIsCreatingBranch(false);
-    }
-  };
-
-  const handleCommit = async () => {
-    if (!hasSandbox) {
-      setError("Sandbox not active. Please wait for sandbox to start.");
-      return;
-    }
-    setIsCommitting(true);
-    setError(null);
-    try {
-      const res = await fetch("/api/generate-pr", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sessionId: session.id,
-          sessionTitle: session.title,
-          baseBranch,
-          branchName: displayBranch,
-          commitOnly: true,
-        }),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        throw new Error(data.error || "Failed to commit changes");
-      }
-
-      if (data.gitActions) {
-        setGitActions(data.gitActions);
-      }
-      if (typeof data.prHeadOwner === "string" && data.prHeadOwner.length > 0) {
-        setPrHeadOwner(data.prHeadOwner);
-      }
-      if (data.branchName && data.branchName !== "HEAD") {
-        setResolvedBranch(data.branchName as string);
-      }
-      // Advance to generate step
-      setHasUncommittedChanges(false);
-      setStep("generate");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to commit changes");
-    } finally {
-      setIsCommitting(false);
     }
   };
 
@@ -416,11 +360,7 @@ export function CreatePRDialog({
   };
 
   const isDisabled =
-    isGenerating ||
-    isCreating ||
-    isCreatingBranch ||
-    isCheckingStatus ||
-    isCommitting;
+    isGenerating || isCreating || isCreatingBranch || isCheckingStatus;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -505,26 +445,15 @@ export function CreatePRDialog({
                 </>
               )}
 
-              {/* Step: Commit Changes */}
-              {step === "commit" && (
-                <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
-                  <AlertCircle className="mt-0.5 h-4 w-4 text-amber-500" />
-                  <div>
-                    <p className="font-medium text-amber-700 dark:text-amber-400">
-                      {uncommittedFileCount > 0
-                        ? `${uncommittedFileCount} uncommitted ${uncommittedFileCount === 1 ? "file" : "files"}`
-                        : "Uncommitted changes detected"}
-                    </p>
-                    <p className="text-muted-foreground">
-                      Commit your changes before creating a pull request.
-                    </p>
-                  </div>
-                </div>
-              )}
-
               {/* Step: Generate PR */}
               {step === "generate" && (
                 <>
+                  {hasUncommittedChanges && (
+                    <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400">
+                      Commit your changes before creating a pull request.
+                    </div>
+                  )}
+
                   {/* Git Actions Banner */}
                   {gitActions &&
                     (gitActions.committed || gitActions.pushed) && (
@@ -617,30 +546,18 @@ export function CreatePRDialog({
                 </Button>
               )}
 
-              {/* Step: Commit - Footer */}
-              {step === "commit" && (
-                <Button
-                  onClick={handleCommit}
-                  disabled={isDisabled || !hasSandbox}
-                >
-                  {isCommitting ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Committing...
-                    </>
-                  ) : (
-                    "Commit changes"
-                  )}
-                </Button>
-              )}
-
               {/* Step: Generate PR - Footer */}
               {step === "generate" && (
                 <>
                   <Button
                     variant="outline"
                     onClick={handleGenerate}
-                    disabled={isDisabled || !hasSandbox || hasGenerated}
+                    disabled={
+                      isDisabled ||
+                      !hasSandbox ||
+                      hasGenerated ||
+                      hasUncommittedChanges
+                    }
                   >
                     {isGenerating ? (
                       <>
@@ -661,7 +578,9 @@ export function CreatePRDialog({
                   </Button>
                   <Button
                     onClick={handleCreate}
-                    disabled={isDisabled || !title.trim()}
+                    disabled={
+                      isDisabled || !title.trim() || hasUncommittedChanges
+                    }
                   >
                     {isCreating ? (
                       <>

--- a/apps/web/hooks/use-session-git-status.ts
+++ b/apps/web/hooks/use-session-git-status.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import useSWR from "swr";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function toSessionGitStatus(value: unknown): SessionGitStatus {
+  if (!isRecord(value)) {
+    throw new Error("Invalid git status response");
+  }
+
+  const branch = asOptionalString(value.branch);
+  if (!branch) {
+    throw new Error("Invalid git status response");
+  }
+
+  return {
+    branch,
+    isDetachedHead: value.isDetachedHead === true,
+    hasUncommittedChanges: value.hasUncommittedChanges === true,
+    hasUnpushedCommits: value.hasUnpushedCommits === true,
+    stagedCount: typeof value.stagedCount === "number" ? value.stagedCount : 0,
+    unstagedCount:
+      typeof value.unstagedCount === "number" ? value.unstagedCount : 0,
+    untrackedCount:
+      typeof value.untrackedCount === "number" ? value.untrackedCount : 0,
+    uncommittedFiles:
+      typeof value.uncommittedFiles === "number" ? value.uncommittedFiles : 0,
+  };
+}
+
+export interface SessionGitStatus {
+  branch: string;
+  isDetachedHead: boolean;
+  hasUncommittedChanges: boolean;
+  hasUnpushedCommits: boolean;
+  stagedCount: number;
+  unstagedCount: number;
+  untrackedCount: number;
+  uncommittedFiles: number;
+}
+
+export interface UseSessionGitStatusReturn {
+  gitStatus: SessionGitStatus | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<SessionGitStatus | undefined>;
+}
+
+async function fetchGitStatus(sessionId: string): Promise<SessionGitStatus> {
+  const res = await fetch("/api/git-status", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionId }),
+  });
+
+  if (!res.ok) {
+    const error = new Error("Failed to fetch git status");
+    try {
+      const data: unknown = await res.json();
+      if (isRecord(data)) {
+        const message = asOptionalString(data.error);
+        error.message = message ?? res.statusText;
+      } else {
+        error.message = res.statusText;
+      }
+    } catch {
+      error.message = res.statusText;
+    }
+    throw error;
+  }
+
+  const data: unknown = await res.json();
+  return toSessionGitStatus(data);
+}
+
+export function useSessionGitStatus(
+  sessionId: string,
+  sandboxConnected: boolean,
+): UseSessionGitStatusReturn {
+  const key = sandboxConnected ? (["git-status", sessionId] as const) : null;
+
+  const { data, error, isLoading, mutate } = useSWR<SessionGitStatus>(
+    key,
+    async ([, id]: readonly [string, string]) => fetchGitStatus(id),
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 1500,
+    },
+  );
+
+  return {
+    gitStatus: data ?? null,
+    isLoading,
+    error: error?.message ?? null,
+    refresh: mutate,
+  };
+}


### PR DESCRIPTION
## Summary
- add a commit-first git workflow in session chat with a dedicated Commit dialog and shadcn Tabs for AI vs manual commit messages
- gate PR creation on clean workspace + branch diff readiness, while keeping Create PR visible with clear disabled-state reasons
- improve git status handling and refresh behavior so modal states and header actions stay consistent after commits and pushes