### PR TITLE
fix: chunk resumable stream replay to avoid Upstash 10 MB limit

### DIFF
--- a/apps/web/lib/chunked-publisher-adapter.test.ts
+++ b/apps/web/lib/chunked-publisher-adapter.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createChunkedPublisherAdapter,
+  MAX_REPLAY_FRAME_CHARS,
+  type RedisLikeClient,
+} from "./chunked-publisher-adapter";
+
+/** Creates a mock Redis client that records all publish calls. */
+function createMockClient() {
+  const publishes: Array<{ channel: string; message: string }> = [];
+
+  const client: RedisLikeClient = {
+    publish: async (channel: string, message: string) => {
+      publishes.push({ channel, message });
+      return 1;
+    },
+    set: async () => "OK",
+    get: async () => null,
+    incr: async () => 1,
+  };
+
+  return { client, publishes };
+}
+
+describe("createChunkedPublisherAdapter", () => {
+  test("passes small messages through as a single publish", async () => {
+    const { client, publishes } = createMockClient();
+    const adapter = createChunkedPublisherAdapter(client);
+
+    await adapter.publish("ch", "hello");
+
+    expect(publishes).toHaveLength(1);
+    expect(publishes[0]).toEqual({ channel: "ch", message: "hello" });
+  });
+
+  test("passes empty string through as a single publish (resume ack)", async () => {
+    const { client, publishes } = createMockClient();
+    const adapter = createChunkedPublisherAdapter(client);
+
+    await adapter.publish("ch", "");
+
+    expect(publishes).toHaveLength(1);
+    expect(publishes[0]).toEqual({ channel: "ch", message: "" });
+  });
+
+  test("passes message exactly at the frame limit as a single publish", async () => {
+    const { client, publishes } = createMockClient();
+    const adapter = createChunkedPublisherAdapter(client);
+    const exactMessage = "x".repeat(MAX_REPLAY_FRAME_CHARS);
+
+    await adapter.publish("ch", exactMessage);
+
+    expect(publishes).toHaveLength(1);
+    expect(publishes[0]?.message).toBe(exactMessage);
+  });
+
+  test("chunks a message one char over the limit into two frames", async () => {
+    const { client, publishes } = createMockClient();
+    const adapter = createChunkedPublisherAdapter(client);
+    const message = "x".repeat(MAX_REPLAY_FRAME_CHARS + 1);
+
+    await adapter.publish("ch", message);
+
+    expect(publishes).toHaveLength(2);
+    expect(publishes[0]?.message.length).toBe(MAX_REPLAY_FRAME_CHARS);
+    expect(publishes[1]?.message.length).toBe(1);
+  });
+
+  test("chunks a large message and reconstructs the original", async () => {
+    const { client, publishes } = createMockClient();
+    const adapter = createChunkedPublisherAdapter(client);
+
+    // ~12 MB of characters -- well above the 10 MB Upstash limit
+    const totalChars = 12 * 1024 * 1024;
+    const message = "a".repeat(totalChars);
+
+    await adapter.publish("ch", message);
+
+    const expectedFrames = Math.ceil(totalChars / MAX_REPLAY_FRAME_CHARS);
+    expect(publishes).toHaveLength(expectedFrames);
+
+    // Reconstruct and verify byte-for-byte integrity
+    const reconstructed = publishes.map((p) => p.message).join("");
+    expect(reconstructed).toBe(message);
+  });
+
+  test("preserves ordering of frames", async () => {
+    const { client, publishes } = createMockClient();
+    const adapter = createChunkedPublisherAdapter(client);
+
+    // Build a message with distinct content per frame boundary
+    const frameCount = 5;
+    const parts = Array.from({ length: frameCount }, (_, i) =>
+      String(i).repeat(MAX_REPLAY_FRAME_CHARS),
+    );
+    const message = parts.join("");
+
+    await adapter.publish("ch", message);
+
+    expect(publishes).toHaveLength(frameCount);
+    for (let i = 0; i < frameCount; i++) {
+      expect(publishes[i]?.message).toBe(parts[i]);
+    }
+  });
+
+  test("publishes all frames to the same channel", async () => {
+    const { client, publishes } = createMockClient();
+    const adapter = createChunkedPublisherAdapter(client);
+    const message = "z".repeat(MAX_REPLAY_FRAME_CHARS * 3);
+
+    await adapter.publish("my-channel", message);
+
+    for (const p of publishes) {
+      expect(p.channel).toBe("my-channel");
+    }
+  });
+
+  test("delegates set, get, incr to the underlying client", async () => {
+    const { client } = createMockClient();
+    const adapter = createChunkedPublisherAdapter(client);
+
+    expect(await adapter.set("k", "v")).toBe("OK");
+    expect(await adapter.get("k")).toBe(null);
+    expect(await adapter.incr("k")).toBe(1);
+  });
+
+  test("set passes EX option correctly", async () => {
+    let capturedArgs: unknown[] = [];
+    const client: RedisLikeClient = {
+      publish: async () => 1,
+      set: async (...args: unknown[]) => {
+        capturedArgs = args;
+        return "OK";
+      },
+      get: async () => null,
+      incr: async () => 1,
+    };
+    const adapter = createChunkedPublisherAdapter(client);
+
+    await adapter.set("k", "v", { EX: 3600 });
+
+    expect(capturedArgs).toEqual(["k", "v", "EX", 3600]);
+  });
+});

--- a/apps/web/lib/chunked-publisher-adapter.test.ts
+++ b/apps/web/lib/chunked-publisher-adapter.test.ts
@@ -124,6 +124,36 @@ describe("createChunkedPublisherAdapter", () => {
     expect(await adapter.incr("k")).toBe(1);
   });
 
+  test("dispatches all frames synchronously before yielding", async () => {
+    // Simulates the upstream pattern where replay + DONE are dispatched via
+    // Promise.all. All replay frames must enter the pipeline before the caller
+    // can dispatch DONE, otherwise DONE arrives between frames.
+    const callOrder: string[] = [];
+
+    const client: RedisLikeClient = {
+      publish: async (_channel: string, message: string) => {
+        callOrder.push(message.startsWith("DONE") ? "DONE" : "frame");
+        return 1;
+      },
+      set: async () => "OK",
+      get: async () => null,
+      incr: async () => 1,
+    };
+    const adapter = createChunkedPublisherAdapter(client);
+
+    const bigMessage = "x".repeat(MAX_REPLAY_FRAME_CHARS * 3);
+    const DONE = "DONE_SENTINEL";
+
+    // Mirror upstream: push both publishes, then Promise.all
+    const promises: Array<Promise<number | unknown>> = [];
+    promises.push(adapter.publish("ch", bigMessage));
+    promises.push(adapter.publish("ch", DONE));
+    await Promise.all(promises);
+
+    // All 3 frames must appear before DONE
+    expect(callOrder).toEqual(["frame", "frame", "frame", "DONE"]);
+  });
+
   test("set passes EX option correctly", async () => {
     let capturedArgs: unknown[] = [];
     const client: RedisLikeClient = {

--- a/apps/web/lib/chunked-publisher-adapter.ts
+++ b/apps/web/lib/chunked-publisher-adapter.ts
@@ -1,0 +1,58 @@
+/**
+ * Maximum characters per replay publish frame. Conservative limit to stay
+ * well under Upstash's 10 MB request size cap even with multi-byte content.
+ * At worst case (4 bytes per char), a single frame is ~1 MB.
+ */
+export const MAX_REPLAY_FRAME_CHARS = 256 * 1024;
+
+/** Redis-like client interface covering the methods the publisher adapter needs. */
+export interface RedisLikeClient {
+  publish(channel: string, message: string): Promise<number>;
+  set(key: string, value: string, ...args: unknown[]): Promise<"OK" | unknown>;
+  get(key: string): Promise<string | null>;
+  incr(key: string): Promise<number>;
+}
+
+/**
+ * Creates a publisher adapter that chunks large PUBLISH payloads into
+ * sequential frames to avoid exceeding Upstash's 10 MB request size limit
+ * during stream replay.
+ *
+ * Small publishes (live chunks, done sentinel) pass through unchanged.
+ * Only replay payloads that exceed the frame cap are split.
+ */
+export function createChunkedPublisherAdapter(client: RedisLikeClient) {
+  return {
+    connect: () => Promise.resolve(),
+
+    publish: async (
+      channel: string,
+      message: string,
+    ): Promise<number | unknown> => {
+      if (message.length <= MAX_REPLAY_FRAME_CHARS) {
+        return client.publish(channel, message);
+      }
+
+      let offset = 0;
+      let lastResult: number | unknown = 0;
+
+      while (offset < message.length) {
+        const frame = message.slice(offset, offset + MAX_REPLAY_FRAME_CHARS);
+        lastResult = await client.publish(channel, frame);
+        offset += frame.length;
+      }
+
+      return lastResult;
+    },
+
+    set: (key: string, value: string, options?: { EX?: number }) => {
+      if (options?.EX) {
+        return client.set(key, value, "EX", options.EX);
+      }
+      return client.set(key, value);
+    },
+
+    get: (key: string) => client.get(key),
+    incr: (key: string) => client.incr(key),
+  };
+}

--- a/apps/web/lib/chunked-publisher-adapter.ts
+++ b/apps/web/lib/chunked-publisher-adapter.ts
@@ -33,16 +33,20 @@ export function createChunkedPublisherAdapter(client: RedisLikeClient) {
         return client.publish(channel, message);
       }
 
+      // Dispatch all frames synchronously so they enter the ioredis pipeline
+      // in order BEFORE this async function yields. This prevents the caller
+      // from interleaving a DONE_MESSAGE publish between frames.
       let offset = 0;
-      let lastResult: number | unknown = 0;
+      const framePromises: Array<Promise<number>> = [];
 
       while (offset < message.length) {
         const frame = message.slice(offset, offset + MAX_REPLAY_FRAME_CHARS);
-        lastResult = await client.publish(channel, frame);
+        framePromises.push(client.publish(channel, frame));
         offset += frame.length;
       }
 
-      return lastResult;
+      const results = await Promise.all(framePromises);
+      return results[results.length - 1];
     },
 
     set: (key: string, value: string, options?: { EX?: number }) => {

--- a/apps/web/lib/resumable-stream-context.ts
+++ b/apps/web/lib/resumable-stream-context.ts
@@ -1,6 +1,20 @@
+import { Redis } from "ioredis";
 import { after } from "next/server";
 import { createResumableStreamContext } from "resumable-stream/ioredis";
+import { createChunkedPublisherAdapter } from "./chunked-publisher-adapter";
+
+function getRedisUrl(): string {
+  const url = process.env.REDIS_URL || process.env.KV_URL;
+  if (!url) {
+    throw new Error(
+      "REDIS_URL or KV_URL environment variable is required for resumable streams",
+    );
+  }
+  return url;
+}
 
 export const resumableStreamContext = createResumableStreamContext({
   waitUntil: after,
+  publisher: createChunkedPublisherAdapter(new Redis(getRedisUrl())),
+  subscriber: new Redis(getRedisUrl()),
 });

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cc-clone-ai-sdk",

--- a/docs/plans/incomplete/resumable-stream-replay-chunking-plan.md
+++ b/docs/plans/incomplete/resumable-stream-replay-chunking-plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- Drafted
+- Implemented
 - Scope: fast safety fix only ("fix #1")
 
 ## Assumptions


### PR DESCRIPTION
## Summary

- Wraps the resumable-stream Redis publisher with a chunked adapter that splits oversized replay payloads into sequential 256 KB frames
- Fixes `ReplyError: ERR max request size exceeded` (observed at 91 MB vs 10 MB limit) and subsequent OOM crashes during stream resume
- Adds unit tests covering frame splitting, ordering, boundary conditions, and resume ack handshake preservation

## Problem

When a client reconnects to a resumable stream, the `resumable-stream` library joins all buffered chunks (`chunks.join("")`) and publishes the entire replay as a single Redis PUBLISH message. For large agent streams this can far exceed Upstash's 10 MB request size limit, causing the publish to be rejected and the serverless function to run out of memory.

## Approach

Rather than patching the upstream library, this adds a local publisher adapter (`chunked-publisher-adapter.ts`) that intercepts `publish` calls. Messages under 256 KB pass through unchanged (normal live chunks, done sentinel). Messages over the limit are sliced into sequential frames published in order on the same channel. The subscriber side already handles multiple messages per channel, so this is transparent.

## Changes

- `apps/web/lib/chunked-publisher-adapter.ts` -- new module with `createChunkedPublisherAdapter` and `MAX_REPLAY_FRAME_CHARS` constant
- `apps/web/lib/chunked-publisher-adapter.test.ts` -- 9 unit tests covering small/empty/exact/oversized messages, ordering, and delegation
- `apps/web/lib/resumable-stream-context.ts` -- uses the chunked adapter with explicit ioredis clients instead of library defaults
- `docs/plans/incomplete/resumable-stream-replay-chunking-plan.md` -- status updated to Implemented