### PR TITLE
Hydrate session diff button from cached server diff

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
@@ -94,16 +94,10 @@ export default async function SessionChatPage({
     notFound();
   }
   const initialMessages = dbMessages.map((m) => m.parts as WebAgentUIMessage);
-  const sessionForClient = {
-    ...sessionRecord,
-    cachedDiff: null,
-    cachedDiffUpdatedAt: null,
-  };
-
   return (
     <DiffsProvider>
       <SessionChatProvider
-        session={sessionForClient}
+        session={sessionRecord}
         chat={chat}
         initialMessages={initialMessages}
       >


### PR DESCRIPTION
## Summary
- stop clearing `cachedDiff` and `cachedDiffUpdatedAt` on the session chat page before passing session data to the client provider
- allow the session nav Diff button to render from server-fetched cached diff data immediately
- keep the existing client diff fetch as a refresh path

## Testing
- not run (small server-page prop change)
