### PR TITLE
fix(web): stabilize streaming chat render keys

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -148,17 +148,41 @@ type MessageRenderGroup =
       type: "part";
       part: WebAgentUIMessagePart;
       index: number;
+      renderKey: string;
     }
   | {
       type: "task-group";
       tasks: TaskToolUIPart[];
       startIndex: number;
+      renderKey: string;
     };
 
 interface GroupedRenderMessage {
   message: WebAgentUIMessage;
   groups: MessageRenderGroup[];
   isStreaming: boolean;
+}
+
+function getPartIdentity(part: WebAgentUIMessagePart): string {
+  if (isToolUIPart(part)) {
+    return part.toolCallId ? `tool:${part.toolCallId}` : `tool:${part.type}`;
+  }
+
+  if (isReasoningUIPart(part)) {
+    return "reasoning";
+  }
+
+  if (part.type === "text") {
+    return "text";
+  }
+
+  if (part.type === "file") {
+    if (part.url) return `file:${part.url}`;
+    if (part.filename) return `file:${part.filename}`;
+    return "file";
+  }
+
+  return `part:${part.type}`;
 }
 
 type CreateSandboxResponse = SandboxInfo & {
@@ -831,6 +855,38 @@ export function SessionChatContent() {
       const groups: MessageRenderGroup[] = [];
       let currentTaskGroup: TaskToolUIPart[] = [];
       let taskGroupStartIndex = 0;
+      let taskGroupOrdinal = 0;
+      const partIdentityCounts = new Map<string, number>();
+
+      const getStablePartRenderKey = (part: WebAgentUIMessagePart): string => {
+        const identity = getPartIdentity(part);
+
+        if (isToolUIPart(part) && part.toolCallId) {
+          return identity;
+        }
+
+        const count = partIdentityCounts.get(identity) ?? 0;
+        partIdentityCounts.set(identity, count + 1);
+        return `${identity}:${count}`;
+      };
+
+      const flushTaskGroup = () => {
+        if (currentTaskGroup.length === 0) return;
+
+        const firstTaskId =
+          currentTaskGroup.find((task) => task.toolCallId)?.toolCallId ?? null;
+
+        groups.push({
+          type: "task-group",
+          tasks: currentTaskGroup,
+          startIndex: taskGroupStartIndex,
+          renderKey: firstTaskId
+            ? `task-group:${firstTaskId}`
+            : `task-group:${taskGroupOrdinal}`,
+        });
+        currentTaskGroup = [];
+        taskGroupOrdinal += 1;
+      };
 
       message.parts.forEach((part, index) => {
         if (isToolUIPart(part) && part.type === "tool-task") {
@@ -841,25 +897,16 @@ export function SessionChatContent() {
           return;
         }
 
-        if (currentTaskGroup.length > 0) {
-          groups.push({
-            type: "task-group",
-            tasks: currentTaskGroup,
-            startIndex: taskGroupStartIndex,
-          });
-          currentTaskGroup = [];
-        }
-
-        groups.push({ type: "part", part, index });
+        flushTaskGroup();
+        groups.push({
+          type: "part",
+          part,
+          index,
+          renderKey: getStablePartRenderKey(part),
+        });
       });
 
-      if (currentTaskGroup.length > 0) {
-        groups.push({
-          type: "task-group",
-          tasks: currentTaskGroup,
-          startIndex: taskGroupStartIndex,
-        });
-      }
+      flushTaskGroup();
 
       return {
         message,
@@ -2106,7 +2153,7 @@ export function SessionChatContent() {
                     if (group.type === "task-group") {
                       return (
                         <div
-                          key={`${m.id}-task-group-${group.startIndex}`}
+                          key={`${m.id}-${group.renderKey}`}
                           className="max-w-full"
                         >
                           <TaskGroupView
@@ -2133,12 +2180,11 @@ export function SessionChatContent() {
                     }
 
                     const p = group.part;
-                    const i = group.index;
 
                     if (isReasoningUIPart(p)) {
                       return (
                         <div
-                          key={`${m.id}-${i}`}
+                          key={`${m.id}-${group.renderKey}`}
                           className="flex justify-start"
                         >
                           <ThinkingBlock
@@ -2154,7 +2200,7 @@ export function SessionChatContent() {
                     if (p.type === "text") {
                       return (
                         <div
-                          key={`${m.id}-${i}`}
+                          key={`${m.id}-${group.renderKey}`}
                           className={cn(
                             "flex min-w-0",
                             m.role === "user" ? "justify-end" : "justify-start",
@@ -2190,7 +2236,7 @@ export function SessionChatContent() {
 
                     if (isToolUIPart(p)) {
                       return (
-                        <div key={`${m.id}-${i}`} className="max-w-full">
+                        <div key={`${m.id}-${group.renderKey}`} className="max-w-full">
                           <ToolCall
                             part={p as WebAgentUIToolPart}
                             isStreaming={isMessageStreaming}
@@ -2215,7 +2261,7 @@ export function SessionChatContent() {
                       p.mediaType?.startsWith("image/")
                     ) {
                       return (
-                        <div key={`${m.id}-${i}`} className="flex justify-end">
+                        <div key={`${m.id}-${group.renderKey}`} className="flex justify-end">
                           <div className="max-w-[80%]">
                             {/* eslint-disable-next-line @next/next/no-img-element -- Data URLs not supported by next/image */}
                             <img

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -2236,7 +2236,10 @@ export function SessionChatContent() {
 
                     if (isToolUIPart(p)) {
                       return (
-                        <div key={`${m.id}-${group.renderKey}`} className="max-w-full">
+                        <div
+                          key={`${m.id}-${group.renderKey}`}
+                          className="max-w-full"
+                        >
                           <ToolCall
                             part={p as WebAgentUIToolPart}
                             isStreaming={isMessageStreaming}
@@ -2261,7 +2264,10 @@ export function SessionChatContent() {
                       p.mediaType?.startsWith("image/")
                     ) {
                       return (
-                        <div key={`${m.id}-${group.renderKey}`} className="flex justify-end">
+                        <div
+                          key={`${m.id}-${group.renderKey}`}
+                          className="flex justify-end"
+                        >
                           <div className="max-w-[80%]">
                             {/* eslint-disable-next-line @next/next/no-img-element -- Data URLs not supported by next/image */}
                             <img

--- a/apps/web/components/tool-call/renderers/glob-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/glob-renderer.tsx
@@ -55,8 +55,8 @@ export function GlobRenderer({
           Files ({files.length})
         </div>
         <div className="max-h-64 overflow-auto rounded border border-border bg-muted p-2 font-mono text-xs">
-          {files.map((file, i) => (
-            <div key={i} className="text-foreground">
+          {files.map((file) => (
+            <div key={file.path} className="text-foreground">
               {file?.path}
             </div>
           ))}

--- a/apps/web/components/tool-call/renderers/grep-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/grep-renderer.tsx
@@ -67,8 +67,11 @@ export function GrepRenderer({
           Matches ({matches.length})
         </div>
         <div className="max-h-64 space-y-1 overflow-auto rounded border border-border bg-muted p-2 font-mono text-xs">
-          {matches.map((match, i) => (
-            <div key={i} className="text-foreground">
+          {matches.map((match) => (
+            <div
+              key={`${match.file}:${match.line}:${match.content ?? ""}`}
+              className="text-foreground"
+            >
               <span className="text-muted-foreground">{match.file}</span>
               <span className="text-yellow-500">:{match.line}</span>
               {match.content && (

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -13,6 +13,40 @@ import { ApprovalButtons } from "../approval-buttons";
 
 type SubagentMessagePart = SubagentUIMessage["parts"][number];
 
+type KeyedSubagentPart = {
+  part: SubagentMessagePart;
+  renderKey: string;
+};
+
+function getRelevantPartRenderEntries(
+  messageParts: SubagentMessagePart[],
+): KeyedSubagentPart[] {
+  const entries: KeyedSubagentPart[] = [];
+  let textOrdinal = 0;
+  let toolOrdinal = 0;
+
+  for (const part of messageParts) {
+    if (isToolUIPart(part)) {
+      entries.push({
+        part,
+        renderKey: part.toolCallId ?? `tool:${part.type}:${toolOrdinal}`,
+      });
+      toolOrdinal += 1;
+      continue;
+    }
+
+    if (isTextUIPart(part)) {
+      entries.push({
+        part,
+        renderKey: `text:${textOrdinal}`,
+      });
+      textOrdinal += 1;
+    }
+  }
+
+  return entries;
+}
+
 function getToolSummary(part: SubagentMessagePart): string {
   switch (part.type) {
     case "tool-read":
@@ -120,15 +154,14 @@ export function TaskRenderer({
   const message = hasOutput ? part.output : undefined;
 
   const messageParts = message?.parts ?? [];
-  const relevantParts = messageParts.filter(
-    (p) => isToolUIPart(p) || isTextUIPart(p),
-  );
+  const relevantPartEntries = getRelevantPartRenderEntries(messageParts);
+  const relevantParts = relevantPartEntries.map((entry) => entry.part);
   const toolParts = messageParts.filter(isToolUIPart);
   const textParts = messageParts.filter(isTextUIPart);
 
   const maxVisible = 4;
-  const hiddenCount = Math.max(0, relevantParts.length - maxVisible);
-  const visibleParts = relevantParts.slice(-maxVisible);
+  const hiddenCount = Math.max(0, relevantPartEntries.length - maxVisible);
+  const visibleParts = relevantPartEntries.slice(-maxVisible);
 
   const isComplete = hasOutput && !isPreliminary;
   const isTaskStreaming = hasOutput && isPreliminary;
@@ -254,9 +287,9 @@ export function TaskRenderer({
               ... {hiddenCount} more above
             </div>
           )}
-          {visibleParts.map((p, i) => {
+          {visibleParts.map(({ part: p, renderKey }) => {
             if (isToolUIPart(p)) {
-              return <SubagentToolCall key={p.toolCallId ?? i} part={p} />;
+              return <SubagentToolCall key={renderKey} part={p} />;
             }
             if (isTextUIPart(p)) {
               const text = p.text?.trim() ?? "";
@@ -265,7 +298,7 @@ export function TaskRenderer({
                 text.length > 80 ? text.slice(0, 80) + "..." : text;
               return (
                 <div
-                  key={`text-${i}`}
+                  key={renderKey}
                   className="border-l-2 border-border py-1 pl-3 text-sm text-muted-foreground"
                 >
                   {truncated}
@@ -309,14 +342,10 @@ export function TaskRenderer({
                 Tool Calls ({toolParts.length})
               </div>
               <div className="max-h-96 space-y-1 overflow-auto">
-                {relevantParts.map((p, i) => {
+                {relevantPartEntries.map(({ part: p, renderKey }) => {
                   if (isToolUIPart(p)) {
                     return (
-                      <SubagentToolCall
-                        key={p.toolCallId ?? i}
-                        part={p}
-                        expanded
-                      />
+                      <SubagentToolCall key={renderKey} part={p} expanded />
                     );
                   }
                   if (isTextUIPart(p)) {
@@ -324,7 +353,7 @@ export function TaskRenderer({
                     if (!text) return null;
                     return (
                       <div
-                        key={`text-${i}`}
+                        key={renderKey}
                         className="border-l-2 border-border py-1 pl-3 text-sm text-muted-foreground"
                       >
                         {text}

--- a/apps/web/components/tool-call/renderers/todo-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/todo-renderer.tsx
@@ -70,35 +70,43 @@ export function TodoRenderer({
       {/* Expanded full content */}
       {isExpanded && todos.length > 0 && (
         <div className="mt-3 space-y-1 border-t border-border pt-3">
-          {todos.map((todo, index) => {
-            if (!todo) return null;
-            return (
-              <div
-                key={`${keyPrefix}-${index}`}
-                className="flex items-center gap-2"
-              >
-                {todo.status === "completed" ? (
-                  <CheckSquare className="h-4 w-4 text-green-500" />
-                ) : todo.status === "in_progress" ? (
-                  <Circle className="h-4 w-4 fill-yellow-500 text-yellow-500" />
-                ) : (
-                  <Square className="h-4 w-4 text-muted-foreground" />
-                )}
-                <span
-                  className={cn(
-                    "text-sm",
-                    todo.status === "completed"
-                      ? "text-muted-foreground line-through"
-                      : todo.status === "in_progress"
-                        ? "text-yellow-500"
-                        : "text-foreground",
-                  )}
+          {(() => {
+            const todoContentCounts = new Map<string, number>();
+            return todos.map((todo) => {
+              if (!todo) return null;
+
+              const contentKey = todo.content ?? "";
+              const occurrence = todoContentCounts.get(contentKey) ?? 0;
+              todoContentCounts.set(contentKey, occurrence + 1);
+
+              return (
+                <div
+                  key={`${keyPrefix}-${contentKey}-${occurrence}`}
+                  className="flex items-center gap-2"
                 >
-                  {todo.content}
-                </span>
-              </div>
-            );
-          })}
+                  {todo.status === "completed" ? (
+                    <CheckSquare className="h-4 w-4 text-green-500" />
+                  ) : todo.status === "in_progress" ? (
+                    <Circle className="h-4 w-4 fill-yellow-500 text-yellow-500" />
+                  ) : (
+                    <Square className="h-4 w-4 text-muted-foreground" />
+                  )}
+                  <span
+                    className={cn(
+                      "text-sm",
+                      todo.status === "completed"
+                        ? "text-muted-foreground line-through"
+                        : todo.status === "in_progress"
+                          ? "text-yellow-500"
+                          : "text-foreground",
+                    )}
+                  >
+                    {todo.content}
+                  </span>
+                </div>
+              );
+            });
+          })()}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- replace index-based chat render keys with stable per-part/group keys during streaming
- key task groups by tool call identity when available
- prevent assistant blocks from remounting/flickering when streamed parts shift indexes

## Testing
- manual verification recommended in chat streaming UI
- `turbo typecheck --filter=web` (blocked by unrelated repo issue: missing `vaul` module/types in `apps/web/components/ui/drawer.tsx`)
