### PR TITLE
feat: add vercel base snapshot refresh tooling

### DIFF
--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -35,11 +35,12 @@ export const DEFAULT_WORKING_DIRECTORY = "/vercel/sandbox";
 
 /**
  * Base snapshot for fresh cloud sandboxes.
- * - Current snapshot includes: bun + jq + agent-browser + chromium
- * - Previous snapshot includes: bun + jq
+ * - Current snapshot includes: bun + jq + agent-browser + chromium + code-server
+ * - Previous snapshot includes: bun + jq + agent-browser + chromium
  */
 export const DEFAULT_SANDBOX_BASE_SNAPSHOT_ID =
   process.env.VERCEL_SANDBOX_BASE_SNAPSHOT_ID ??
-  // Previous snapshot (bun + jq): "snap_MQ0NqdLL5qEXiYusgWL3K0yaMmql"
-  // Current snapshot (bun + jq + agent-browser + chromium):
-  "snap_C8tUFhwRXZky4MaFvTuwO7DH66wx";
+  // Previous snapshot (bun + jq + agent-browser + chromium):
+  // "snap_C8tUFhwRXZky4MaFvTuwO7DH66wx"
+  // Current snapshot (bun + jq + agent-browser + chromium + code-server):
+  "snap_6IhQgcSngY9IpCp71vIQqL2khSP9";

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "web": "cd apps/web/ && bun run dev",
     "dev": "turbo dev",
     "build": "turbo build",
+    "sandbox:snapshot-base": "bun run scripts/vercel-refresh-base-snapshot.ts",
     "typecheck": "turbo typecheck",
     "check": "ultracite check",
     "fix": "ultracite fix",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -8,7 +8,9 @@
     ".": "./index.ts",
     "./interface.js": "./interface.ts",
     "./types.js": "./types.ts",
+    "./vercel": "./vercel/index.ts",
     "./vercel/index.js": "./vercel/index.ts",
+    "./vercel/snapshot-refresh.js": "./vercel/snapshot-refresh.ts",
     "./vercel/sandbox.js": "./vercel/sandbox.ts",
     "./vercel/config.js": "./vercel/config.ts"
   },

--- a/packages/sandbox/vercel/index.ts
+++ b/packages/sandbox/vercel/index.ts
@@ -2,3 +2,12 @@ export { VercelSandbox, connectVercelSandbox } from "./sandbox";
 export type { VercelSandboxConfig, VercelSandboxConnectConfig } from "./config";
 export type { VercelState } from "./state";
 export { connectVercel } from "./connect";
+export {
+  DEFAULT_BASE_SNAPSHOT_COMMAND_TIMEOUT_MS,
+  refreshBaseSnapshot,
+} from "./snapshot-refresh";
+export type {
+  RefreshBaseSnapshotCommandResult,
+  RefreshBaseSnapshotOptions,
+  RefreshBaseSnapshotResult,
+} from "./snapshot-refresh";

--- a/packages/sandbox/vercel/snapshot-refresh.test.ts
+++ b/packages/sandbox/vercel/snapshot-refresh.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SandboxConnectConfig } from "../factory";
+import type { ExecResult } from "../interface";
+import {
+  DEFAULT_BASE_SNAPSHOT_COMMAND_TIMEOUT_MS,
+  refreshBaseSnapshot,
+} from "./snapshot-refresh";
+
+interface MockSnapshotSandbox {
+  workingDirectory: string;
+  exec: (
+    command: string,
+    cwd: string,
+    timeoutMs: number,
+  ) => Promise<ExecResult>;
+  stop: () => Promise<void>;
+  snapshot?: () => Promise<{ snapshotId: string }>;
+}
+
+function createExecResult(overrides: Partial<ExecResult> = {}): ExecResult {
+  return {
+    success: true,
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    truncated: false,
+    ...overrides,
+  };
+}
+
+function createSandbox(
+  overrides: Partial<MockSnapshotSandbox> = {},
+): MockSnapshotSandbox {
+  return {
+    workingDirectory: "/vercel/sandbox",
+    exec: async () => createExecResult(),
+    stop: async () => {},
+    snapshot: async () => ({ snapshotId: "snap-next" }),
+    ...overrides,
+  };
+}
+
+describe("refreshBaseSnapshot", () => {
+  test("creates a new snapshot from the configured base snapshot", async () => {
+    const connectCalls: SandboxConnectConfig[] = [];
+    const execCalls: Array<{
+      command: string;
+      cwd: string;
+      timeoutMs: number;
+    }> = [];
+    const logs: string[] = [];
+    const stop = mock(async () => {});
+    const snapshot = mock(async () => ({ snapshotId: "snap-next" }));
+
+    const result = await refreshBaseSnapshot(
+      {
+        baseSnapshotId: "snap-current",
+        sandboxTimeoutMs: 300_000,
+        ports: [3000, 5173],
+        commands: ["bun --version", "jq --version"],
+        log: (message) => logs.push(message),
+      },
+      {
+        connectSandbox: async (config) => {
+          connectCalls.push(config);
+
+          return createSandbox({
+            stop,
+            snapshot,
+            exec: async (command, cwd, timeoutMs) => {
+              execCalls.push({ command, cwd, timeoutMs });
+              return createExecResult({ stdout: `ran ${command}` });
+            },
+          });
+        },
+      },
+    );
+
+    expect(connectCalls).toEqual([
+      {
+        state: { type: "vercel" },
+        options: {
+          baseSnapshotId: "snap-current",
+          timeout: 300_000,
+          ports: [3000, 5173],
+        },
+      },
+    ]);
+    expect(execCalls).toEqual([
+      {
+        command: "bun --version",
+        cwd: "/vercel/sandbox",
+        timeoutMs: DEFAULT_BASE_SNAPSHOT_COMMAND_TIMEOUT_MS,
+      },
+      {
+        command: "jq --version",
+        cwd: "/vercel/sandbox",
+        timeoutMs: DEFAULT_BASE_SNAPSHOT_COMMAND_TIMEOUT_MS,
+      },
+    ]);
+    expect(snapshot).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      sourceSnapshotId: "snap-current",
+      snapshotId: "snap-next",
+      commandResults: [
+        {
+          command: "bun --version",
+          exitCode: 0,
+          stdout: "ran bun --version",
+          stderr: "",
+          truncated: false,
+        },
+        {
+          command: "jq --version",
+          exitCode: 0,
+          stdout: "ran jq --version",
+          stderr: "",
+          truncated: false,
+        },
+      ],
+    });
+    expect(logs).toEqual([
+      "Creating sandbox from base snapshot snap-current.",
+      "Running command 1/2: bun --version",
+      "Running command 2/2: jq --version",
+      "Creating snapshot from prepared sandbox.",
+      "Created snapshot snap-next.",
+    ]);
+  });
+
+  test("stops the sandbox and surfaces command output when setup fails", async () => {
+    const stop = mock(async () => {});
+    const snapshot = mock(async () => ({ snapshotId: "snap-next" }));
+
+    const refreshPromise = refreshBaseSnapshot(
+      {
+        baseSnapshotId: "snap-current",
+        sandboxTimeoutMs: 300_000,
+        commands: ["bun install"],
+      },
+      {
+        connectSandbox: async () =>
+          createSandbox({
+            stop,
+            snapshot,
+            exec: async () =>
+              createExecResult({
+                success: false,
+                exitCode: 1,
+                stdout: "install output",
+                stderr: "install error",
+              }),
+          }),
+      },
+    );
+
+    await expect(refreshPromise).rejects.toThrow(
+      "Command failed while preparing base snapshot: bun install",
+    );
+    await expect(refreshPromise).rejects.toThrow("stdout:\ninstall output");
+    await expect(refreshPromise).rejects.toThrow("stderr:\ninstall error");
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops the sandbox when snapshot support is unavailable", async () => {
+    const stop = mock(async () => {});
+
+    const refreshPromise = refreshBaseSnapshot(
+      {
+        baseSnapshotId: "snap-current",
+        sandboxTimeoutMs: 300_000,
+      },
+      {
+        connectSandbox: async () =>
+          createSandbox({
+            stop,
+            snapshot: undefined,
+          }),
+      },
+    );
+
+    await expect(refreshPromise).rejects.toThrow(
+      "Configured sandbox provider does not support snapshots.",
+    );
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sandbox/vercel/snapshot-refresh.ts
+++ b/packages/sandbox/vercel/snapshot-refresh.ts
@@ -1,0 +1,149 @@
+import { connectSandbox, type SandboxConnectConfig } from "../factory";
+import type { ExecResult, SnapshotResult } from "../interface";
+
+export const DEFAULT_BASE_SNAPSHOT_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
+
+interface SnapshotSandbox {
+  workingDirectory: string;
+  exec(command: string, cwd: string, timeoutMs: number): Promise<ExecResult>;
+  stop(): Promise<void>;
+  snapshot?(): Promise<SnapshotResult>;
+}
+
+type SnapshotSandboxConnector = (
+  config: SandboxConnectConfig,
+) => Promise<SnapshotSandbox>;
+
+export interface RefreshBaseSnapshotOptions {
+  baseSnapshotId: string;
+  commands?: string[];
+  sandboxTimeoutMs: number;
+  commandTimeoutMs?: number;
+  ports?: number[];
+  env?: Record<string, string>;
+  log?: (message: string) => void;
+}
+
+export interface RefreshBaseSnapshotCommandResult {
+  command: string;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+}
+
+export interface RefreshBaseSnapshotResult {
+  sourceSnapshotId: string;
+  snapshotId: string;
+  commandResults: RefreshBaseSnapshotCommandResult[];
+}
+
+interface RefreshBaseSnapshotDependencies {
+  connectSandbox?: SnapshotSandboxConnector;
+}
+
+function defaultConnectSnapshotSandbox(
+  config: SandboxConnectConfig,
+): Promise<SnapshotSandbox> {
+  return connectSandbox(config);
+}
+
+function formatCommandOutput(label: string, output: string): string | null {
+  const trimmedOutput = output.trim();
+  if (!trimmedOutput) {
+    return null;
+  }
+
+  return `${label}:\n${trimmedOutput}`;
+}
+
+function formatCommandFailure(command: string, result: ExecResult): string {
+  const sections = [
+    `Command failed while preparing base snapshot: ${command}`,
+    result.exitCode === null ? null : `Exit code: ${result.exitCode}`,
+    formatCommandOutput("stdout", result.stdout),
+    formatCommandOutput("stderr", result.stderr),
+    result.truncated ? "Output was truncated." : null,
+  ].filter((section): section is string => section !== null);
+
+  return sections.join("\n\n");
+}
+
+export async function refreshBaseSnapshot(
+  options: RefreshBaseSnapshotOptions,
+  dependencies: RefreshBaseSnapshotDependencies = {},
+): Promise<RefreshBaseSnapshotResult> {
+  const commands =
+    options.commands?.filter((command) => command.trim().length > 0) ?? [];
+  const commandTimeoutMs =
+    options.commandTimeoutMs ?? DEFAULT_BASE_SNAPSHOT_COMMAND_TIMEOUT_MS;
+  const log = options.log ?? (() => {});
+  const connectSnapshotSandbox =
+    dependencies.connectSandbox ?? defaultConnectSnapshotSandbox;
+
+  let sandbox: SnapshotSandbox | null = null;
+  let snapshotCreated = false;
+
+  try {
+    log(`Creating sandbox from base snapshot ${options.baseSnapshotId}.`);
+    sandbox = await connectSnapshotSandbox({
+      state: { type: "vercel" },
+      options: {
+        baseSnapshotId: options.baseSnapshotId,
+        timeout: options.sandboxTimeoutMs,
+        ...(options.ports !== undefined && { ports: options.ports }),
+        ...(options.env !== undefined && { env: options.env }),
+      },
+    });
+
+    if (!sandbox.snapshot) {
+      throw new Error(
+        "Configured sandbox provider does not support snapshots.",
+      );
+    }
+
+    const commandResults: RefreshBaseSnapshotCommandResult[] = [];
+
+    for (const [index, command] of commands.entries()) {
+      log(`Running command ${index + 1}/${commands.length}: ${command}`);
+
+      const result = await sandbox.exec(
+        command,
+        sandbox.workingDirectory,
+        commandTimeoutMs,
+      );
+
+      commandResults.push({
+        command,
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        truncated: result.truncated,
+      });
+
+      if (!result.success) {
+        throw new Error(formatCommandFailure(command, result));
+      }
+    }
+
+    log("Creating snapshot from prepared sandbox.");
+    const snapshot = await sandbox.snapshot();
+    snapshotCreated = true;
+    log(`Created snapshot ${snapshot.snapshotId}.`);
+
+    return {
+      sourceSnapshotId: options.baseSnapshotId,
+      snapshotId: snapshot.snapshotId,
+      commandResults,
+    };
+  } finally {
+    if (sandbox && !snapshotCreated) {
+      try {
+        await sandbox.stop();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log(`Failed to stop sandbox after refresh attempt: ${message}`);
+      }
+    }
+  }
+}

--- a/scripts/vercel-refresh-base-snapshot.ts
+++ b/scripts/vercel-refresh-base-snapshot.ts
@@ -1,0 +1,152 @@
+/**
+ * Create a new sandbox base snapshot from the currently configured snapshot.
+ *
+ * Usage:
+ *   bun run scripts/vercel-refresh-base-snapshot.ts --command "apt-get update"
+ *   bun run scripts/vercel-refresh-base-snapshot.ts --from snap_123 --command "apt-get install -y ripgrep"
+ */
+
+import {
+  DEFAULT_BASE_SNAPSHOT_COMMAND_TIMEOUT_MS,
+  refreshBaseSnapshot,
+} from "@open-harness/sandbox/vercel";
+import {
+  DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
+  DEFAULT_SANDBOX_PORTS,
+  DEFAULT_SANDBOX_TIMEOUT_MS,
+} from "../apps/web/lib/sandbox/config";
+
+const SANDBOX_BASE_SNAPSHOT_CONFIG_PATH = "apps/web/lib/sandbox/config.ts";
+
+interface CliOptions {
+  baseSnapshotId?: string;
+  sandboxTimeoutMs?: number;
+  commandTimeoutMs?: number;
+  commands: string[];
+}
+
+interface HelpResult {
+  help: true;
+}
+
+function printUsage() {
+  console.log(`Usage:
+  bun run sandbox:snapshot-base -- --command "apt-get update"
+  bun run sandbox:snapshot-base -- --from snap_123 --command "apt-get install -y ripgrep"
+
+Options:
+  --from <snapshot-id>         Override the starting snapshot id
+  --command <shell-command>    Command to run inside the sandbox. Repeat as needed.
+  --sandbox-timeout-ms <ms>    Sandbox lifetime for the refresh run
+  --command-timeout-ms <ms>    Timeout for each setup command (default: ${DEFAULT_BASE_SNAPSHOT_COMMAND_TIMEOUT_MS})
+  --help                       Show this message
+
+Current configured base snapshot:
+  ${DEFAULT_SANDBOX_BASE_SNAPSHOT_ID}`);
+}
+
+function requireOptionValue(
+  argv: string[],
+  index: number,
+  option: string,
+): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}.`);
+  }
+
+  return value;
+}
+
+function parsePositiveNumber(value: string, option: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${option} must be a positive number.`);
+  }
+
+  return parsed;
+}
+
+function parseArgs(argv: string[]): CliOptions | HelpResult {
+  const commands: string[] = [];
+  let baseSnapshotId: string | undefined;
+  let sandboxTimeoutMs: number | undefined;
+  let commandTimeoutMs: number | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--help" || arg === "-h") {
+      return { help: true };
+    }
+
+    if (arg === "--from") {
+      baseSnapshotId = requireOptionValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--command") {
+      commands.push(requireOptionValue(argv, index, arg));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--sandbox-timeout-ms") {
+      sandboxTimeoutMs = parsePositiveNumber(
+        requireOptionValue(argv, index, arg),
+        arg,
+      );
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--command-timeout-ms") {
+      commandTimeoutMs = parsePositiveNumber(
+        requireOptionValue(argv, index, arg),
+        arg,
+      );
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    baseSnapshotId,
+    sandboxTimeoutMs,
+    commandTimeoutMs,
+    commands,
+  };
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if ("help" in parsed) {
+    printUsage();
+    return;
+  }
+
+  const result = await refreshBaseSnapshot({
+    baseSnapshotId: parsed.baseSnapshotId ?? DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
+    commands: parsed.commands,
+    sandboxTimeoutMs: parsed.sandboxTimeoutMs ?? DEFAULT_SANDBOX_TIMEOUT_MS,
+    commandTimeoutMs: parsed.commandTimeoutMs,
+    ports: DEFAULT_SANDBOX_PORTS,
+    log: (message) => console.log(message),
+  });
+
+  console.log("");
+  console.log(`New snapshot id: ${result.snapshotId}`);
+  console.log(`Started from snapshot: ${result.sourceSnapshotId}`);
+  console.log(
+    `Update ${SANDBOX_BASE_SNAPSHOT_CONFIG_PATH} to use: "${result.snapshotId}"`,
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Vercel-specific snapshot refresh helper plus a root maintenance script so base snapshots can be rebuilt from the repo with setup commands
- update the sandbox package exports so the refresh flow lives under the Vercel provider boundary instead of the web app
- refresh the configured sandbox base snapshot to include code-server and record the new snapshot id in config

## Testing
- bun test "packages/sandbox/vercel/snapshot-refresh.test.ts"
- bun run typecheck
- bun run ci