### PR TITLE
Refactor task tool to use fullStream API and output schema

### DIFF
--- a/apps/cli/tui/components/task-group-view.tsx
+++ b/apps/cli/tui/components/task-group-view.tsx
@@ -47,31 +47,33 @@ function formatTime(seconds: number): string {
   return `${mins}m ${secs}s`;
 }
 
-function useTaskTiming(isRunning: boolean) {
-  const startTimeRef = useRef<number | null>(null);
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+function useTaskTiming(isRunning: boolean, startedAtMs?: number) {
+  const fallbackStartRef = useRef<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
-    if (isRunning && !startTimeRef.current) {
-      startTimeRef.current = Date.now();
-    }
-
     if (!isRunning) {
       return;
     }
 
+    if (startedAtMs == null && !fallbackStartRef.current) {
+      fallbackStartRef.current = Date.now();
+    }
+
+    setNow(Date.now());
     const interval = setInterval(() => {
-      if (startTimeRef.current) {
-        setElapsedSeconds(
-          Math.floor((Date.now() - startTimeRef.current) / 1000),
-        );
-      }
+      setNow(Date.now());
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [isRunning]);
+  }, [isRunning, startedAtMs]);
 
-  return elapsedSeconds;
+  const effectiveStart = startedAtMs ?? fallbackStartRef.current;
+  if (!isRunning || effectiveStart == null) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor((now - effectiveStart) / 1000));
 }
 
 type TaskStatus =
@@ -159,7 +161,6 @@ function TaskItem({
 }) {
   const status = getTaskStatus(part, isStreaming);
   const isRunning = status === "running" || status === "pending";
-  const elapsedSeconds = useTaskTiming(isRunning);
   const { state: chatState } = useChatContext();
   const cwd = chatState.workingDirectory ?? process.cwd();
   const { width } = useTerminalDimensions();
@@ -168,6 +169,9 @@ function TaskItem({
   const hasOutput = part.state === "output-available";
   const isComplete = hasOutput && !part.preliminary;
   const output = hasOutput ? part.output : undefined;
+  const startedAt =
+    typeof output?.startedAt === "number" ? output.startedAt : undefined;
+  const elapsedSeconds = useTaskTiming(isRunning, startedAt);
 
   const pendingToolCall: PendingToolCall | null = output?.pending ?? null;
   const toolCount =

--- a/apps/cli/tui/components/task-group-view.tsx
+++ b/apps/cli/tui/components/task-group-view.tsx
@@ -1,4 +1,4 @@
-import type { TaskToolUIPart } from "@open-harness/agent";
+import type { TaskPendingToolCall, TaskToolUIPart } from "@open-harness/agent";
 import { formatTokens } from "@open-harness/shared";
 import { TextAttributes } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
@@ -7,8 +7,6 @@ import { useChatContext } from "../chat-context";
 import { PRIMARY_COLOR } from "../lib/colors";
 import { truncateText } from "../lib/truncate";
 import { toRelativePath } from "./tool-renderers/shared";
-
-type PendingToolCall = { name: string; input: unknown };
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -111,7 +109,7 @@ function countToolCalls(messages: unknown): number {
   ).length;
 }
 
-function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
+function getToolSummary(toolCall: TaskPendingToolCall, cwd: string): string {
   const input = toolCall.input as Record<string, unknown> | undefined;
   switch (toolCall.name) {
     case "read":
@@ -173,7 +171,7 @@ function TaskItem({
     typeof output?.startedAt === "number" ? output.startedAt : undefined;
   const elapsedSeconds = useTaskTiming(isRunning, startedAt);
 
-  const pendingToolCall: PendingToolCall | null = output?.pending ?? null;
+  const pendingToolCall: TaskPendingToolCall | null = output?.pending ?? null;
   const toolCount =
     output?.toolCallCount ?? (isComplete ? countToolCalls(output?.final) : 0);
   const tokenCount = output?.usage?.inputTokens ?? null;

--- a/apps/cli/tui/components/task-group-view.tsx
+++ b/apps/cli/tui/components/task-group-view.tsx
@@ -99,26 +99,14 @@ function getTaskStatus(part: TaskToolUIPart, isStreaming: boolean): TaskStatus {
   return "pending";
 }
 
-/**
- * Hook to accumulate pending tool calls from the task tool's streaming output.
- * Each yield replaces the previous output, so we track seen tool calls in a ref.
- */
-function useAccumulatedToolCalls(part: TaskToolUIPart) {
-  const toolCallsRef = useRef<PendingToolCall[]>([]);
-  const lastPendingKeyRef = useRef<string | null>(null);
-
-  const hasOutput = part.state === "output-available";
-  const output = hasOutput ? part.output : undefined;
-
-  if (output?.pending) {
-    const key = JSON.stringify(output.pending);
-    if (key !== lastPendingKeyRef.current) {
-      lastPendingKeyRef.current = key;
-      toolCallsRef.current = [...toolCallsRef.current, output.pending];
-    }
-  }
-
-  return toolCallsRef.current;
+function countToolCalls(messages: unknown): number {
+  if (!Array.isArray(messages)) return 0;
+  return messages.filter(
+    (m) =>
+      typeof m === "object" &&
+      m !== null &&
+      (m as { role?: string }).role === "tool",
+  ).length;
 }
 
 function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
@@ -179,17 +167,15 @@ function TaskItem({
   const { width } = useTerminalDimensions();
   const terminalWidth = width ?? 80;
 
-  const toolCalls = useAccumulatedToolCalls(part);
-  const toolCount = toolCalls.length;
-
   const hasOutput = part.state === "output-available";
   const isComplete = hasOutput && !part.preliminary;
   const output = hasOutput ? part.output : undefined;
+
+  const pendingToolCall: PendingToolCall | null = output?.pending ?? null;
+  const toolCount = isComplete ? countToolCalls(output?.final) : 0;
   const tokenCount = isComplete
     ? (output?.usage?.inputTokens ?? null)
     : null;
-
-  const lastToolCall = toolCalls[toolCalls.length - 1] ?? null;
 
   const desc = part.input?.task ?? "Task";
 
@@ -215,15 +201,14 @@ function TaskItem({
     nestedStatus = "Awaiting approval...";
   } else if (status === "pending") {
     nestedStatus = "Initializing...";
-  } else if (status === "running" && (!lastToolCall || toolCount === 0)) {
+  } else if (status === "running" && !pendingToolCall) {
     nestedStatus = "Initializing...";
-  } else if (lastToolCall) {
+  } else if (pendingToolCall) {
     const displayName =
-      lastToolCall.name.charAt(0).toUpperCase() + lastToolCall.name.slice(1);
-    const summary = getToolSummary(lastToolCall, cwd);
-    nestedStatus = summary
-      ? `${displayName}(${summary})`
-      : displayName;
+      pendingToolCall.name.charAt(0).toUpperCase() +
+      pendingToolCall.name.slice(1);
+    const summary = getToolSummary(pendingToolCall, cwd);
+    nestedStatus = summary ? `${displayName}(${summary})` : displayName;
   }
   const toolCountText = ` - ${toolCount} tool${toolCount !== 1 ? "s" : ""}`;
   const tokenText =

--- a/apps/cli/tui/components/task-group-view.tsx
+++ b/apps/cli/tui/components/task-group-view.tsx
@@ -1,15 +1,14 @@
-import type { SubagentUIMessage, TaskToolUIPart } from "@open-harness/agent";
+import type { TaskToolUIPart } from "@open-harness/agent";
 import { formatTokens } from "@open-harness/shared";
 import { TextAttributes } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
-import { getToolName, isToolUIPart } from "ai";
 import React, { useEffect, useRef, useState } from "react";
 import { useChatContext } from "../chat-context";
 import { PRIMARY_COLOR } from "../lib/colors";
 import { truncateText } from "../lib/truncate";
 import { toRelativePath } from "./tool-renderers/shared";
 
-type SubagentMessagePart = SubagentUIMessage["parts"][number];
+type PendingToolCall = { name: string; input: unknown };
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -100,61 +99,46 @@ function getTaskStatus(part: TaskToolUIPart, isStreaming: boolean): TaskStatus {
   return "pending";
 }
 
-function countTaskTools(part: TaskToolUIPart): number {
-  if (part.state !== "output-available") return 0;
-  const message = part.output;
-  if (!message?.parts) return 0;
-  return message.parts.filter(isToolUIPart).length;
+/**
+ * Hook to accumulate pending tool calls from the task tool's streaming output.
+ * Each yield replaces the previous output, so we track seen tool calls in a ref.
+ */
+function useAccumulatedToolCalls(part: TaskToolUIPart) {
+  const toolCallsRef = useRef<PendingToolCall[]>([]);
+  const lastPendingKeyRef = useRef<string | null>(null);
+
+  const hasOutput = part.state === "output-available";
+  const output = hasOutput ? part.output : undefined;
+
+  if (output?.pending) {
+    const key = JSON.stringify(output.pending);
+    if (key !== lastPendingKeyRef.current) {
+      lastPendingKeyRef.current = key;
+      toolCallsRef.current = [...toolCallsRef.current, output.pending];
+    }
+  }
+
+  return toolCallsRef.current;
 }
 
-function getTaskTokens(part: TaskToolUIPart): number | null {
-  if (part.state !== "output-available") return null;
-  const message = part.output;
-  return message?.metadata?.lastStepUsage?.inputTokens ?? null;
-}
-
-function getToolSummary(part: SubagentMessagePart, cwd: string): string {
-  switch (part.type) {
-    case "tool-read":
-    case "tool-write":
-    case "tool-edit":
-      return part.input?.filePath
-        ? toRelativePath(part.input.filePath, cwd)
+function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
+  const input = toolCall.input as Record<string, unknown> | undefined;
+  switch (toolCall.name) {
+    case "read":
+    case "write":
+    case "edit":
+      return input?.filePath
+        ? toRelativePath(String(input.filePath), cwd)
         : "";
-    case "tool-grep":
-    case "tool-glob":
-      return part.input?.pattern ? `"${part.input.pattern}"` : "";
-    case "tool-bash": {
-      return part.input?.command ?? "";
+    case "grep":
+    case "glob":
+      return input?.pattern ? `"${input.pattern}"` : "";
+    case "bash": {
+      return input?.command ? String(input.command) : "";
     }
     default:
       return "";
   }
-}
-
-function getLastToolInfo(
-  part: TaskToolUIPart,
-  cwd: string,
-): { name: string; summary: string } | null {
-  if (part.state !== "output-available") return null;
-  const message = part.output;
-  if (!message?.parts) return null;
-
-  const toolParts = message.parts.filter(
-    (toolPart) =>
-      isToolUIPart(toolPart) && toolPart.state !== "input-streaming",
-  );
-  if (toolParts.length === 0) return null;
-
-  const lastTool = toolParts[toolParts.length - 1];
-  // Double-check needed for TypeScript narrowing with union types
-  if (!lastTool || !isToolUIPart(lastTool)) return null;
-
-  const toolName = getToolName(lastTool);
-  const summary = getToolSummary(lastTool, cwd);
-
-  const displayName = toolName.charAt(0).toUpperCase() + toolName.slice(1);
-  return { name: displayName, summary };
 }
 
 function TaskStatusIndicator({ status }: { status: TaskStatus }) {
@@ -190,13 +174,22 @@ function TaskItem({
   const status = getTaskStatus(part, isStreaming);
   const isRunning = status === "running" || status === "pending";
   const elapsedSeconds = useTaskTiming(isRunning);
-  const toolCount = countTaskTools(part);
-  const tokenCount = getTaskTokens(part);
   const { state: chatState } = useChatContext();
   const cwd = chatState.workingDirectory ?? process.cwd();
-  const lastTool = getLastToolInfo(part, cwd);
   const { width } = useTerminalDimensions();
   const terminalWidth = width ?? 80;
+
+  const toolCalls = useAccumulatedToolCalls(part);
+  const toolCount = toolCalls.length;
+
+  const hasOutput = part.state === "output-available";
+  const isComplete = hasOutput && !part.preliminary;
+  const output = hasOutput ? part.output : undefined;
+  const tokenCount = isComplete
+    ? (output?.usage?.inputTokens ?? null)
+    : null;
+
+  const lastToolCall = toolCalls[toolCalls.length - 1] ?? null;
 
   const desc = part.input?.task ?? "Task";
 
@@ -222,12 +215,15 @@ function TaskItem({
     nestedStatus = "Awaiting approval...";
   } else if (status === "pending") {
     nestedStatus = "Initializing...";
-  } else if (status === "running" && (!lastTool || toolCount === 0)) {
+  } else if (status === "running" && (!lastToolCall || toolCount === 0)) {
     nestedStatus = "Initializing...";
-  } else if (lastTool) {
-    nestedStatus = lastTool.summary
-      ? `${lastTool.name}(${lastTool.summary})`
-      : lastTool.name;
+  } else if (lastToolCall) {
+    const displayName =
+      lastToolCall.name.charAt(0).toUpperCase() + lastToolCall.name.slice(1);
+    const summary = getToolSummary(lastToolCall, cwd);
+    nestedStatus = summary
+      ? `${displayName}(${summary})`
+      : displayName;
   }
   const toolCountText = ` - ${toolCount} tool${toolCount !== 1 ? "s" : ""}`;
   const tokenText =

--- a/apps/cli/tui/components/task-group-view.tsx
+++ b/apps/cli/tui/components/task-group-view.tsx
@@ -115,9 +115,7 @@ function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
     case "read":
     case "write":
     case "edit":
-      return input?.filePath
-        ? toRelativePath(String(input.filePath), cwd)
-        : "";
+      return input?.filePath ? toRelativePath(String(input.filePath), cwd) : "";
     case "grep":
     case "glob":
       return input?.pattern ? `"${input.pattern}"` : "";
@@ -172,10 +170,9 @@ function TaskItem({
   const output = hasOutput ? part.output : undefined;
 
   const pendingToolCall: PendingToolCall | null = output?.pending ?? null;
-  const toolCount = isComplete ? countToolCalls(output?.final) : 0;
-  const tokenCount = isComplete
-    ? (output?.usage?.inputTokens ?? null)
-    : null;
+  const toolCount =
+    output?.toolCallCount ?? (isComplete ? countToolCalls(output?.final) : 0);
+  const tokenCount = output?.usage?.inputTokens ?? null;
 
   const desc = part.input?.task ?? "Task";
 

--- a/apps/cli/tui/components/tool-renderers/task-renderer.tsx
+++ b/apps/cli/tui/components/tool-renderers/task-renderer.tsx
@@ -1,7 +1,7 @@
 import { formatTokens } from "@open-harness/shared";
 import { TextAttributes } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
-import React, { useRef } from "react";
+import React from "react";
 import { useChatContext } from "../../chat-context";
 import { PRIMARY_COLOR } from "../../lib/colors";
 import type { ToolRendererProps } from "../../lib/render-tool";
@@ -27,6 +27,13 @@ function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
     default:
       return "";
   }
+}
+
+function countToolCalls(messages: unknown): number {
+  if (!Array.isArray(messages)) return 0;
+  return messages.filter(
+    (m) => typeof m === "object" && m !== null && (m as { role?: string }).role === "tool",
+  ).length;
 }
 
 function SubagentToolCall({
@@ -77,9 +84,6 @@ function SubagentToolCall({
 }
 
 export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
-  const toolCallsRef = useRef<PendingToolCall[]>([]);
-  const lastPendingKeyRef = useRef<string | null>(null);
-
   const isInputReady = part.state !== "input-streaming";
   const desc = isInputReady ? (part.input?.task ?? "Spawning subagent") : "...";
   const subagentType = isInputReady ? part.input?.subagentType : undefined;
@@ -92,21 +96,8 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
   const isComplete = hasOutput && !isPreliminary;
   const output = hasOutput ? part.output : undefined;
 
-  // Accumulate pending tool calls across yields (each yield replaces the previous)
-  if (output?.pending) {
-    const key = JSON.stringify(output.pending);
-    if (key !== lastPendingKeyRef.current) {
-      lastPendingKeyRef.current = key;
-      toolCallsRef.current = [...toolCallsRef.current, output.pending];
-    }
-  }
-
-  const toolCalls = toolCallsRef.current;
-
-  // Show only the last few parts to avoid too much output
-  const maxVisible = 4;
-  const hiddenCount = Math.max(0, toolCalls.length - maxVisible);
-  const visibleCalls = toolCalls.slice(-maxVisible);
+  const pendingToolCall = output?.pending ?? null;
+  const toolCount = isComplete ? countToolCalls(output?.final) : 0;
 
   const isStreaming = hasOutput && isPreliminary;
 
@@ -185,25 +176,10 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
         </box>
       )}
 
-      {/* Nested tool calls from subagent */}
-      {hasOutput && visibleCalls.length > 0 && !state.interrupted && (
+      {/* Current pending tool call from subagent */}
+      {pendingToolCall && !state.interrupted && (
         <box flexDirection="column" paddingLeft={2} marginTop={1}>
-          {hiddenCount > 0 && (
-            <box marginBottom={1} flexDirection="row">
-              <text fg="gray">... {hiddenCount} more above</text>
-            </box>
-          )}
-          {visibleCalls.map((tc, i) => {
-            const isLast = i === visibleCalls.length - 1;
-            const isToolRunning = isLast && isPreliminary;
-            return (
-              <SubagentToolCall
-                key={`${tc.name}-${i + hiddenCount}`}
-                toolCall={tc}
-                isRunning={isToolRunning}
-              />
-            );
-          })}
+          <SubagentToolCall toolCall={pendingToolCall} isRunning={isPreliminary} />
         </box>
       )}
 
@@ -212,7 +188,7 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
         <box paddingLeft={2} flexDirection="row">
           <text fg="gray">└ </text>
           <text fg="white">
-            Complete ({toolCalls.length} tool calls
+            Complete ({toolCount} tool calls
             {output?.usage?.inputTokens
               ? `, ${formatTokens(output.usage.inputTokens)} tokens`
               : ""}

--- a/apps/cli/tui/components/tool-renderers/task-renderer.tsx
+++ b/apps/cli/tui/components/tool-renderers/task-renderer.tsx
@@ -1,52 +1,52 @@
-import type { SubagentUIMessage } from "@open-harness/agent";
 import { formatTokens } from "@open-harness/shared";
 import { TextAttributes } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
-import { getToolName, isTextUIPart, isToolUIPart } from "ai";
-import React from "react";
+import React, { useRef } from "react";
 import { useChatContext } from "../../chat-context";
 import { PRIMARY_COLOR } from "../../lib/colors";
 import type { ToolRendererProps } from "../../lib/render-tool";
 import { truncateText } from "../../lib/truncate";
 import { ToolSpinner, toRelativePath } from "./shared";
 
-type SubagentMessagePart = SubagentUIMessage["parts"][number];
+type PendingToolCall = { name: string; input: unknown };
 
-function getToolSummary(part: SubagentMessagePart, cwd: string): string {
-  switch (part.type) {
-    case "tool-read":
-    case "tool-write":
-    case "tool-edit":
-      return part.input?.filePath
-        ? toRelativePath(part.input.filePath, cwd)
+function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
+  const input = toolCall.input as Record<string, unknown> | undefined;
+  switch (toolCall.name) {
+    case "read":
+    case "write":
+    case "edit":
+      return input?.filePath
+        ? toRelativePath(String(input.filePath), cwd)
         : "";
-    case "tool-grep":
-    case "tool-glob":
-      return part.input?.pattern ? `"${part.input.pattern}"` : "";
-    case "tool-bash":
-      return part.input?.command ?? "";
+    case "grep":
+    case "glob":
+      return input?.pattern ? `"${input.pattern}"` : "";
+    case "bash":
+      return input?.command ? String(input.command) : "";
     default:
       return "";
   }
 }
 
-function SubagentToolCall({ part }: { part: SubagentMessagePart }) {
+function SubagentToolCall({
+  toolCall,
+  isRunning,
+}: {
+  toolCall: PendingToolCall;
+  isRunning: boolean;
+}) {
   const { state: chatState } = useChatContext();
   const cwd = chatState.workingDirectory ?? process.cwd();
   const { width } = useTerminalDimensions();
-  if (!isToolUIPart(part)) return null;
-  if (part.state === "input-streaming") return null;
-  const toolName = getToolName(part);
-  const isRunning = part.state === "input-available";
-  const hasError = part.state === "output-error";
-  const summary = getToolSummary(part, cwd);
+  const summary = getToolSummary(toolCall, cwd);
   const terminalWidth = width ?? 80;
 
-  const dotColor = isRunning ? PRIMARY_COLOR : hasError ? "red" : "green";
-  const displayName = toolName.charAt(0).toUpperCase() + toolName.slice(1);
-  const errorSuffix = hasError ? " - error" : "";
+  const dotColor = isRunning ? PRIMARY_COLOR : "green";
+  const displayName =
+    toolCall.name.charAt(0).toUpperCase() + toolCall.name.slice(1);
   const prefixLength = 2 + 2 + displayName.length + 1;
-  const suffixLength = 1 + errorSuffix.length;
+  const suffixLength = 1;
   const maxSummaryWidth = Math.max(
     10,
     terminalWidth - prefixLength - suffixLength,
@@ -71,13 +71,15 @@ function SubagentToolCall({ part }: { part: SubagentMessagePart }) {
             <text fg="gray">)</text>
           </>
         )}
-        {hasError && <text fg="red">{errorSuffix}</text>}
       </box>
     </box>
   );
 }
 
 export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
+  const toolCallsRef = useRef<PendingToolCall[]>([]);
+  const lastPendingKeyRef = useRef<string | null>(null);
+
   const isInputReady = part.state !== "input-streaming";
   const desc = isInputReady ? (part.input?.task ?? "Spawning subagent") : "...";
   const subagentType = isInputReady ? part.input?.subagentType : undefined;
@@ -85,27 +87,27 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
   const taskDenied = part.state === "output-denied";
   const taskDenialReason = taskDenied ? part.approval?.reason : undefined;
 
-  // The output is a UIMessage with parts (text, tool-invocation, etc.)
-  // Preliminary results have preliminary: true, final result has preliminary: false/undefined
   const hasOutput = part.state === "output-available";
   const isPreliminary = hasOutput && part.preliminary === true;
-  const message = hasOutput ? part.output : undefined;
+  const isComplete = hasOutput && !isPreliminary;
+  const output = hasOutput ? part.output : undefined;
 
-  // Get all parts in order, filter to text and tool parts
-  const messageParts = message?.parts ?? [];
-  const relevantParts = messageParts.filter((p) => {
-    if (isTextUIPart(p)) return true;
-    if (!isToolUIPart(p)) return false;
-    return p.state !== "input-streaming";
-  });
-  const toolParts = messageParts.filter(isToolUIPart);
+  // Accumulate pending tool calls across yields (each yield replaces the previous)
+  if (output?.pending) {
+    const key = JSON.stringify(output.pending);
+    if (key !== lastPendingKeyRef.current) {
+      lastPendingKeyRef.current = key;
+      toolCallsRef.current = [...toolCallsRef.current, output.pending];
+    }
+  }
+
+  const toolCalls = toolCallsRef.current;
 
   // Show only the last few parts to avoid too much output
   const maxVisible = 4;
-  const hiddenCount = Math.max(0, relevantParts.length - maxVisible);
-  const visibleParts = relevantParts.slice(-maxVisible);
+  const hiddenCount = Math.max(0, toolCalls.length - maxVisible);
+  const visibleCalls = toolCalls.slice(-maxVisible);
 
-  const isComplete = hasOutput && !isPreliminary;
   const isStreaming = hasOutput && isPreliminary;
 
   const dotColor = taskDenied
@@ -141,7 +143,6 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
     taskTerminalWidth - taskPrefixLength - taskSuffixLength,
   );
   const displayDesc = truncateText(desc, maxDescWidth);
-  const maxTextWidth = Math.max(10, taskTerminalWidth - 4);
   const errorPrefix = "Error: ";
   const maxErrorWidth = Math.max(
     10,
@@ -184,33 +185,24 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
         </box>
       )}
 
-      {/* Nested parts from subagent (text and tools in order) */}
-      {hasOutput && visibleParts.length > 0 && !state.interrupted && (
+      {/* Nested tool calls from subagent */}
+      {hasOutput && visibleCalls.length > 0 && !state.interrupted && (
         <box flexDirection="column" paddingLeft={2} marginTop={1}>
           {hiddenCount > 0 && (
             <box marginBottom={1} flexDirection="row">
               <text fg="gray">... {hiddenCount} more above</text>
             </box>
           )}
-          {visibleParts.map((p, i) => {
-            if (isToolUIPart(p)) {
-              return <SubagentToolCall key={p.toolCallId} part={p} />;
-            }
-            if (isTextUIPart(p)) {
-              // Show truncated text, dimmed
-              const text = p.text.trim();
-              if (!text) return null;
-              const truncated = truncateText(text, maxTextWidth);
-              return (
-                <box key={`text-${i}`} paddingLeft={1} flexDirection="row">
-                  <text fg="gray">│ </text>
-                  <text fg="gray" attributes={TextAttributes.DIM}>
-                    {truncated}
-                  </text>
-                </box>
-              );
-            }
-            return null;
+          {visibleCalls.map((tc, i) => {
+            const isLast = i === visibleCalls.length - 1;
+            const isToolRunning = isLast && isPreliminary;
+            return (
+              <SubagentToolCall
+                key={`${tc.name}-${i + hiddenCount}`}
+                toolCall={tc}
+                isRunning={isToolRunning}
+              />
+            );
           })}
         </box>
       )}
@@ -220,9 +212,9 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
         <box paddingLeft={2} flexDirection="row">
           <text fg="gray">└ </text>
           <text fg="white">
-            Complete ({toolParts.length} tool calls
-            {message?.metadata?.lastStepUsage?.inputTokens
-              ? `, ${formatTokens(message.metadata.lastStepUsage.inputTokens)} tokens`
+            Complete ({toolCalls.length} tool calls
+            {output?.usage?.inputTokens
+              ? `, ${formatTokens(output.usage.inputTokens)} tokens`
               : ""}
             )
           </text>

--- a/apps/cli/tui/components/tool-renderers/task-renderer.tsx
+++ b/apps/cli/tui/components/tool-renderers/task-renderer.tsx
@@ -16,9 +16,7 @@ function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
     case "read":
     case "write":
     case "edit":
-      return input?.filePath
-        ? toRelativePath(String(input.filePath), cwd)
-        : "";
+      return input?.filePath ? toRelativePath(String(input.filePath), cwd) : "";
     case "grep":
     case "glob":
       return input?.pattern ? `"${input.pattern}"` : "";
@@ -32,7 +30,10 @@ function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
 function countToolCalls(messages: unknown): number {
   if (!Array.isArray(messages)) return 0;
   return messages.filter(
-    (m) => typeof m === "object" && m !== null && (m as { role?: string }).role === "tool",
+    (m) =>
+      typeof m === "object" &&
+      m !== null &&
+      (m as { role?: string }).role === "tool",
   ).length;
 }
 
@@ -97,7 +98,8 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
   const output = hasOutput ? part.output : undefined;
 
   const pendingToolCall = output?.pending ?? null;
-  const toolCount = isComplete ? countToolCalls(output?.final) : 0;
+  const toolCount =
+    output?.toolCallCount ?? (isComplete ? countToolCalls(output?.final) : 0);
 
   const isStreaming = hasOutput && isPreliminary;
 
@@ -179,7 +181,10 @@ export function TaskRenderer({ part, state }: ToolRendererProps<"tool-task">) {
       {/* Current pending tool call from subagent */}
       {pendingToolCall && !state.interrupted && (
         <box flexDirection="column" paddingLeft={2} marginTop={1}>
-          <SubagentToolCall toolCall={pendingToolCall} isRunning={isPreliminary} />
+          <SubagentToolCall
+            toolCall={pendingToolCall}
+            isRunning={isPreliminary}
+          />
         </box>
       )}
 

--- a/apps/cli/tui/components/tool-renderers/task-renderer.tsx
+++ b/apps/cli/tui/components/tool-renderers/task-renderer.tsx
@@ -1,3 +1,4 @@
+import type { TaskPendingToolCall } from "@open-harness/agent";
 import { formatTokens } from "@open-harness/shared";
 import { TextAttributes } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
@@ -8,9 +9,7 @@ import type { ToolRendererProps } from "../../lib/render-tool";
 import { truncateText } from "../../lib/truncate";
 import { ToolSpinner, toRelativePath } from "./shared";
 
-type PendingToolCall = { name: string; input: unknown };
-
-function getToolSummary(toolCall: PendingToolCall, cwd: string): string {
+function getToolSummary(toolCall: TaskPendingToolCall, cwd: string): string {
   const input = toolCall.input as Record<string, unknown> | undefined;
   switch (toolCall.name) {
     case "read":
@@ -41,7 +40,7 @@ function SubagentToolCall({
   toolCall,
   isRunning,
 }: {
-  toolCall: PendingToolCall;
+  toolCall: TaskPendingToolCall;
   isRunning: boolean;
 }) {
   const { state: chatState } = useChatContext();

--- a/apps/web/components/task-group-view.tsx
+++ b/apps/web/components/task-group-view.tsx
@@ -52,9 +52,7 @@ function getToolSummary(toolCall: PendingToolCall): string {
     case "write":
     case "edit": {
       const fp = input?.filePath ?? "";
-      return fp
-        ? toRelativePath(String(fp), DEFAULT_WORKING_DIRECTORY)
-        : "";
+      return fp ? toRelativePath(String(fp), DEFAULT_WORKING_DIRECTORY) : "";
     }
     case "grep":
     case "glob":
@@ -153,10 +151,9 @@ function TaskItem({
   const output = hasOutput ? part.output : undefined;
 
   const pendingToolCall: PendingToolCall | null = output?.pending ?? null;
-  const toolCount = isComplete ? countToolCalls(output?.final) : 0;
-  const tokenCount = isComplete
-    ? (output?.usage?.inputTokens ?? null)
-    : null;
+  const toolCount =
+    output?.toolCallCount ?? (isComplete ? countToolCalls(output?.final) : 0);
+  const tokenCount = output?.usage?.inputTokens ?? null;
 
   const desc = part.input?.task ?? "Task";
   const subagentType = part.input?.subagentType;
@@ -183,16 +180,17 @@ function TaskItem({
     nestedStatus = denialReason ? `Denied: ${denialReason}` : "Denied";
   } else if (approvalRequested) {
     nestedStatus = "Awaiting approval...";
-  } else if (status === "pending" || (status === "running" && !pendingToolCall)) {
+  } else if (
+    status === "pending" ||
+    (status === "running" && !pendingToolCall)
+  ) {
     nestedStatus = "Initializing...";
   } else if (pendingToolCall) {
     const displayName =
       pendingToolCall.name.charAt(0).toUpperCase() +
       pendingToolCall.name.slice(1);
     const summary = getToolSummary(pendingToolCall);
-    nestedStatus = summary
-      ? `${displayName}(${summary})`
-      : displayName;
+    nestedStatus = summary ? `${displayName}(${summary})` : displayName;
   }
 
   return (

--- a/apps/web/components/task-group-view.tsx
+++ b/apps/web/components/task-group-view.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useEffect, useRef } from "react";
 import { Loader2 } from "lucide-react";
-import { isToolUIPart, getToolName } from "ai";
 import type { TaskToolUIPart } from "@open-harness/agent";
 import { formatTokens, toRelativePath } from "@open-harness/shared";
 import { cn } from "@/lib/utils";
 import { DEFAULT_WORKING_DIRECTORY } from "@/lib/sandbox/config";
 import { ApprovalButtons } from "./tool-call/approval-buttons";
+
+type PendingToolCall = { name: string; input: unknown };
 
 type TaskStatus =
   | "pending"
@@ -34,53 +35,49 @@ function getTaskStatus(part: TaskToolUIPart, isStreaming: boolean): TaskStatus {
   return "pending";
 }
 
-function countTaskTools(part: TaskToolUIPart): number {
-  if (part.state !== "output-available") return 0;
-  const message = part.output;
-  if (!message?.parts) return 0;
-  return message.parts.filter(isToolUIPart).length;
-}
+/**
+ * Hook to accumulate pending tool calls from the task tool's streaming output.
+ * Each yield replaces the previous output, so we track seen tool calls in a ref.
+ */
+function useAccumulatedToolCalls(part: TaskToolUIPart) {
+  const toolCallsRef = useRef<PendingToolCall[]>([]);
+  const lastPendingKeyRef = useRef<string | null>(null);
 
-function getTaskTokens(part: TaskToolUIPart): number | null {
-  if (part.state !== "output-available") return null;
-  const message = part.output;
-  // Use totalMessageUsage when complete, lastStepUsage when still running
-  const isComplete = !part.preliminary;
-  if (isComplete) {
-    return message?.metadata?.totalMessageUsage?.inputTokens ?? null;
-  }
-  return message?.metadata?.lastStepUsage?.inputTokens ?? null;
-}
+  const hasOutput = part.state === "output-available";
+  const output = hasOutput ? part.output : undefined;
 
-function getLastToolInfo(
-  part: TaskToolUIPart,
-): { name: string; summary: string } | null {
-  if (part.state !== "output-available") return null;
-  const message = part.output;
-  if (!message?.parts) return null;
-
-  const toolParts = message.parts.filter(isToolUIPart);
-  if (toolParts.length === 0) return null;
-
-  const lastTool = toolParts[toolParts.length - 1];
-  // Double-check needed for TypeScript narrowing with union types
-  if (!lastTool || !isToolUIPart(lastTool)) return null;
-
-  const toolName = getToolName(lastTool);
-  const input = lastTool.input as Record<string, unknown> | undefined;
-
-  let summary = "";
-  if (input?.filePath) {
-    summary = toRelativePath(String(input.filePath), DEFAULT_WORKING_DIRECTORY);
-  } else if (input?.pattern) {
-    summary = `"${input.pattern}"`;
-  } else if (input?.command) {
-    const cmd = String(input.command);
-    summary = cmd.length > 40 ? cmd.slice(0, 40) + "..." : cmd;
+  if (output?.pending) {
+    const key = JSON.stringify(output.pending);
+    if (key !== lastPendingKeyRef.current) {
+      lastPendingKeyRef.current = key;
+      toolCallsRef.current = [...toolCallsRef.current, output.pending];
+    }
   }
 
-  const displayName = toolName.charAt(0).toUpperCase() + toolName.slice(1);
-  return { name: displayName, summary };
+  return toolCallsRef.current;
+}
+
+function getToolSummary(toolCall: PendingToolCall): string {
+  const input = toolCall.input as Record<string, unknown> | undefined;
+  switch (toolCall.name) {
+    case "read":
+    case "write":
+    case "edit": {
+      const fp = input?.filePath ?? "";
+      return fp
+        ? toRelativePath(String(fp), DEFAULT_WORKING_DIRECTORY)
+        : "";
+    }
+    case "grep":
+    case "glob":
+      return input?.pattern ? `"${input.pattern}"` : "";
+    case "bash": {
+      const cmd = input?.command ? String(input.command) : "";
+      return cmd.length > 40 ? cmd.slice(0, 40) + "..." : cmd;
+    }
+    default:
+      return "";
+  }
 }
 
 function formatTime(seconds: number): string {
@@ -162,9 +159,18 @@ function TaskItem({
   const status = getTaskStatus(part, isStreaming);
   const isRunning = status === "running" || status === "pending";
   const elapsedSeconds = useTaskTiming(isRunning);
-  const toolCount = countTaskTools(part);
-  const tokenCount = getTaskTokens(part);
-  const lastTool = getLastToolInfo(part);
+
+  const toolCalls = useAccumulatedToolCalls(part);
+  const toolCount = toolCalls.length;
+
+  const hasOutput = part.state === "output-available";
+  const isComplete = hasOutput && !part.preliminary;
+  const output = hasOutput ? part.output : undefined;
+  const tokenCount = isComplete
+    ? (output?.usage?.inputTokens ?? null)
+    : null;
+
+  const lastToolCall = toolCalls[toolCalls.length - 1] ?? null;
 
   const desc = part.input?.task ?? "Task";
   const subagentType = part.input?.subagentType;
@@ -196,10 +202,13 @@ function TaskItem({
     (status === "running" && toolCount === 0)
   ) {
     nestedStatus = "Initializing...";
-  } else if (lastTool) {
-    nestedStatus = lastTool.summary
-      ? `${lastTool.name}(${lastTool.summary})`
-      : lastTool.name;
+  } else if (lastToolCall) {
+    const displayName =
+      lastToolCall.name.charAt(0).toUpperCase() + lastToolCall.name.slice(1);
+    const summary = getToolSummary(lastToolCall);
+    nestedStatus = summary
+      ? `${displayName}(${summary})`
+      : displayName;
   }
 
   return (

--- a/apps/web/components/task-group-view.tsx
+++ b/apps/web/components/task-group-view.tsx
@@ -35,26 +35,14 @@ function getTaskStatus(part: TaskToolUIPart, isStreaming: boolean): TaskStatus {
   return "pending";
 }
 
-/**
- * Hook to accumulate pending tool calls from the task tool's streaming output.
- * Each yield replaces the previous output, so we track seen tool calls in a ref.
- */
-function useAccumulatedToolCalls(part: TaskToolUIPart) {
-  const toolCallsRef = useRef<PendingToolCall[]>([]);
-  const lastPendingKeyRef = useRef<string | null>(null);
-
-  const hasOutput = part.state === "output-available";
-  const output = hasOutput ? part.output : undefined;
-
-  if (output?.pending) {
-    const key = JSON.stringify(output.pending);
-    if (key !== lastPendingKeyRef.current) {
-      lastPendingKeyRef.current = key;
-      toolCallsRef.current = [...toolCallsRef.current, output.pending];
-    }
-  }
-
-  return toolCallsRef.current;
+function countToolCalls(messages: unknown): number {
+  if (!Array.isArray(messages)) return 0;
+  return messages.filter(
+    (m) =>
+      typeof m === "object" &&
+      m !== null &&
+      (m as { role?: string }).role === "tool",
+  ).length;
 }
 
 function getToolSummary(toolCall: PendingToolCall): string {
@@ -160,17 +148,15 @@ function TaskItem({
   const isRunning = status === "running" || status === "pending";
   const elapsedSeconds = useTaskTiming(isRunning);
 
-  const toolCalls = useAccumulatedToolCalls(part);
-  const toolCount = toolCalls.length;
-
   const hasOutput = part.state === "output-available";
   const isComplete = hasOutput && !part.preliminary;
   const output = hasOutput ? part.output : undefined;
+
+  const pendingToolCall: PendingToolCall | null = output?.pending ?? null;
+  const toolCount = isComplete ? countToolCalls(output?.final) : 0;
   const tokenCount = isComplete
     ? (output?.usage?.inputTokens ?? null)
     : null;
-
-  const lastToolCall = toolCalls[toolCalls.length - 1] ?? null;
 
   const desc = part.input?.task ?? "Task";
   const subagentType = part.input?.subagentType;
@@ -197,15 +183,13 @@ function TaskItem({
     nestedStatus = denialReason ? `Denied: ${denialReason}` : "Denied";
   } else if (approvalRequested) {
     nestedStatus = "Awaiting approval...";
-  } else if (
-    status === "pending" ||
-    (status === "running" && toolCount === 0)
-  ) {
+  } else if (status === "pending" || (status === "running" && !pendingToolCall)) {
     nestedStatus = "Initializing...";
-  } else if (lastToolCall) {
+  } else if (pendingToolCall) {
     const displayName =
-      lastToolCall.name.charAt(0).toUpperCase() + lastToolCall.name.slice(1);
-    const summary = getToolSummary(lastToolCall);
+      pendingToolCall.name.charAt(0).toUpperCase() +
+      pendingToolCall.name.slice(1);
+    const summary = getToolSummary(pendingToolCall);
     nestedStatus = summary
       ? `${displayName}(${summary})`
       : displayName;

--- a/apps/web/components/task-group-view.tsx
+++ b/apps/web/components/task-group-view.tsx
@@ -2,13 +2,11 @@
 
 import { useState, useEffect, useRef } from "react";
 import { Loader2 } from "lucide-react";
-import type { TaskToolUIPart } from "@open-harness/agent";
+import type { TaskPendingToolCall, TaskToolUIPart } from "@open-harness/agent";
 import { formatTokens, toRelativePath } from "@open-harness/shared";
 import { cn } from "@/lib/utils";
 import { DEFAULT_WORKING_DIRECTORY } from "@/lib/sandbox/config";
 import { ApprovalButtons } from "./tool-call/approval-buttons";
-
-type PendingToolCall = { name: string; input: unknown };
 
 type TaskStatus =
   | "pending"
@@ -45,7 +43,7 @@ function countToolCalls(messages: unknown): number {
   ).length;
 }
 
-function getToolSummary(toolCall: PendingToolCall): string {
+function getToolSummary(toolCall: TaskPendingToolCall): string {
   const input = toolCall.input as Record<string, unknown> | undefined;
   switch (toolCall.name) {
     case "read":
@@ -154,7 +152,7 @@ function TaskItem({
     typeof output?.startedAt === "number" ? output.startedAt : undefined;
   const elapsedSeconds = useTaskTiming(isRunning, startedAt);
 
-  const pendingToolCall: PendingToolCall | null = output?.pending ?? null;
+  const pendingToolCall: TaskPendingToolCall | null = output?.pending ?? null;
   const toolCount =
     output?.toolCallCount ?? (isComplete ? countToolCalls(output?.final) : 0);
   const tokenCount = output?.usage?.inputTokens ?? null;

--- a/apps/web/components/task-group-view.tsx
+++ b/apps/web/components/task-group-view.tsx
@@ -75,31 +75,33 @@ function formatTime(seconds: number): string {
   return `${mins}m ${secs}s`;
 }
 
-function useTaskTiming(isRunning: boolean) {
-  const startTimeRef = useRef<number | null>(null);
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+function useTaskTiming(isRunning: boolean, startedAtMs?: number) {
+  const fallbackStartRef = useRef<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
-    if (isRunning && !startTimeRef.current) {
-      startTimeRef.current = Date.now();
-    }
-
     if (!isRunning) {
       return;
     }
 
+    if (startedAtMs == null && !fallbackStartRef.current) {
+      fallbackStartRef.current = Date.now();
+    }
+
+    setNow(Date.now());
     const interval = setInterval(() => {
-      if (startTimeRef.current) {
-        setElapsedSeconds(
-          Math.floor((Date.now() - startTimeRef.current) / 1000),
-        );
-      }
+      setNow(Date.now());
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [isRunning]);
+  }, [isRunning, startedAtMs]);
 
-  return elapsedSeconds;
+  const effectiveStart = startedAtMs ?? fallbackStartRef.current;
+  if (!isRunning || effectiveStart == null) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor((now - effectiveStart) / 1000));
 }
 
 function TaskStatusIndicator({ status }: { status: TaskStatus }) {
@@ -144,11 +146,13 @@ function TaskItem({
 }) {
   const status = getTaskStatus(part, isStreaming);
   const isRunning = status === "running" || status === "pending";
-  const elapsedSeconds = useTaskTiming(isRunning);
 
   const hasOutput = part.state === "output-available";
   const isComplete = hasOutput && !part.preliminary;
   const output = hasOutput ? part.output : undefined;
+  const startedAt =
+    typeof output?.startedAt === "number" ? output.startedAt : undefined;
+  const elapsedSeconds = useTaskTiming(isRunning, startedAt);
 
   const pendingToolCall: PendingToolCall | null = output?.pending ?? null;
   const toolCount =

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -3,7 +3,7 @@
 import { formatTokens, toRelativePath } from "@open-harness/shared";
 import { Loader2 } from "lucide-react";
 import type React from "react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import type { ToolRendererProps } from "@/app/lib/render-tool";
 import { DEFAULT_WORKING_DIRECTORY } from "@/lib/sandbox/config";
 import { cn } from "@/lib/utils";
@@ -30,6 +30,16 @@ function getToolSummary(toolCall: PendingToolCall): string {
   }
 }
 
+function countToolCalls(messages: unknown): number {
+  if (!Array.isArray(messages)) return 0;
+  return messages.filter(
+    (m) =>
+      typeof m === "object" &&
+      m !== null &&
+      (m as { role?: string }).role === "tool",
+  ).length;
+}
+
 function SubagentToolCall({
   toolCall,
   isRunning,
@@ -41,9 +51,7 @@ function SubagentToolCall({
 }) {
   const summary = getToolSummary(toolCall);
 
-  const dotColor = isRunning
-    ? "bg-yellow-500"
-    : "bg-green-500";
+  const dotColor = isRunning ? "bg-yellow-500" : "bg-green-500";
   const displayName =
     toolCall.name.charAt(0).toUpperCase() + toolCall.name.slice(1);
 
@@ -97,8 +105,6 @@ export function TaskRenderer({
   onDeny,
 }: ToolRendererProps<"tool-task">) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const toolCallsRef = useRef<PendingToolCall[]>([]);
-  const lastPendingKeyRef = useRef<string | null>(null);
 
   const input = part.input;
   const desc = input?.task ?? "Spawning subagent";
@@ -113,20 +119,8 @@ export function TaskRenderer({
   const isComplete = hasOutput && !isPreliminary;
   const output = hasOutput ? part.output : undefined;
 
-  // Accumulate pending tool calls across yields (each yield replaces the previous)
-  if (output?.pending) {
-    const key = JSON.stringify(output.pending);
-    if (key !== lastPendingKeyRef.current) {
-      lastPendingKeyRef.current = key;
-      toolCallsRef.current = [...toolCallsRef.current, output.pending];
-    }
-  }
-
-  const toolCalls = toolCallsRef.current;
-
-  const maxVisible = 4;
-  const hiddenCount = Math.max(0, toolCalls.length - maxVisible);
-  const visibleCalls = toolCalls.slice(-maxVisible);
+  const pendingToolCall = output?.pending ?? null;
+  const toolCount = isComplete ? countToolCalls(output?.final) : 0;
 
   const isTaskStreaming = hasOutput && isPreliminary;
 
@@ -158,9 +152,11 @@ export function TaskRenderer({
           ? "General"
           : "Task";
 
-  // Has expandable content if there are tool calls or the prompt is long
+  // Has expandable content if there's a pending tool call or the prompt is long
   const hasExpandableContent =
-    toolCalls.length > 0 || (fullPrompt && fullPrompt.length > 80);
+    pendingToolCall !== null ||
+    (fullPrompt && fullPrompt.length > 80) ||
+    isComplete;
 
   const handleClick = () => {
     if (hasExpandableContent) {
@@ -197,7 +193,9 @@ export function TaskRenderer({
         ) : state.running || isActuallyRunning ? (
           <Loader2 className="h-3 w-3 animate-spin text-yellow-500" />
         ) : (
-          <span className={cn("inline-block h-2 w-2 rounded-full", dotColor)} />
+          <span
+            className={cn("inline-block h-2 w-2 rounded-full", dotColor)}
+          />
         )}
         <span
           className={cn(
@@ -241,29 +239,14 @@ export function TaskRenderer({
         </div>
       )}
 
-      {/* Collapsed view - show last 4 tool calls */}
-      {!isExpanded && hasOutput && visibleCalls.length > 0 && (
+      {/* Collapsed view - show current pending tool call */}
+      {!isExpanded && pendingToolCall && (
         <div className="mt-3 space-y-1 pl-3">
-          {hiddenCount > 0 && (
-            <div className="text-sm text-muted-foreground">
-              ... {hiddenCount} more above
-            </div>
-          )}
-          {visibleCalls.map((tc, i) => {
-            const isLast = i === visibleCalls.length - 1;
-            const isToolRunning = isLast && isPreliminary;
-            return (
-              <SubagentToolCall
-                key={`${tc.name}-${i + hiddenCount}`}
-                toolCall={tc}
-                isRunning={isToolRunning}
-              />
-            );
-          })}
+          <SubagentToolCall toolCall={pendingToolCall} isRunning={isPreliminary} />
         </div>
       )}
 
-      {/* Expanded view - show all tool calls with full details */}
+      {/* Expanded view - show prompt and current tool call details */}
       {isExpanded && (
         <div className="mt-3 space-y-3 border-t border-border pt-3">
           {/* Full prompt */}
@@ -288,26 +271,17 @@ export function TaskRenderer({
             </div>
           )}
 
-          {/* All tool calls */}
-          {toolCalls.length > 0 && (
+          {/* Current tool call */}
+          {pendingToolCall && (
             <div>
               <div className="mb-1 text-xs font-medium text-muted-foreground">
-                Tool Calls ({toolCalls.length})
+                Current Tool Call
               </div>
-              <div className="max-h-96 space-y-1 overflow-auto">
-                {toolCalls.map((tc, i) => {
-                  const isLast = i === toolCalls.length - 1;
-                  const isToolRunning = isLast && isPreliminary;
-                  return (
-                    <SubagentToolCall
-                      key={`${tc.name}-${i}`}
-                      toolCall={tc}
-                      isRunning={isToolRunning}
-                      expanded
-                    />
-                  );
-                })}
-              </div>
+              <SubagentToolCall
+                toolCall={pendingToolCall}
+                isRunning={isPreliminary}
+                expanded
+              />
             </div>
           )}
         </div>
@@ -315,7 +289,7 @@ export function TaskRenderer({
 
       {!isExpanded && isComplete && (
         <div className="mt-2 pl-5 text-sm text-muted-foreground">
-          Complete ({toolCalls.length} tool calls
+          Complete ({toolCount} tool calls
           {output?.usage?.inputTokens
             ? `, ${formatTokens(output.usage.inputTokens)} tokens`
             : ""}

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -120,7 +120,8 @@ export function TaskRenderer({
   const output = hasOutput ? part.output : undefined;
 
   const pendingToolCall = output?.pending ?? null;
-  const toolCount = isComplete ? countToolCalls(output?.final) : 0;
+  const toolCount =
+    output?.toolCallCount ?? (isComplete ? countToolCalls(output?.final) : 0);
 
   const isTaskStreaming = hasOutput && isPreliminary;
 
@@ -193,9 +194,7 @@ export function TaskRenderer({
         ) : state.running || isActuallyRunning ? (
           <Loader2 className="h-3 w-3 animate-spin text-yellow-500" />
         ) : (
-          <span
-            className={cn("inline-block h-2 w-2 rounded-full", dotColor)}
-          />
+          <span className={cn("inline-block h-2 w-2 rounded-full", dotColor)} />
         )}
         <span
           className={cn(
@@ -242,7 +241,10 @@ export function TaskRenderer({
       {/* Collapsed view - show current pending tool call */}
       {!isExpanded && pendingToolCall && (
         <div className="mt-3 space-y-1 pl-3">
-          <SubagentToolCall toolCall={pendingToolCall} isRunning={isPreliminary} />
+          <SubagentToolCall
+            toolCall={pendingToolCall}
+            isRunning={isPreliminary}
+          />
         </div>
       )}
 

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { TaskPendingToolCall } from "@open-harness/agent";
 import { formatTokens, toRelativePath } from "@open-harness/shared";
 import { Loader2 } from "lucide-react";
 import type React from "react";
@@ -9,9 +10,7 @@ import { DEFAULT_WORKING_DIRECTORY } from "@/lib/sandbox/config";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "../approval-buttons";
 
-type PendingToolCall = { name: string; input: unknown };
-
-function getToolSummary(toolCall: PendingToolCall): string {
+function getToolSummary(toolCall: TaskPendingToolCall): string {
   const input = toolCall.input as Record<string, unknown> | undefined;
   switch (toolCall.name) {
     case "read":
@@ -45,7 +44,7 @@ function SubagentToolCall({
   isRunning,
   expanded = false,
 }: {
-  toolCall: PendingToolCall;
+  toolCall: TaskPendingToolCall;
   isRunning: boolean;
   expanded?: boolean;
 }) {

--- a/apps/web/components/tool-call/renderers/task-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/task-renderer.tsx
@@ -1,92 +1,51 @@
 "use client";
 
-import type { SubagentUIMessage } from "@open-harness/agent";
 import { formatTokens, toRelativePath } from "@open-harness/shared";
-import { getToolName, isTextUIPart, isToolUIPart } from "ai";
 import { Loader2 } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { ToolRendererProps } from "@/app/lib/render-tool";
 import { DEFAULT_WORKING_DIRECTORY } from "@/lib/sandbox/config";
 import { cn } from "@/lib/utils";
 import { ApprovalButtons } from "../approval-buttons";
 
-type SubagentMessagePart = SubagentUIMessage["parts"][number];
+type PendingToolCall = { name: string; input: unknown };
 
-type KeyedSubagentPart = {
-  part: SubagentMessagePart;
-  renderKey: string;
-};
-
-function getRelevantPartRenderEntries(
-  messageParts: SubagentMessagePart[],
-): KeyedSubagentPart[] {
-  const entries: KeyedSubagentPart[] = [];
-  let textOrdinal = 0;
-  let toolOrdinal = 0;
-
-  for (const part of messageParts) {
-    if (isToolUIPart(part)) {
-      entries.push({
-        part,
-        renderKey: part.toolCallId ?? `tool:${part.type}:${toolOrdinal}`,
-      });
-      toolOrdinal += 1;
-      continue;
+function getToolSummary(toolCall: PendingToolCall): string {
+  const input = toolCall.input as Record<string, unknown> | undefined;
+  switch (toolCall.name) {
+    case "read":
+    case "write":
+    case "edit": {
+      const fp = input?.filePath ?? "";
+      return fp ? toRelativePath(String(fp), DEFAULT_WORKING_DIRECTORY) : "";
     }
-
-    if (isTextUIPart(part)) {
-      entries.push({
-        part,
-        renderKey: `text:${textOrdinal}`,
-      });
-      textOrdinal += 1;
-    }
-  }
-
-  return entries;
-}
-
-function getToolSummary(part: SubagentMessagePart): string {
-  switch (part.type) {
-    case "tool-read":
-    case "tool-write":
-    case "tool-edit": {
-      const fp = part.input?.filePath ?? "";
-      return fp ? toRelativePath(fp, DEFAULT_WORKING_DIRECTORY) : "";
-    }
-    case "tool-grep":
-    case "tool-glob":
-      return part.input?.pattern ? `"${part.input.pattern}"` : "";
-    case "tool-bash":
-      return part.input?.command ?? "";
+    case "grep":
+    case "glob":
+      return input?.pattern ? `"${input.pattern}"` : "";
+    case "bash":
+      return input?.command ? String(input.command) : "";
     default:
       return "";
   }
 }
 
 function SubagentToolCall({
-  part,
+  toolCall,
+  isRunning,
   expanded = false,
 }: {
-  part: SubagentMessagePart;
+  toolCall: PendingToolCall;
+  isRunning: boolean;
   expanded?: boolean;
 }) {
-  if (!isToolUIPart(part)) return null;
-
-  const toolName = getToolName(part);
-  const isRunning =
-    part.state === "input-streaming" || part.state === "input-available";
-  const hasError = part.state === "output-error";
-
-  const summary = getToolSummary(part);
+  const summary = getToolSummary(toolCall);
 
   const dotColor = isRunning
     ? "bg-yellow-500"
-    : hasError
-      ? "bg-red-500"
-      : "bg-green-500";
-  const displayName = toolName.charAt(0).toUpperCase() + toolName.slice(1);
+    : "bg-green-500";
+  const displayName =
+    toolCall.name.charAt(0).toUpperCase() + toolCall.name.slice(1);
 
   return (
     <div className="border-l-2 border-border py-1 pl-3">
@@ -120,14 +79,11 @@ function SubagentToolCall({
             <span className="text-sm text-muted-foreground">)</span>
           </>
         )}
-        {hasError ? (
-          <span className="text-sm text-red-500"> - error</span>
-        ) : null}
       </div>
       {/* Show full input in expanded mode */}
       {expanded && (
         <pre className="ml-4 mt-1 max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-xs text-foreground">
-          {JSON.stringify(part.input, null, 2)}
+          {JSON.stringify(toolCall.input, null, 2)}
         </pre>
       )}
     </div>
@@ -141,6 +97,9 @@ export function TaskRenderer({
   onDeny,
 }: ToolRendererProps<"tool-task">) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const toolCallsRef = useRef<PendingToolCall[]>([]);
+  const lastPendingKeyRef = useRef<string | null>(null);
+
   const input = part.input;
   const desc = input?.task ?? "Spawning subagent";
   const fullPrompt = input?.instructions;
@@ -151,19 +110,24 @@ export function TaskRenderer({
 
   const hasOutput = part.state === "output-available";
   const isPreliminary = hasOutput && part.preliminary === true;
-  const message = hasOutput ? part.output : undefined;
+  const isComplete = hasOutput && !isPreliminary;
+  const output = hasOutput ? part.output : undefined;
 
-  const messageParts = message?.parts ?? [];
-  const relevantPartEntries = getRelevantPartRenderEntries(messageParts);
-  const relevantParts = relevantPartEntries.map((entry) => entry.part);
-  const toolParts = messageParts.filter(isToolUIPart);
-  const textParts = messageParts.filter(isTextUIPart);
+  // Accumulate pending tool calls across yields (each yield replaces the previous)
+  if (output?.pending) {
+    const key = JSON.stringify(output.pending);
+    if (key !== lastPendingKeyRef.current) {
+      lastPendingKeyRef.current = key;
+      toolCallsRef.current = [...toolCallsRef.current, output.pending];
+    }
+  }
+
+  const toolCalls = toolCallsRef.current;
 
   const maxVisible = 4;
-  const hiddenCount = Math.max(0, relevantPartEntries.length - maxVisible);
-  const visibleParts = relevantPartEntries.slice(-maxVisible);
+  const hiddenCount = Math.max(0, toolCalls.length - maxVisible);
+  const visibleCalls = toolCalls.slice(-maxVisible);
 
-  const isComplete = hasOutput && !isPreliminary;
   const isTaskStreaming = hasOutput && isPreliminary;
 
   // Compute running states using state.interrupted from shared extractRenderState
@@ -194,11 +158,9 @@ export function TaskRenderer({
           ? "General"
           : "Task";
 
-  // Has expandable content if there are tool parts or the prompt is long
+  // Has expandable content if there are tool calls or the prompt is long
   const hasExpandableContent =
-    toolParts.length > 0 ||
-    (fullPrompt && fullPrompt.length > 80) ||
-    textParts.length > 0;
+    toolCalls.length > 0 || (fullPrompt && fullPrompt.length > 80);
 
   const handleClick = () => {
     if (hasExpandableContent) {
@@ -279,38 +241,29 @@ export function TaskRenderer({
         </div>
       )}
 
-      {/* Collapsed view - show last 4 parts */}
-      {!isExpanded && hasOutput && visibleParts.length > 0 && (
+      {/* Collapsed view - show last 4 tool calls */}
+      {!isExpanded && hasOutput && visibleCalls.length > 0 && (
         <div className="mt-3 space-y-1 pl-3">
           {hiddenCount > 0 && (
             <div className="text-sm text-muted-foreground">
               ... {hiddenCount} more above
             </div>
           )}
-          {visibleParts.map(({ part: p, renderKey }) => {
-            if (isToolUIPart(p)) {
-              return <SubagentToolCall key={renderKey} part={p} />;
-            }
-            if (isTextUIPart(p)) {
-              const text = p.text?.trim() ?? "";
-              if (!text) return null;
-              const truncated =
-                text.length > 80 ? text.slice(0, 80) + "..." : text;
-              return (
-                <div
-                  key={renderKey}
-                  className="border-l-2 border-border py-1 pl-3 text-sm text-muted-foreground"
-                >
-                  {truncated}
-                </div>
-              );
-            }
-            return null;
+          {visibleCalls.map((tc, i) => {
+            const isLast = i === visibleCalls.length - 1;
+            const isToolRunning = isLast && isPreliminary;
+            return (
+              <SubagentToolCall
+                key={`${tc.name}-${i + hiddenCount}`}
+                toolCall={tc}
+                isRunning={isToolRunning}
+              />
+            );
           })}
         </div>
       )}
 
-      {/* Expanded view - show all parts with full details */}
+      {/* Expanded view - show all tool calls with full details */}
       {isExpanded && (
         <div className="mt-3 space-y-3 border-t border-border pt-3">
           {/* Full prompt */}
@@ -336,31 +289,23 @@ export function TaskRenderer({
           )}
 
           {/* All tool calls */}
-          {relevantParts.length > 0 && (
+          {toolCalls.length > 0 && (
             <div>
               <div className="mb-1 text-xs font-medium text-muted-foreground">
-                Tool Calls ({toolParts.length})
+                Tool Calls ({toolCalls.length})
               </div>
               <div className="max-h-96 space-y-1 overflow-auto">
-                {relevantPartEntries.map(({ part: p, renderKey }) => {
-                  if (isToolUIPart(p)) {
-                    return (
-                      <SubagentToolCall key={renderKey} part={p} expanded />
-                    );
-                  }
-                  if (isTextUIPart(p)) {
-                    const text = p.text?.trim() ?? "";
-                    if (!text) return null;
-                    return (
-                      <div
-                        key={renderKey}
-                        className="border-l-2 border-border py-1 pl-3 text-sm text-muted-foreground"
-                      >
-                        {text}
-                      </div>
-                    );
-                  }
-                  return null;
+                {toolCalls.map((tc, i) => {
+                  const isLast = i === toolCalls.length - 1;
+                  const isToolRunning = isLast && isPreliminary;
+                  return (
+                    <SubagentToolCall
+                      key={`${tc.name}-${i}`}
+                      toolCall={tc}
+                      isRunning={isToolRunning}
+                      expanded
+                    />
+                  );
                 })}
               </div>
             </div>
@@ -370,9 +315,9 @@ export function TaskRenderer({
 
       {!isExpanded && isComplete && (
         <div className="mt-2 pl-5 text-sm text-muted-foreground">
-          Complete ({toolParts.length} tool calls
-          {message?.metadata?.totalMessageUsage?.inputTokens
-            ? `, ${formatTokens(message.metadata.totalMessageUsage.inputTokens)} tokens`
+          Complete ({toolCalls.length} tool calls
+          {output?.usage?.inputTokens
+            ? `, ${formatTokens(output.usage.inputTokens)} tokens`
             : ""}
           )
         </div>

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cc-clone-ai-sdk",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cc-clone-ai-sdk",

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -29,7 +29,11 @@ export {
 } from "./tools/ask-user-question";
 export type { SkillToolInput } from "./tools/skill";
 // Tool exports
-export { type TaskToolUIPart } from "./tools/task";
+export type {
+  TaskPendingToolCall,
+  TaskToolOutput,
+  TaskToolUIPart,
+} from "./tools/task";
 export type {
   ApprovalConfig,
   ApprovalRule,

--- a/packages/agent/tools/index.ts
+++ b/packages/agent/tools/index.ts
@@ -4,7 +4,12 @@ export { writeFileTool, editFileTool } from "./write";
 export { grepTool } from "./grep";
 export { globTool } from "./glob";
 export { bashTool, commandNeedsApproval } from "./bash";
-export { taskTool, type TaskToolUIPart } from "./task";
+export {
+  taskTool,
+  type TaskPendingToolCall,
+  type TaskToolOutput,
+  type TaskToolUIPart,
+} from "./task";
 export {
   askUserQuestionTool,
   type AskUserQuestionToolUIPart,

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -14,6 +14,7 @@ import {
   getSandbox,
   shouldAutoApprove,
 } from "./utils";
+import { sumLanguageModelUsage } from "../usage";
 
 const subagentTypeSchema = z.enum(["explorer", "executor"]);
 
@@ -40,6 +41,7 @@ const toolCall = z.object({
 
 const taskOutputSchema = z.object({
   pending: toolCall.optional(),
+  toolCallCount: z.number().int().nonnegative().optional(),
   final: z.custom<ModelMessage[]>().optional(),
   usage: z.custom<LanguageModelUsage>().optional(),
 });
@@ -154,15 +156,27 @@ NOTE: The executor subagent requires user approval before running because it has
       abortSignal,
     });
 
+    let toolCallCount = 0;
+    let pending: { name: string; input: unknown } | undefined;
+    let usage: LanguageModelUsage | undefined;
+
     for await (const part of result.fullStream) {
       if (part.type === "tool-call") {
-        yield { pending: { name: part.toolName, input: part.input } };
+        toolCallCount += 1;
+        pending = { name: part.toolName, input: part.input };
+        yield { pending, toolCallCount, usage };
+      }
+
+      if (part.type === "finish-step") {
+        usage = sumLanguageModelUsage(usage, part.usage);
+        pending = undefined;
+        yield { pending, toolCallCount, usage };
       }
     }
-    const response = await result.response;
-    yield { final: response.messages, usage: await result.usage };
 
-    // Track last step usage for message metadata
+    const response = await result.response;
+    const finalUsage = usage ?? (await result.usage);
+    yield { final: response.messages, toolCallCount, usage: finalUsage };
   },
   toModelOutput: ({ output: { final: messages } }) => {
     if (!messages) {

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -42,6 +42,7 @@ const toolCall = z.object({
 const taskOutputSchema = z.object({
   pending: toolCall.optional(),
   toolCallCount: z.number().int().nonnegative().optional(),
+  startedAt: z.number().int().nonnegative().optional(),
   final: z.custom<ModelMessage[]>().optional(),
   usage: z.custom<LanguageModelUsage>().optional(),
 });
@@ -156,27 +157,36 @@ NOTE: The executor subagent requires user approval before running because it has
       abortSignal,
     });
 
+    const startedAt = Date.now();
     let toolCallCount = 0;
     let pending: { name: string; input: unknown } | undefined;
     let usage: LanguageModelUsage | undefined;
+
+    // Emit an initial state so UIs can show elapsed time from a stable timestamp.
+    yield { toolCallCount, startedAt };
 
     for await (const part of result.fullStream) {
       if (part.type === "tool-call") {
         toolCallCount += 1;
         pending = { name: part.toolName, input: part.input };
-        yield { pending, toolCallCount, usage };
+        yield { pending, toolCallCount, usage, startedAt };
       }
 
       if (part.type === "finish-step") {
         usage = sumLanguageModelUsage(usage, part.usage);
         pending = undefined;
-        yield { pending, toolCallCount, usage };
+        yield { pending, toolCallCount, usage, startedAt };
       }
     }
 
     const response = await result.response;
     const finalUsage = usage ?? (await result.usage);
-    yield { final: response.messages, toolCallCount, usage: finalUsage };
+    yield {
+      final: response.messages,
+      toolCallCount,
+      usage: finalUsage,
+      startedAt,
+    };
   },
   toModelOutput: ({ output: { final: messages } }) => {
     if (!messages) {

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -43,6 +43,7 @@ const taskOutputSchema = z.object({
   pending: toolCall.optional(),
   toolCallCount: z.number().int().nonnegative().optional(),
   startedAt: z.number().int().nonnegative().optional(),
+  modelId: z.string().optional(),
   final: z.custom<ModelMessage[]>().optional(),
   usage: z.custom<LanguageModelUsage>().optional(),
 });
@@ -146,6 +147,7 @@ NOTE: The executor subagent requires user approval before running because it has
   ) {
     const sandbox = getSandbox(experimental_context, "task");
     const model = getSubagentModel(experimental_context, "task");
+    const subagentModelId = typeof model === "string" ? model : model.modelId;
 
     const subagent =
       subagentType === "explorer" ? explorerSubagent : executorSubagent;
@@ -163,19 +165,31 @@ NOTE: The executor subagent requires user approval before running because it has
     let usage: LanguageModelUsage | undefined;
 
     // Emit an initial state so UIs can show elapsed time from a stable timestamp.
-    yield { toolCallCount, startedAt };
+    yield { toolCallCount, startedAt, modelId: subagentModelId };
 
     for await (const part of result.fullStream) {
       if (part.type === "tool-call") {
         toolCallCount += 1;
         pending = { name: part.toolName, input: part.input };
-        yield { pending, toolCallCount, usage, startedAt };
+        yield {
+          pending,
+          toolCallCount,
+          usage,
+          startedAt,
+          modelId: subagentModelId,
+        };
       }
 
       if (part.type === "finish-step") {
         usage = sumLanguageModelUsage(usage, part.usage);
         pending = undefined;
-        yield { pending, toolCallCount, usage, startedAt };
+        yield {
+          pending,
+          toolCallCount,
+          usage,
+          startedAt,
+          modelId: subagentModelId,
+        };
       }
     }
 
@@ -186,6 +200,7 @@ NOTE: The executor subagent requires user approval before running because it has
       toolCallCount,
       usage: finalUsage,
       startedAt,
+      modelId: subagentModelId,
     };
   },
   toModelOutput: ({ output: { final: messages } }) => {

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -34,19 +34,23 @@ const taskInputSchema = z.object({
   ),
 });
 
-const toolCall = z.object({
+const taskPendingToolCallSchema = z.object({
   name: z.string(),
   input: z.unknown(),
 });
 
-const taskOutputSchema = z.object({
-  pending: toolCall.optional(),
+export type TaskPendingToolCall = z.infer<typeof taskPendingToolCallSchema>;
+
+export const taskOutputSchema = z.object({
+  pending: taskPendingToolCallSchema.optional(),
   toolCallCount: z.number().int().nonnegative().optional(),
   startedAt: z.number().int().nonnegative().optional(),
   modelId: z.string().optional(),
   final: z.custom<ModelMessage[]>().optional(),
   usage: z.custom<LanguageModelUsage>().optional(),
 });
+
+export type TaskToolOutput = z.infer<typeof taskOutputSchema>;
 
 /**
  * Check if a subagent type matches any approval rules.
@@ -161,7 +165,7 @@ NOTE: The executor subagent requires user approval before running because it has
 
     const startedAt = Date.now();
     let toolCallCount = 0;
-    let pending: { name: string; input: unknown } | undefined;
+    let pending: TaskPendingToolCall | undefined;
     let usage: LanguageModelUsage | undefined;
 
     // Emit an initial state so UIs can show elapsed time from a stable timestamp.

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -182,7 +182,8 @@ NOTE: The executor subagent requires user approval before running because it has
 
       if (part.type === "finish-step") {
         usage = sumLanguageModelUsage(usage, part.usage);
-        pending = undefined;
+        // Keep the last observed tool call in interim updates so task UIs don't
+        // flicker back to an initializing state between subagent steps.
         yield {
           pending,
           toolCallCount,

--- a/packages/agent/tools/task.ts
+++ b/packages/agent/tools/task.ts
@@ -1,13 +1,12 @@
 import {
-  type LanguageModelUsage,
-  readUIMessageStream,
   tool,
+  type ModelMessage,
   type UIToolInvocation,
+  type LanguageModelUsage,
 } from "ai";
 import { z } from "zod";
 import { executorSubagent } from "../subagents/executor";
 import { explorerSubagent } from "../subagents/explorer";
-import type { SubagentUIMessage } from "../subagents/types";
 import type { ApprovalRule } from "../types";
 import {
   getApprovalContext,
@@ -32,6 +31,17 @@ const taskInputSchema = z.object({
 - Constraints and patterns to follow
 - How to verify the work`,
   ),
+});
+
+const toolCall = z.object({
+  name: z.string(),
+  input: z.unknown(),
+});
+
+const taskOutputSchema = z.object({
+  pending: toolCall.optional(),
+  final: z.custom<ModelMessage[]>().optional(),
+  usage: z.custom<LanguageModelUsage>().optional(),
 });
 
 /**
@@ -126,13 +136,13 @@ IMPORTANT:
 
 NOTE: The executor subagent requires user approval before running because it has full write access.`,
   inputSchema: taskInputSchema,
+  outputSchema: taskOutputSchema,
   execute: async function* (
     { subagentType, task, instructions },
     { experimental_context, abortSignal },
   ) {
     const sandbox = getSandbox(experimental_context, "task");
     const model = getSubagentModel(experimental_context, "task");
-    const subagentModelId = typeof model === "string" ? model : model.modelId;
 
     const subagent =
       subagentType === "explorer" ? explorerSubagent : executorSubagent;
@@ -144,43 +154,36 @@ NOTE: The executor subagent requires user approval before running because it has
       abortSignal,
     });
 
-    // Track last step usage for message metadata
-    let lastStepUsage: LanguageModelUsage | undefined;
-
-    for await (const message of readUIMessageStream<SubagentUIMessage>({
-      stream: result.toUIMessageStream<SubagentUIMessage>({
-        messageMetadata: ({ part }) => {
-          // Track per-step usage from finish-step events
-          if (part.type === "finish-step") {
-            lastStepUsage = part.usage;
-            return {
-              lastStepUsage,
-              totalMessageUsage: undefined,
-              modelId: subagentModelId,
-            };
-          }
-          // On finish, include both the last step usage and total message usage
-          if (part.type === "finish") {
-            return {
-              lastStepUsage,
-              totalMessageUsage: part.totalUsage,
-              modelId: subagentModelId,
-            };
-          }
-        },
-      }),
-    })) {
-      yield message;
+    for await (const part of result.fullStream) {
+      if (part.type === "tool-call") {
+        yield { pending: { name: part.toolName, input: part.input } };
+      }
     }
+    const response = await result.response;
+    yield { final: response.messages, usage: await result.usage };
+
+    // Track last step usage for message metadata
   },
-  toModelOutput: ({ output: message }) => {
-    if (!message) {
+  toModelOutput: ({ output: { final: messages } }) => {
+    if (!messages) {
       return { type: "text", value: "Task completed." };
     }
 
-    const lastTextPart = message.parts.findLast((p) => p.type === "text");
+    const lastAssistantMessage = messages.findLast(
+      (p) => p.role === "assistant",
+    );
+    const content = lastAssistantMessage?.content;
 
-    if (!lastTextPart || lastTextPart.type !== "text") {
+    if (!content) {
+      return { type: "text", value: "Task completed." };
+    }
+
+    if (typeof content === "string") {
+      return { type: "text", value: content };
+    }
+
+    const lastTextPart = content.findLast((p) => p.type === "text");
+    if (!lastTextPart) {
       return { type: "text", value: "Task completed." };
     }
 

--- a/packages/agent/usage.ts
+++ b/packages/agent/usage.ts
@@ -108,10 +108,16 @@ function extractTaskOutputUsage(
     return undefined;
   }
 
-  // New output shape: { usage?: LanguageModelUsage, final?: ModelMessage[] }
+  // New output shape: {
+  //   usage?: LanguageModelUsage,
+  //   final?: ModelMessage[],
+  //   modelId?: string,
+  // }
   const usage = output.usage;
+  const modelId =
+    typeof output.modelId === "string" ? output.modelId : undefined;
   if (isLanguageModelUsage(usage)) {
-    return { usage };
+    return { usage, modelId };
   }
 
   // Legacy fallback: { metadata: { totalMessageUsage?, lastStepUsage?, modelId? } }
@@ -119,15 +125,15 @@ function extractTaskOutputUsage(
   if (!isRecord(metadata)) {
     return undefined;
   }
-  const modelId =
+  const legacyModelId =
     typeof metadata.modelId === "string" ? metadata.modelId : undefined;
   const totalMessageUsage = metadata.totalMessageUsage;
   if (isLanguageModelUsage(totalMessageUsage)) {
-    return { usage: totalMessageUsage, modelId };
+    return { usage: totalMessageUsage, modelId: legacyModelId };
   }
   const lastStepUsage = metadata.lastStepUsage;
   if (isLanguageModelUsage(lastStepUsage)) {
-    return { usage: lastStepUsage, modelId };
+    return { usage: lastStepUsage, modelId: legacyModelId };
   }
   return undefined;
 }

--- a/packages/agent/usage.ts
+++ b/packages/agent/usage.ts
@@ -107,6 +107,14 @@ function extractTaskOutputUsage(
   if (!isRecord(output)) {
     return undefined;
   }
+
+  // New output shape: { usage?: LanguageModelUsage, final?: ModelMessage[] }
+  const usage = output.usage;
+  if (isLanguageModelUsage(usage)) {
+    return { usage };
+  }
+
+  // Legacy fallback: { metadata: { totalMessageUsage?, lastStepUsage?, modelId? } }
   const metadata = output.metadata;
   if (!isRecord(metadata)) {
     return undefined;


### PR DESCRIPTION
Simplify task tool implementation by migrating from custom message stream handling to the standard fullStream API.

- Replace `readUIMessageStream` with direct `fullStream` iteration to simplify message processing
- Add `taskOutputSchema` to define tool output structure with pending tool calls, final messages, and usage data
- Remove custom `messageMetadata` transformation logic and unused `toUIMessageStream` handling
- Update `toModelOutput` to extract text from `ModelMessage[]` instead of legacy message parts
- Clean up imports (remove unused `readUIMessageStream` and `SubagentUIMessage` type)