### PR TITLE
Use vercelLight theme for code plugin first theme

### DIFF
--- a/apps/web/lib/streamdown-config.test.ts
+++ b/apps/web/lib/streamdown-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeStreamdownHighlightResult } from "./streamdown-config";
+
+describe("normalizeStreamdownHighlightResult", () => {
+  test("normalizes dual-theme fg/bg and token styles", () => {
+    const input: Parameters<typeof normalizeStreamdownHighlightResult>[0] = {
+      bg: "#ffffff;--shiki-dark-bg:#0a0a0a",
+      fg: "#171717;--shiki-dark:#ededed",
+      rootStyle: "font-style:normal",
+      themeName: "vercel-light vercel-dark",
+      tokens: [
+        [
+          {
+            bgColor: "#ffffff",
+            color: "#bd2864",
+            content: "const",
+            htmlStyle: {
+              "background-color": "#ffffff;--shiki-dark-bg:#0a0a0a",
+              color: "#bd2864;--shiki-dark:#f75f8f",
+            },
+            offset: 0,
+          },
+        ],
+      ],
+    };
+
+    const normalized = normalizeStreamdownHighlightResult(input);
+    const [token] = normalized.tokens[0];
+
+    expect(normalized.fg).toBe("#171717");
+    expect(normalized.bg).toBe("#ffffff");
+    expect(normalized.rootStyle).toContain("font-style:normal");
+    expect(normalized.rootStyle).toContain("--shiki-dark:#ededed");
+    expect(normalized.rootStyle).toContain("--shiki-dark-bg:#0a0a0a");
+    expect(token.color).toBe("#bd2864");
+    expect(token.bgColor).toBe("#ffffff");
+    expect(token.htmlStyle?.color).toBeUndefined();
+    expect(token.htmlStyle?.["background-color"]).toBeUndefined();
+    expect(token.htmlStyle?.["--shiki-dark"]).toBe("#f75f8f");
+    expect(token.htmlStyle?.["--shiki-dark-bg"]).toBe("#0a0a0a");
+  });
+});

--- a/apps/web/lib/streamdown-config.tsx
+++ b/apps/web/lib/streamdown-config.tsx
@@ -1,8 +1,154 @@
 import { createCodePlugin } from "@streamdown/code";
-import { vercelLight, vercelDark } from "./vercel-themes";
+import { vercelDark, vercelLight } from "./vercel-themes";
+
+const baseCodePlugin = createCodePlugin({
+  themes: [vercelLight, vercelDark],
+});
+
+type HighlightOptions = Parameters<typeof baseCodePlugin.highlight>[0];
+type HighlightResult = NonNullable<ReturnType<typeof baseCodePlugin.highlight>>;
+type HighlightCallback = (result: HighlightResult) => void;
+type HighlightLine = HighlightResult["tokens"][number];
+type HighlightToken = HighlightLine[number];
+
+type CssDeclarations = Record<string, string>;
+
+function parseCssValue(value: string): {
+  baseValue: string | undefined;
+  declarations: CssDeclarations;
+} {
+  const declarations: CssDeclarations = {};
+  let baseValue: string | undefined;
+
+  for (const rawSegment of value.split(";")) {
+    const segment = rawSegment.trim();
+    if (!segment) {
+      continue;
+    }
+
+    const separatorIndex = segment.indexOf(":");
+    if (separatorIndex === -1) {
+      if (!baseValue) {
+        baseValue = segment;
+      }
+      continue;
+    }
+
+    const property = segment.slice(0, separatorIndex).trim();
+    const propertyValue = segment.slice(separatorIndex + 1).trim();
+    if (!property || !propertyValue) {
+      continue;
+    }
+
+    declarations[property] = propertyValue;
+  }
+
+  return { baseValue, declarations };
+}
+
+function normalizeThemeValue(
+  value: string | undefined,
+  rootDeclarations: CssDeclarations,
+): string | undefined {
+  if (!value) {
+    return value;
+  }
+
+  const { baseValue, declarations } = parseCssValue(value);
+  for (const [property, propertyValue] of Object.entries(declarations)) {
+    rootDeclarations[property] = propertyValue;
+  }
+
+  return baseValue;
+}
+
+function normalizeHighlightResult(result: HighlightResult): HighlightResult {
+  const rootDeclarations: CssDeclarations = {};
+  const fg = normalizeThemeValue(result.fg, rootDeclarations);
+  const bg = normalizeThemeValue(result.bg, rootDeclarations);
+
+  const tokens: HighlightResult["tokens"] = result.tokens.map(
+    (line: HighlightLine) =>
+      line.map((token: HighlightToken) => {
+        const htmlStyle = token.htmlStyle ? { ...token.htmlStyle } : undefined;
+        let color = token.color;
+        let bgColor = token.bgColor;
+
+        if (htmlStyle) {
+          const rawColor = htmlStyle.color;
+          if (typeof rawColor === "string") {
+            const { baseValue, declarations } = parseCssValue(rawColor);
+            if (baseValue) {
+              color = baseValue;
+            }
+            for (const [property, propertyValue] of Object.entries(
+              declarations,
+            )) {
+              htmlStyle[property] = propertyValue;
+            }
+            delete htmlStyle.color;
+          }
+
+          const rawBackgroundColor = htmlStyle["background-color"];
+          if (typeof rawBackgroundColor === "string") {
+            const { baseValue, declarations } =
+              parseCssValue(rawBackgroundColor);
+            if (baseValue) {
+              bgColor = baseValue;
+            }
+            for (const [property, propertyValue] of Object.entries(
+              declarations,
+            )) {
+              htmlStyle[property] = propertyValue;
+            }
+            delete htmlStyle["background-color"];
+          }
+        }
+
+        return {
+          ...token,
+          bgColor,
+          color,
+          htmlStyle,
+        };
+      }),
+  );
+
+  const rootStyleParts: string[] = [];
+  if (typeof result.rootStyle === "string" && result.rootStyle.length > 0) {
+    rootStyleParts.push(result.rootStyle);
+  }
+
+  for (const [property, propertyValue] of Object.entries(rootDeclarations)) {
+    rootStyleParts.push(`${property}:${propertyValue}`);
+  }
+
+  const rootStyle =
+    rootStyleParts.length > 0 ? rootStyleParts.join(";") : result.rootStyle;
+
+  return {
+    ...result,
+    bg,
+    fg,
+    rootStyle,
+    tokens,
+  };
+}
+
+const codePlugin = {
+  ...baseCodePlugin,
+  highlight(options: HighlightOptions, callback?: HighlightCallback) {
+    const normalizedCallback: HighlightCallback | undefined = callback
+      ? (result) => {
+          callback(normalizeHighlightResult(result));
+        }
+      : undefined;
+
+    const result = baseCodePlugin.highlight(options, normalizedCallback);
+    return result ? normalizeHighlightResult(result) : null;
+  },
+};
 
 export const streamdownPlugins = {
-  code: createCodePlugin({
-    themes: [vercelLight, vercelDark],
-  }),
+  code: codePlugin,
 };

--- a/apps/web/lib/streamdown-config.tsx
+++ b/apps/web/lib/streamdown-config.tsx
@@ -1,8 +1,8 @@
 import { createCodePlugin } from "@streamdown/code";
-import { vercelDark } from "./vercel-themes";
+import { vercelLight, vercelDark } from "./vercel-themes";
 
 export const streamdownPlugins = {
   code: createCodePlugin({
-    themes: [vercelDark, vercelDark],
+    themes: [vercelLight, vercelDark],
   }),
 };

--- a/apps/web/lib/streamdown-config.tsx
+++ b/apps/web/lib/streamdown-config.tsx
@@ -10,6 +10,7 @@ type HighlightResult = NonNullable<ReturnType<typeof baseCodePlugin.highlight>>;
 type HighlightCallback = (result: HighlightResult) => void;
 type HighlightLine = HighlightResult["tokens"][number];
 type HighlightToken = HighlightLine[number];
+type TokenHtmlStyle = NonNullable<HighlightToken["htmlStyle"]>;
 
 type CssDeclarations = Record<string, string>;
 
@@ -46,85 +47,97 @@ function parseCssValue(value: string): {
   return { baseValue, declarations };
 }
 
-function normalizeThemeValue(
+function mergeDeclarations(
+  target: CssDeclarations,
+  source: CssDeclarations,
+): void {
+  for (const [property, propertyValue] of Object.entries(source)) {
+    target[property] = propertyValue;
+  }
+}
+
+function consumeThemeValue(
   value: string | undefined,
-  rootDeclarations: CssDeclarations,
+  declarationTarget: CssDeclarations,
 ): string | undefined {
   if (!value) {
     return value;
   }
 
   const { baseValue, declarations } = parseCssValue(value);
-  for (const [property, propertyValue] of Object.entries(declarations)) {
-    rootDeclarations[property] = propertyValue;
-  }
+  mergeDeclarations(declarationTarget, declarations);
 
   return baseValue;
 }
 
-function normalizeHighlightResult(result: HighlightResult): HighlightResult {
-  const rootDeclarations: CssDeclarations = {};
-  const fg = normalizeThemeValue(result.fg, rootDeclarations);
-  const bg = normalizeThemeValue(result.bg, rootDeclarations);
-
-  const tokens: HighlightResult["tokens"] = result.tokens.map(
-    (line: HighlightLine) =>
-      line.map((token: HighlightToken) => {
-        const htmlStyle = token.htmlStyle ? { ...token.htmlStyle } : undefined;
-        let color = token.color;
-        let bgColor = token.bgColor;
-
-        if (htmlStyle) {
-          const rawColor = htmlStyle.color;
-          if (typeof rawColor === "string") {
-            const { baseValue, declarations } = parseCssValue(rawColor);
-            if (baseValue) {
-              color = baseValue;
-            }
-            for (const [property, propertyValue] of Object.entries(
-              declarations,
-            )) {
-              htmlStyle[property] = propertyValue;
-            }
-            delete htmlStyle.color;
-          }
-
-          const rawBackgroundColor = htmlStyle["background-color"];
-          if (typeof rawBackgroundColor === "string") {
-            const { baseValue, declarations } =
-              parseCssValue(rawBackgroundColor);
-            if (baseValue) {
-              bgColor = baseValue;
-            }
-            for (const [property, propertyValue] of Object.entries(
-              declarations,
-            )) {
-              htmlStyle[property] = propertyValue;
-            }
-            delete htmlStyle["background-color"];
-          }
-        }
-
-        return {
-          ...token,
-          bgColor,
-          color,
-          htmlStyle,
-        };
-      }),
-  );
-
-  const rootStyleParts: string[] = [];
-  if (typeof result.rootStyle === "string" && result.rootStyle.length > 0) {
-    rootStyleParts.push(result.rootStyle);
+function normalizeTokenStyleProperty(
+  htmlStyle: TokenHtmlStyle,
+  property: "color" | "background-color",
+): string | undefined {
+  const value = htmlStyle[property];
+  if (typeof value !== "string") {
+    return undefined;
   }
 
-  for (const [property, propertyValue] of Object.entries(rootDeclarations)) {
+  const { baseValue, declarations } = parseCssValue(value);
+  mergeDeclarations(htmlStyle, declarations);
+  delete htmlStyle[property];
+
+  return baseValue;
+}
+
+function normalizeHighlightToken(token: HighlightToken): HighlightToken {
+  const htmlStyle = token.htmlStyle ? { ...token.htmlStyle } : undefined;
+  if (!htmlStyle) {
+    return token;
+  }
+
+  const color = normalizeTokenStyleProperty(htmlStyle, "color") ?? token.color;
+  const bgColor =
+    normalizeTokenStyleProperty(htmlStyle, "background-color") ?? token.bgColor;
+
+  return {
+    ...token,
+    bgColor,
+    color,
+    htmlStyle,
+  };
+}
+
+function mergeRootStyle(
+  rootStyle: string | undefined,
+  declarations: CssDeclarations,
+): string | undefined {
+  const declarationEntries = Object.entries(declarations);
+  if (declarationEntries.length === 0) {
+    return rootStyle;
+  }
+
+  const rootStyleParts: string[] = [];
+  if (typeof rootStyle === "string" && rootStyle.length > 0) {
+    rootStyleParts.push(rootStyle);
+  }
+
+  for (const [property, propertyValue] of declarationEntries) {
     rootStyleParts.push(`${property}:${propertyValue}`);
   }
 
-  const rootStyle =
-    rootStyleParts.length > 0 ? rootStyleParts.join(";") : result.rootStyle;
+  return rootStyleParts.join(";");
+}
+
+export function normalizeStreamdownHighlightResult(
+  result: HighlightResult,
+): HighlightResult {
+  // Shiki dual-theme output can encode dark-mode overrides in semicolon-delimited
+  // values. Streamdown expects base colors in fg/bg + token color/bgColor, with
+  // dark variants left in CSS variables on styles.
+  const rootDeclarations: CssDeclarations = {};
+  const fg = consumeThemeValue(result.fg, rootDeclarations);
+  const bg = consumeThemeValue(result.bg, rootDeclarations);
+  const tokens: HighlightResult["tokens"] = result.tokens.map(
+    (line: HighlightLine) => line.map(normalizeHighlightToken),
+  );
+  const rootStyle = mergeRootStyle(result.rootStyle, rootDeclarations);
 
   return {
     ...result,
@@ -140,12 +153,12 @@ const codePlugin = {
   highlight(options: HighlightOptions, callback?: HighlightCallback) {
     const normalizedCallback: HighlightCallback | undefined = callback
       ? (result) => {
-          callback(normalizeHighlightResult(result));
+          callback(normalizeStreamdownHighlightResult(result));
         }
       : undefined;
 
     const result = baseCodePlugin.highlight(options, normalizedCallback);
-    return result ? normalizeHighlightResult(result) : null;
+    return result ? normalizeStreamdownHighlightResult(result) : null;
   },
 };
 

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -89,6 +89,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 - For resumed chat streams, `chat.stop()` alone is insufficient because reconnect fetches are not wired to the active abort signal; always pair stop with aborting the managed transport tied to that chat instance.
 - In chat UI rendering, treat both `submitted` and `streaming` as in-flight. If only `streaming` is considered active, task/tool parts can be marked interrupted too early and stale `Thinking...` indicators can linger until a full page refresh.
 - In Streamdown, `plugins.code.getThemes()` overrides the `shikiTheme` prop; configure code themes in `createCodePlugin(...)` and pass actual custom theme objects for non-bundled themes (for example `vercelLight`/`vercelDark`) or highlighting can fall back to unstyled/plain tokens.
+- Shiki dual-theme `TokensResult` can encode dark variants inside semicolon-delimited `fg`/`bg` values and token `htmlStyle` fields (for example `color` + `--shiki-dark`); normalize these into Streamdown's `color`/`bgColor` fields plus root CSS vars, or inline light colors can override dark-mode classes and keep code blocks stuck in light theme.
 
 ## GitHub App / PR Flows
 


### PR DESCRIPTION
Updates the streamdown code plugin configuration to use `vercelLight` as the first theme instead of duplicating `vercelDark`.

- Imports `vercelLight` from vercel-themes module
- Changes code plugin themes array from `[vercelDark, vercelDark]` to `[vercelLight, vercelDark]` for better visual variety