### PR TITLE
Checkout PR source branch in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Updates the checkout step to explicitly target the pull request's source branch and commit SHA instead of the default branch.

- Ensures CI runs against the exact commit from the PR author's fork
- Fixes potential issues where CI would run against merged/rebased versions
- Uses GitHub event context to dynamically reference the correct repository and ref