### PR TITLE
fix: invalidate stale web sessions when user no longer exists

### DIFF
--- a/apps/web/app/api/auth/info/route.ts
+++ b/apps/web/app/api/auth/info/route.ts
@@ -1,36 +1,48 @@
+import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { getGitHubAccount } from "@/lib/db/accounts";
 import { getInstallationsByUserId } from "@/lib/db/installations";
+import { userExists } from "@/lib/db/users";
+import { SESSION_COOKIE_NAME } from "@/lib/session/constants";
 import { getSessionFromReq } from "@/lib/session/server";
 import type { SessionUserInfo } from "@/lib/session/types";
+
+const UNAUTHENTICATED: SessionUserInfo = { user: undefined };
 
 export async function GET(req: NextRequest) {
   const session = await getSessionFromReq(req);
 
-  let hasGitHub = false;
-  let hasGitHubAccount = false;
-  let hasGitHubInstallations = false;
-  if (session?.user?.id) {
-    const [ghAccount, installations] = await Promise.all([
-      getGitHubAccount(session.user.id),
-      getInstallationsByUserId(session.user.id),
-    ]);
-    hasGitHubAccount = ghAccount !== null;
-    hasGitHubInstallations = installations.length > 0;
-    hasGitHub = hasGitHubAccount || hasGitHubInstallations;
+  if (!session?.user?.id) {
+    return Response.json(UNAUTHENTICATED);
   }
 
-  const data: SessionUserInfo = session
-    ? {
-        user: session.user,
-        authProvider: session.authProvider,
-        hasGitHub,
-        hasGitHubAccount,
-        hasGitHubInstallations,
-      }
-    : { user: undefined };
+  // Run the user-existence check in parallel with the GitHub queries
+  // so there is zero added latency on the happy path.
+  const [exists, ghAccount, installations] = await Promise.all([
+    userExists(session.user.id),
+    getGitHubAccount(session.user.id),
+    getInstallationsByUserId(session.user.id),
+  ]);
 
-  return new Response(JSON.stringify(data), {
-    headers: { "Content-Type": "application/json" },
-  });
+  // The session cookie (JWE) is self-contained and can outlive the user record.
+  // If the user no longer exists, clear the stale cookie.
+  if (!exists) {
+    const store = await cookies();
+    store.delete(SESSION_COOKIE_NAME);
+    return Response.json(UNAUTHENTICATED);
+  }
+
+  const hasGitHubAccount = ghAccount !== null;
+  const hasGitHubInstallations = installations.length > 0;
+  const hasGitHub = hasGitHubAccount || hasGitHubInstallations;
+
+  const data: SessionUserInfo = {
+    user: session.user,
+    authProvider: session.authProvider,
+    hasGitHub,
+    hasGitHubAccount,
+    hasGitHubInstallations,
+  };
+
+  return Response.json(data);
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "sonner";
+import { Providers } from "./providers";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -31,7 +32,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} overflow-x-hidden antialiased`}
       >
-        {children}
+        <Providers>{children}</Providers>
         <Toaster theme="dark" />
       </body>
     </html>

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useRef } from "react";
+import { SWRConfig } from "swr";
+import { FetchError } from "@/lib/swr";
+
+/**
+ * Global providers for the app. Wraps children in SWRConfig with a
+ * global error handler that detects 401 responses and signs the user out.
+ */
+export function Providers({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const signingOut = useRef(false);
+
+  const handleError = useCallback(
+    (error: Error) => {
+      if (
+        error instanceof FetchError &&
+        error.status === 401 &&
+        !signingOut.current
+      ) {
+        signingOut.current = true;
+        // POST to the signout endpoint to clear the session cookie,
+        // then redirect to the home page.
+        fetch("/api/auth/signout", { method: "POST", redirect: "manual" })
+          .catch(() => {
+            // If signout fails, navigate anyway so the user isn't stuck.
+          })
+          .finally(() => {
+            signingOut.current = false;
+            router.replace("/");
+            router.refresh();
+          });
+      }
+    },
+    [router],
+  );
+
+  return <SWRConfig value={{ onError: handleError }}>{children}</SWRConfig>;
+}

--- a/apps/web/lib/db/users.ts
+++ b/apps/web/lib/db/users.ts
@@ -1,7 +1,20 @@
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
 import { db } from "./client";
 import { users } from "./schema";
-import { eq, and } from "drizzle-orm";
-import { nanoid } from "nanoid";
+
+/**
+ * Check if a user exists in the database by ID.
+ * Returns true if found, false otherwise. Lightweight query (only fetches the ID).
+ */
+export async function userExists(userId: string): Promise<boolean> {
+  const result = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return result.length > 0;
+}
 
 export async function upsertUser(userData: {
   provider: "github" | "vercel";

--- a/apps/web/lib/swr.test.ts
+++ b/apps/web/lib/swr.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { FetchError, fetcher } from "./swr";
+
+// Store the original global fetch so we can restore it.
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// FetchError
+// ---------------------------------------------------------------------------
+describe("FetchError", () => {
+  test("stores status and message", () => {
+    const err = new FetchError("Not Found", 404);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("FetchError");
+    expect(err.message).toBe("Not Found");
+    expect(err.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetcher
+// ---------------------------------------------------------------------------
+describe("fetcher", () => {
+  function mockFetch(response: {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    json?: () => Promise<unknown>;
+  }) {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(response as Response),
+    ) as unknown as typeof fetch;
+  }
+
+  test("returns parsed JSON on success", async () => {
+    mockFetch({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.resolve({ hello: "world" }),
+    });
+
+    const data = await fetcher<{ hello: string }>("https://example.com/api");
+    expect(data).toEqual({ hello: "world" });
+  });
+
+  test("throws FetchError with status on non-OK response", async () => {
+    mockFetch({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: () => Promise.resolve({}),
+    });
+
+    try {
+      await fetcher("https://example.com/api");
+      throw new Error("expected fetcher to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FetchError);
+      expect((err as FetchError).status).toBe(401);
+    }
+  });
+
+  test("extracts error message from JSON body", async () => {
+    mockFetch({
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      json: () => Promise.resolve({ error: "Validation failed" }),
+    });
+
+    try {
+      await fetcher("https://example.com/api");
+      throw new Error("expected fetcher to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FetchError);
+      expect((err as FetchError).message).toBe("Validation failed");
+      expect((err as FetchError).status).toBe(422);
+    }
+  });
+
+  test("falls back to statusText when JSON parsing fails", async () => {
+    mockFetch({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.reject(new Error("not json")),
+    });
+
+    try {
+      await fetcher("https://example.com/api");
+      throw new Error("expected fetcher to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FetchError);
+      expect((err as FetchError).message).toBe("Internal Server Error");
+      expect((err as FetchError).status).toBe(500);
+    }
+  });
+});

--- a/apps/web/lib/swr.ts
+++ b/apps/web/lib/swr.ts
@@ -1,18 +1,33 @@
 /**
+ * Error class that preserves the HTTP status code from failed fetch requests.
+ * Used by the global SWR error handler to detect 401s and trigger sign-out.
+ */
+export class FetchError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "FetchError";
+    this.status = status;
+  }
+}
+
+/**
  * Default fetcher for SWR hooks.
  * Parses JSON responses and extracts error messages from failed requests.
+ * Throws FetchError (with HTTP status) on non-OK responses.
  */
 export const fetcher = async <T>(url: string): Promise<T> => {
   const res = await fetch(url);
   if (!res.ok) {
-    const error = new Error("Fetch failed");
+    let message = res.statusText;
     try {
       const data = (await res.json()) as { error?: string };
-      error.message = data.error ?? res.statusText;
+      message = data.error ?? res.statusText;
     } catch {
-      error.message = res.statusText;
+      // keep statusText
     }
-    throw error;
+    throw new FetchError(message, res.status);
   }
   return res.json() as Promise<T>;
 };


### PR DESCRIPTION
## Summary

- Validate that the session's user still exists in the DB on every `/api/auth/info` call (runs in parallel with existing GitHub queries -- zero added latency on the happy path)
- Clear the session cookie and return unauthenticated if the user record is gone
- Add a global SWR error handler (`Providers` component) that automatically signs the user out when any API route returns 401

**Problem**: The web session is a self-contained JWE cookie (valid for 1 year). If the user is deleted from the DB or the session becomes stale, the cookie still decrypts fine and the UI shows them as logged in, but nothing works.

## Changes

- `apps/web/lib/db/users.ts` -- added `userExists()` for lightweight primary-key lookup
- `apps/web/app/api/auth/info/route.ts` -- validates user exists in DB (parallel with GitHub queries), clears cookie if not
- `apps/web/lib/swr.ts` -- added `FetchError` class that preserves HTTP status codes
- `apps/web/app/providers.tsx` -- new `Providers` component with `SWRConfig` global `onError` handler for 401s
- `apps/web/app/layout.tsx` -- wrapped children in `<Providers>`