### PR TITLE
fix: sanitize incomplete GPT-5.4 reasoning before agent calls

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -3,10 +3,10 @@ import {
   collectTaskToolUsageEvents,
   discoverSkills,
   gateway,
+  removeIncompleteOpenAIReasoningBlocks,
   sumLanguageModelUsage,
 } from "@open-harness/agent";
 import { connectSandbox, type SandboxState } from "@open-harness/sandbox";
-import { DEFAULT_SANDBOX_PORTS } from "@/lib/sandbox/config";
 import {
   convertToModelMessages,
   type GatewayModelId,
@@ -14,6 +14,7 @@ import {
   type LanguageModelUsage,
 } from "ai";
 import { nanoid } from "nanoid";
+import { after } from "next/server";
 import { webAgent } from "@/app/config";
 import type { WebAgentUIMessage } from "@/app/types";
 import {
@@ -29,17 +30,17 @@ import {
   upsertChatMessageScoped,
 } from "@/lib/db/sessions";
 import { recordUsage } from "@/lib/db/usage";
+import { getUserPreferences } from "@/lib/db/user-preferences";
 import { getRepoToken } from "@/lib/github/get-repo-token";
 import { getUserGitHubToken } from "@/lib/github/user-token";
-import { getUserPreferences } from "@/lib/db/user-preferences";
 import { resolveModelSelection } from "@/lib/model-variants";
 import { DEFAULT_MODEL_ID } from "@/lib/models";
 import { resumableStreamContext } from "@/lib/resumable-stream-context";
+import { DEFAULT_SANDBOX_PORTS } from "@/lib/sandbox/config";
 import { buildActiveLifecycleUpdate } from "@/lib/sandbox/lifecycle";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 import { onStopSignal } from "@/lib/stop-signal";
-import { after } from "next/server";
 
 const cachedInputTokensFor = (usage: LanguageModelUsage) =>
   usage.inputTokenDetails?.cacheReadTokens ?? usage.cachedInputTokens ?? 0;
@@ -530,8 +531,35 @@ export async function POST(req: Request) {
 
   let result;
   try {
+    const preparedModelMessages = removeIncompleteOpenAIReasoningBlocks(
+      modelMessages,
+      mainResolvedModelId,
+    );
+
+    if (preparedModelMessages !== modelMessages) {
+      console.warn(
+        `[chat] Removed incomplete GPT-5.4 reasoning blocks for chat ${chatId}`,
+      );
+    }
+
+    // Write out modelMessages to the filesystem for debugging
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const debugDir = path.join(process.cwd(), ".debug");
+    fs.mkdirSync(debugDir, { recursive: true });
+    const debugFile = path.join(
+      debugDir,
+      `model-messages-${chatId}-${Date.now()}.json`,
+    );
+    fs.writeFileSync(
+      debugFile,
+      JSON.stringify(preparedModelMessages, null, 2),
+      "utf-8",
+    );
+    console.log(`[chat] Wrote modelMessages to ${debugFile}`);
+
     result = await webAgent.stream({
-      messages: modelMessages,
+      messages: preparedModelMessages,
       options: {
         sandbox,
         model,

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -3,7 +3,6 @@ import {
   collectTaskToolUsageEvents,
   discoverSkills,
   gateway,
-  removeIncompleteOpenAIReasoningBlocks,
   sumLanguageModelUsage,
 } from "@open-harness/agent";
 import { connectSandbox, type SandboxState } from "@open-harness/sandbox";
@@ -531,35 +530,8 @@ export async function POST(req: Request) {
 
   let result;
   try {
-    const preparedModelMessages = removeIncompleteOpenAIReasoningBlocks(
-      modelMessages,
-      mainResolvedModelId,
-    );
-
-    if (preparedModelMessages !== modelMessages) {
-      console.warn(
-        `[chat] Removed incomplete GPT-5.4 reasoning blocks for chat ${chatId}`,
-      );
-    }
-
-    // Write out modelMessages to the filesystem for debugging
-    const fs = await import("node:fs");
-    const path = await import("node:path");
-    const debugDir = path.join(process.cwd(), ".debug");
-    fs.mkdirSync(debugDir, { recursive: true });
-    const debugFile = path.join(
-      debugDir,
-      `model-messages-${chatId}-${Date.now()}.json`,
-    );
-    fs.writeFileSync(
-      debugFile,
-      JSON.stringify(preparedModelMessages, null, 2),
-      "utf-8",
-    );
-    console.log(`[chat] Wrote modelMessages to ${debugFile}`);
-
     result = await webAgent.stream({
-      messages: preparedModelMessages,
+      messages: modelMessages,
       options: {
         sandbox,
         model,

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -74,6 +74,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 
 ## Chat / Streaming UI
 
+- GPT-5.4 incomplete OpenAI reasoning cleanup belongs in agent `prepareCall`, not in the web route, so every agent entry point sanitizes replay history immediately before model invocation.
 - In the web chat UI, do not keep `@ai-sdk/react` Chat instances alive after route transitions while they are still streaming; abort local stream processing and remove the instance on teardown, then rely on resumable stream reconnect when revisiting that chat.
 - For client-side tool flows (`ask_user_question`), `onFinish`-only assistant persistence is insufficient across route switches: persist the latest incoming message snapshot at API request start (upsert by message id) so answered/declined tool state survives teardown/resume and does not rehydrate stale `input-available` UI.
 - Request-start assistant snapshot persistence must be scoped and ownership-guarded: only upsert assistant messages when the request still owns the chat stream token, and refuse upserts on message-id scope conflict (different chat/role) to prevent stale writes and cross-chat overwrites.

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -6,7 +6,6 @@ export {
   extractTodosFromStep,
   openHarnessAgent,
 } from "./open-harness-agent";
-export { removeIncompleteOpenAIReasoningBlocks } from "./openai-reasoning";
 // Skills exports
 export { discoverSkills, parseSkillFrontmatter } from "./skills/discovery";
 export { extractSkillBody, substituteArguments } from "./skills/loader";

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -6,6 +6,7 @@ export {
   extractTodosFromStep,
   openHarnessAgent,
 } from "./open-harness-agent";
+export { removeIncompleteOpenAIReasoningBlocks } from "./openai-reasoning";
 // Skills exports
 export { discoverSkills, parseSkillFrontmatter } from "./skills/discovery";
 export { extractSkillBody, substituteArguments } from "./skills/loader";

--- a/packages/agent/open-harness-agent.ts
+++ b/packages/agent/open-harness-agent.ts
@@ -10,6 +10,7 @@ import {
 import { z } from "zod";
 import { addCacheControl } from "./context-management";
 import { aggressiveCompactContext } from "./context-management/aggressive-compaction";
+import { preparePromptForOpenAIReasoning } from "./openai-reasoning";
 
 import type { SkillMetadata } from "./skills/types";
 import { buildSystemPrompt } from "./system-prompt";
@@ -180,6 +181,11 @@ export const openHarnessAgent = new ToolLoopAgent({
     const sandbox = options.sandbox;
     const skills = options.skills ?? [];
     const context = options.context;
+    const preparedPrompt = preparePromptForOpenAIReasoning({
+      model: callModel,
+      messages: settings.messages,
+      prompt: settings.prompt,
+    });
 
     // Derive mode for system prompt (interactive vs background)
     const mode = approval.type === "background" ? "background" : "interactive";
@@ -196,6 +202,7 @@ export const openHarnessAgent = new ToolLoopAgent({
 
     return {
       ...settings,
+      ...preparedPrompt,
       model: callModel,
       tools: addCacheControl({
         tools: settings.tools ?? tools,

--- a/packages/agent/openai-reasoning.test.ts
+++ b/packages/agent/openai-reasoning.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import type { ModelMessage } from "ai";
-import { removeIncompleteOpenAIReasoningBlocks } from "./openai-reasoning";
+import { gateway, type ModelMessage } from "ai";
+import {
+  preparePromptForOpenAIReasoning,
+  removeIncompleteOpenAIReasoningBlocks,
+} from "./openai-reasoning";
 
 describe("removeIncompleteOpenAIReasoningBlocks", () => {
   test("removes assistant messages made only of incomplete GPT-5.4 reasoning blocks", () => {
@@ -156,5 +159,45 @@ describe("removeIncompleteOpenAIReasoningBlocks", () => {
     expect(
       removeIncompleteOpenAIReasoningBlocks(messages, "openai/gpt-5.3-codex"),
     ).toBe(messages);
+  });
+
+  test("sanitizes array prompts so prepareCall can reuse the same cleanup", () => {
+    const prompt: ModelMessage[] = [
+      { role: "user", content: "Plan the fix." },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "Inspecting the failure",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(
+      preparePromptForOpenAIReasoning({
+        model: gateway("openai/gpt-5.4-codex"),
+        prompt,
+      }),
+    ).toEqual({
+      prompt: [{ role: "user", content: "Plan the fix." }],
+    });
+  });
+
+  test("leaves string prompts untouched", () => {
+    expect(
+      preparePromptForOpenAIReasoning({
+        model: gateway("openai/gpt-5.4-codex"),
+        prompt: "Plan the fix.",
+      }),
+    ).toEqual({
+      prompt: "Plan the fix.",
+    });
   });
 });

--- a/packages/agent/openai-reasoning.test.ts
+++ b/packages/agent/openai-reasoning.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelMessage } from "ai";
+import { removeIncompleteOpenAIReasoningBlocks } from "./openai-reasoning";
+
+describe("removeIncompleteOpenAIReasoningBlocks", () => {
+  test("removes assistant messages made only of incomplete GPT-5.4 reasoning blocks", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "Plan the fix." },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "Inspecting the failure",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+          {
+            type: "reasoning",
+            text: "Drafting the next step",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+        ],
+      },
+      { role: "user", content: "Keep going" },
+    ];
+
+    expect(
+      removeIncompleteOpenAIReasoningBlocks(messages, "openai/gpt-5.4-codex"),
+    ).toEqual([
+      { role: "user", content: "Plan the fix." },
+      { role: "user", content: "Keep going" },
+    ]);
+  });
+
+  test("keeps the original array when the final GPT-5.4 reasoning part has encrypted content", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "Plan the fix." },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "Inspecting the failure",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+          {
+            type: "reasoning",
+            text: "Drafting the next step",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+                reasoningEncryptedContent: "encrypted",
+              },
+            },
+          },
+          {
+            type: "text",
+            text: "Here is the plan.",
+          },
+        ],
+      },
+    ];
+
+    expect(
+      removeIncompleteOpenAIReasoningBlocks(messages, "openai/gpt-5.4-codex"),
+    ).toBe(messages);
+  });
+
+  test("strips only incomplete reasoning runs and preserves surrounding assistant content", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "Plan the fix." },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Started planning.",
+          },
+          {
+            type: "reasoning",
+            text: "Inspecting the failure",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+          {
+            type: "reasoning",
+            text: "Drafting the next step",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+          {
+            type: "text",
+            text: "Ready for the next step.",
+          },
+        ],
+      },
+    ];
+
+    expect(
+      removeIncompleteOpenAIReasoningBlocks(messages, "openai/gpt-5.4-codex"),
+    ).toEqual([
+      { role: "user", content: "Plan the fix." },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Started planning.",
+          },
+          {
+            type: "text",
+            text: "Ready for the next step.",
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("skips cleanup for non-GPT-5.4 OpenAI models", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "Plan the fix." },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "Inspecting the failure",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(
+      removeIncompleteOpenAIReasoningBlocks(messages, "openai/gpt-5.3-codex"),
+    ).toBe(messages);
+  });
+});

--- a/packages/agent/openai-reasoning.test.ts
+++ b/packages/agent/openai-reasoning.test.ts
@@ -81,7 +81,7 @@ describe("removeIncompleteOpenAIReasoningBlocks", () => {
     ).toBe(messages);
   });
 
-  test("strips only incomplete reasoning runs and preserves surrounding assistant content", () => {
+  test("strips incomplete GPT-5.4 reasoning per itemId and preserves surrounding assistant content", () => {
     const messages: ModelMessage[] = [
       { role: "user", content: "Plan the fix." },
       {
@@ -93,19 +93,20 @@ describe("removeIncompleteOpenAIReasoningBlocks", () => {
           },
           {
             type: "reasoning",
-            text: "Inspecting the failure",
+            text: "Incomplete first item",
             providerOptions: {
               openai: {
-                itemId: "rs_123",
+                itemId: "rs_incomplete",
               },
             },
           },
           {
             type: "reasoning",
-            text: "Drafting the next step",
+            text: "Complete second item",
             providerOptions: {
               openai: {
-                itemId: "rs_123",
+                itemId: "rs_complete",
+                reasoningEncryptedContent: "encrypted",
               },
             },
           },
@@ -127,6 +128,16 @@ describe("removeIncompleteOpenAIReasoningBlocks", () => {
           {
             type: "text",
             text: "Started planning.",
+          },
+          {
+            type: "reasoning",
+            text: "Complete second item",
+            providerOptions: {
+              openai: {
+                itemId: "rs_complete",
+                reasoningEncryptedContent: "encrypted",
+              },
+            },
           },
           {
             type: "text",

--- a/packages/agent/openai-reasoning.ts
+++ b/packages/agent/openai-reasoning.ts
@@ -15,65 +15,104 @@ function getModelId(model: LanguageModel): string {
   return typeof model === "string" ? model : model.modelId;
 }
 
-function hasEncryptedReasoningContent(part: AssistantContentPart): boolean {
+interface OpenAIReasoningMetadata {
+  hasOpenAIOptions: boolean;
+  itemId: string | null;
+  encryptedContent: string | null;
+}
+
+function getOpenAIReasoningMetadata(
+  part: AssistantContentPart,
+): OpenAIReasoningMetadata {
   if (part.type !== "reasoning") {
-    return false;
+    return {
+      hasOpenAIOptions: false,
+      itemId: null,
+      encryptedContent: null,
+    };
   }
 
-  const encryptedContent =
-    part.providerOptions?.openai?.reasoningEncryptedContent;
+  const openaiOptions = part.providerOptions?.openai;
+  if (!openaiOptions || typeof openaiOptions !== "object") {
+    return {
+      hasOpenAIOptions: false,
+      itemId: null,
+      encryptedContent: null,
+    };
+  }
 
-  return typeof encryptedContent === "string" && encryptedContent.length > 0;
+  const itemId =
+    typeof openaiOptions.itemId === "string" && openaiOptions.itemId.length > 0
+      ? openaiOptions.itemId
+      : null;
+  const encryptedContent =
+    typeof openaiOptions.reasoningEncryptedContent === "string" &&
+    openaiOptions.reasoningEncryptedContent.trim().length > 0
+      ? openaiOptions.reasoningEncryptedContent
+      : null;
+
+  return {
+    hasOpenAIOptions: true,
+    itemId,
+    encryptedContent,
+  };
+}
+
+function collectItemIdsWithEncryptedReasoningContent(
+  messages: ModelMessage[],
+): Set<string> {
+  const itemIdsWithEncryptedContent = new Set<string>();
+
+  for (const message of messages) {
+    if (
+      !message ||
+      message.role !== "assistant" ||
+      !Array.isArray(message.content)
+    ) {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (!part) {
+        continue;
+      }
+
+      const metadata = getOpenAIReasoningMetadata(part);
+      if (metadata.itemId && metadata.encryptedContent) {
+        itemIdsWithEncryptedContent.add(metadata.itemId);
+      }
+    }
+  }
+
+  return itemIdsWithEncryptedContent;
 }
 
 function removeIncompleteReasoningFromAssistantContent(
   content: AssistantContentPart[],
+  itemIdsWithEncryptedContent: Set<string>,
 ): AssistantContentPart[] | null {
   let cleanedContent: AssistantContentPart[] | null = null;
 
-  for (let index = 0; index < content.length; ) {
+  for (let index = 0; index < content.length; index++) {
     const part = content[index];
 
     if (!part) {
-      index += 1;
       continue;
     }
 
-    if (part.type !== "reasoning") {
+    const metadata = getOpenAIReasoningMetadata(part);
+    const shouldStrip =
+      metadata.encryptedContent === null &&
+      ((metadata.itemId !== null &&
+        !itemIdsWithEncryptedContent.has(metadata.itemId)) ||
+        (metadata.itemId === null && metadata.hasOpenAIOptions));
+
+    if (!shouldStrip) {
       cleanedContent?.push(part);
-      index += 1;
       continue;
     }
 
-    let runEnd = index + 1;
-    while (content[runEnd]?.type === "reasoning") {
-      runEnd += 1;
-    }
-
-    const lastReasoningPart = content[runEnd - 1];
-    if (
-      !lastReasoningPart ||
-      !hasEncryptedReasoningContent(lastReasoningPart)
-    ) {
-      cleanedContent ??= content.slice(0, index);
-      index = runEnd;
-      continue;
-    }
-
-    if (cleanedContent) {
-      for (
-        let reasoningIndex = index;
-        reasoningIndex < runEnd;
-        reasoningIndex++
-      ) {
-        const reasoningPart = content[reasoningIndex];
-        if (reasoningPart) {
-          cleanedContent.push(reasoningPart);
-        }
-      }
-    }
-
-    index = runEnd;
+    cleanedContent ??= content.slice(0, index);
   }
 
   if (cleanedContent === null) {
@@ -98,6 +137,9 @@ export function removeIncompleteOpenAIReasoningBlocks(
     return messages;
   }
 
+  const itemIdsWithEncryptedContent =
+    collectItemIdsWithEncryptedReasoningContent(messages);
+
   let cleanedMessages: ModelMessage[] | null = null;
 
   for (let index = 0; index < messages.length; index++) {
@@ -114,6 +156,7 @@ export function removeIncompleteOpenAIReasoningBlocks(
 
     const cleanedContent = removeIncompleteReasoningFromAssistantContent(
       message.content,
+      itemIdsWithEncryptedContent,
     );
 
     if (cleanedContent === message.content) {

--- a/packages/agent/openai-reasoning.ts
+++ b/packages/agent/openai-reasoning.ts
@@ -1,4 +1,4 @@
-import type { AssistantModelMessage, ModelMessage } from "ai";
+import type { AssistantModelMessage, LanguageModel, ModelMessage } from "ai";
 
 const OPENAI_GPT_54_PREFIX = "openai/gpt-5.4";
 
@@ -9,6 +9,10 @@ type AssistantContentPart = Exclude<
 
 function shouldRemoveIncompleteOpenAIReasoningBlocks(modelId: string): boolean {
   return modelId.startsWith(OPENAI_GPT_54_PREFIX);
+}
+
+function getModelId(model: LanguageModel): string {
+  return typeof model === "string" ? model : model.modelId;
 }
 
 function hasEncryptedReasoningContent(part: AssistantContentPart): boolean {
@@ -128,4 +132,33 @@ export function removeIncompleteOpenAIReasoningBlocks(
   }
 
   return cleanedMessages ?? messages;
+}
+
+export function preparePromptForOpenAIReasoning({
+  model,
+  messages,
+  prompt,
+}: {
+  model: LanguageModel;
+  messages?: ModelMessage[];
+  prompt?: string | ModelMessage[];
+}): {
+  messages?: ModelMessage[];
+  prompt?: string | ModelMessage[];
+} {
+  const modelId = getModelId(model);
+
+  if (messages) {
+    return {
+      messages: removeIncompleteOpenAIReasoningBlocks(messages, modelId),
+    };
+  }
+
+  if (Array.isArray(prompt)) {
+    return {
+      prompt: removeIncompleteOpenAIReasoningBlocks(prompt, modelId),
+    };
+  }
+
+  return { prompt };
 }

--- a/packages/agent/openai-reasoning.ts
+++ b/packages/agent/openai-reasoning.ts
@@ -1,0 +1,131 @@
+import type { AssistantModelMessage, ModelMessage } from "ai";
+
+const OPENAI_GPT_54_PREFIX = "openai/gpt-5.4";
+
+type AssistantContentPart = Exclude<
+  AssistantModelMessage["content"],
+  string
+>[number];
+
+function shouldRemoveIncompleteOpenAIReasoningBlocks(modelId: string): boolean {
+  return modelId.startsWith(OPENAI_GPT_54_PREFIX);
+}
+
+function hasEncryptedReasoningContent(part: AssistantContentPart): boolean {
+  if (part.type !== "reasoning") {
+    return false;
+  }
+
+  const encryptedContent =
+    part.providerOptions?.openai?.reasoningEncryptedContent;
+
+  return typeof encryptedContent === "string" && encryptedContent.length > 0;
+}
+
+function removeIncompleteReasoningFromAssistantContent(
+  content: AssistantContentPart[],
+): AssistantContentPart[] | null {
+  let cleanedContent: AssistantContentPart[] | null = null;
+
+  for (let index = 0; index < content.length; ) {
+    const part = content[index];
+
+    if (!part) {
+      index += 1;
+      continue;
+    }
+
+    if (part.type !== "reasoning") {
+      cleanedContent?.push(part);
+      index += 1;
+      continue;
+    }
+
+    let runEnd = index + 1;
+    while (content[runEnd]?.type === "reasoning") {
+      runEnd += 1;
+    }
+
+    const lastReasoningPart = content[runEnd - 1];
+    if (
+      !lastReasoningPart ||
+      !hasEncryptedReasoningContent(lastReasoningPart)
+    ) {
+      cleanedContent ??= content.slice(0, index);
+      index = runEnd;
+      continue;
+    }
+
+    if (cleanedContent) {
+      for (
+        let reasoningIndex = index;
+        reasoningIndex < runEnd;
+        reasoningIndex++
+      ) {
+        const reasoningPart = content[reasoningIndex];
+        if (reasoningPart) {
+          cleanedContent.push(reasoningPart);
+        }
+      }
+    }
+
+    index = runEnd;
+  }
+
+  if (cleanedContent === null) {
+    return content;
+  }
+
+  if (cleanedContent.length === 0) {
+    return null;
+  }
+
+  return cleanedContent;
+}
+
+export function removeIncompleteOpenAIReasoningBlocks(
+  messages: ModelMessage[],
+  modelId: string,
+): ModelMessage[] {
+  if (
+    messages.length === 0 ||
+    !shouldRemoveIncompleteOpenAIReasoningBlocks(modelId)
+  ) {
+    return messages;
+  }
+
+  let cleanedMessages: ModelMessage[] | null = null;
+
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+
+    if (!message) {
+      continue;
+    }
+
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      cleanedMessages?.push(message);
+      continue;
+    }
+
+    const cleanedContent = removeIncompleteReasoningFromAssistantContent(
+      message.content,
+    );
+
+    if (cleanedContent === message.content) {
+      cleanedMessages?.push(message);
+      continue;
+    }
+
+    cleanedMessages ??= messages.slice(0, index);
+
+    if (cleanedContent) {
+      cleanedMessages.push({
+        ...message,
+        content: cleanedContent,
+      });
+    }
+  }
+
+  return cleanedMessages ?? messages;
+}

--- a/packages/agent/subagents/executor.ts
+++ b/packages/agent/subagents/executor.ts
@@ -2,6 +2,7 @@ import type { Sandbox } from "@open-harness/sandbox";
 import type { LanguageModel } from "ai";
 import { gateway, stepCountIs, ToolLoopAgent } from "ai";
 import { z } from "zod";
+import { preparePromptForOpenAIReasoning } from "../openai-reasoning";
 import { bashTool } from "../tools/bash";
 import { globTool } from "../tools/glob";
 import { grepTool } from "../tools/grep";
@@ -83,8 +84,14 @@ export const executorSubagent = new ToolLoopAgent({
   prepareCall: ({ options, ...settings }) => {
     const sandbox = options.sandbox;
     const model = options.model ?? settings.model;
+    const preparedPrompt = preparePromptForOpenAIReasoning({
+      model,
+      messages: settings.messages,
+      prompt: settings.prompt,
+    });
     return {
       ...settings,
+      ...preparedPrompt,
       model,
       instructions: `${EXECUTOR_SYSTEM_PROMPT}
 

--- a/packages/agent/subagents/explorer.ts
+++ b/packages/agent/subagents/explorer.ts
@@ -2,6 +2,7 @@ import type { Sandbox } from "@open-harness/sandbox";
 import type { LanguageModel } from "ai";
 import { gateway, stepCountIs, ToolLoopAgent } from "ai";
 import { z } from "zod";
+import { preparePromptForOpenAIReasoning } from "../openai-reasoning";
 import { bashTool } from "../tools/bash";
 import { globTool } from "../tools/glob";
 import { grepTool } from "../tools/grep";
@@ -84,8 +85,14 @@ export const explorerSubagent = new ToolLoopAgent({
   prepareCall: ({ options, ...settings }) => {
     const sandbox = options.sandbox;
     const model = options.model ?? settings.model;
+    const preparedPrompt = preparePromptForOpenAIReasoning({
+      model,
+      messages: settings.messages,
+      prompt: settings.prompt,
+    });
     return {
       ...settings,
+      ...preparedPrompt,
       model,
       instructions: `${EXPLORER_SYSTEM_PROMPT}
 


### PR DESCRIPTION
## Summary
- remove incomplete GPT-5.4/OpenAI reasoning runs when the final reasoning block is missing encrypted reasoning content
- apply the cleanup in agent `prepareCall` for the main agent and both subagents so replay sanitization happens at the model boundary
- add regression tests for message and prompt replay paths and record the architectural lesson learned

Solves:
```
Item with id 'rs_0697eda9d7fe595e0169ad409e71e48194b9c3985aa9c7f44e' not found. Items are not persisted when `store` is set to false. Try again with `store` set to true, or remove this item from your input.
```