### PR TITLE
fix(sandbox): skip git init when refreshing Vercel base snapshots

### DIFF
--- a/packages/sandbox/factory.ts
+++ b/packages/sandbox/factory.ts
@@ -28,6 +28,10 @@ export interface ConnectOptions {
   ports?: number[];
   /** Snapshot ID used as the base image for new sandboxes */
   baseSnapshotId?: string;
+  /**
+   * Skip git init in an empty workspace (e.g. when refreshing a Vercel base snapshot).
+   */
+  skipGitWorkspaceBootstrap?: boolean;
 }
 
 /**

--- a/packages/sandbox/vercel/config.ts
+++ b/packages/sandbox/vercel/config.ts
@@ -58,6 +58,12 @@ export interface VercelSandboxConfig {
    */
   baseSnapshotId?: string;
   /**
+   * When true, do not run `git init` or an initial empty commit in the workspace.
+   * Use when building a new base snapshot so `/vercel/sandbox` stays empty for a
+   * later `git clone ... .` (a leftover `.git` breaks clone into that directory).
+   */
+  skipGitWorkspaceBootstrap?: boolean;
+  /**
    * Lifecycle hooks for setup and teardown.
    * afterStart is called after the sandbox is created and configured.
    * beforeStop is called before the sandbox is stopped.

--- a/packages/sandbox/vercel/connect.ts
+++ b/packages/sandbox/vercel/connect.ts
@@ -11,6 +11,7 @@ interface ConnectOptions {
   timeout?: number;
   ports?: number[];
   baseSnapshotId?: string;
+  skipGitWorkspaceBootstrap?: boolean;
 }
 
 function getRemainingTimeout(
@@ -93,6 +94,9 @@ export async function connectVercel(
       ...(options?.baseSnapshotId && {
         baseSnapshotId: options.baseSnapshotId,
       }),
+      ...(options?.skipGitWorkspaceBootstrap && {
+        skipGitWorkspaceBootstrap: true,
+      }),
     });
   }
 
@@ -105,6 +109,9 @@ export async function connectVercel(
     ...(options?.ports && { ports: options.ports }),
     ...(options?.baseSnapshotId && {
       baseSnapshotId: options.baseSnapshotId,
+    }),
+    ...(options?.skipGitWorkspaceBootstrap && {
+      skipGitWorkspaceBootstrap: true,
     }),
   });
 }

--- a/packages/sandbox/vercel/sandbox.test.ts
+++ b/packages/sandbox/vercel/sandbox.test.ts
@@ -243,6 +243,20 @@ describe("VercelSandbox.create", () => {
       cwd: "/vercel/sandbox",
     });
   });
+
+  test("skips git workspace bootstrap from base snapshot when requested", async () => {
+    await sandboxModule.VercelSandbox.create({
+      baseSnapshotId: "snap-base-1",
+      skipGitWorkspaceBootstrap: true,
+    });
+
+    expect(createCalls.length).toBe(1);
+    expect(createCalls[0]?.source).toEqual({
+      type: "snapshot",
+      snapshotId: "snap-base-1",
+    });
+    expect(runCommandCalls.filter((c) => c.cmd === "git")).toEqual([]);
+  });
 });
 
 describe("VercelSandbox.execDetached", () => {

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -331,6 +331,8 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
    * Create a new Vercel Sandbox instance.
    * If `baseSnapshotId` is provided, sandbox bootstraps from that snapshot first.
    * If a source is provided with `baseSnapshotId`, the repo is cloned after bootstrap.
+   * Use `skipGitWorkspaceBootstrap` when preparing a new base snapshot so the workspace
+   * stays free of `.git` for subsequent clones.
    */
   static async create(
     config: VercelSandboxConfig = {},
@@ -345,6 +347,7 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
       ports,
       baseSnapshotId,
       hooks,
+      skipGitWorkspaceBootstrap = false,
     } = config;
 
     // Clamp proactive timeout to stay under the SDK's hard max when buffer is applied.
@@ -423,7 +426,7 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
 
     // Initialize git repo for empty sandboxes (no source provided)
     // This ensures git commands work consistently (e.g., for diff viewing)
-    if (!source) {
+    if (!source && !skipGitWorkspaceBootstrap) {
       await sdk.runCommand({
         cmd: "git",
         args: ["init"],
@@ -449,8 +452,8 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
       }
     }
 
-    // Configure git user for commits if provided
-    if (gitUser) {
+    // Configure git user for commits if provided (skip when no repo was created)
+    if (gitUser && (source || !skipGitWorkspaceBootstrap)) {
       await sdk.runCommand({
         cmd: "git",
         args: ["config", "user.name", gitUser.name],
@@ -466,7 +469,7 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
     // Create initial empty commit for empty sandboxes so HEAD exists
     // This is required for git diff HEAD to work (e.g., diff viewer)
     // Must be done after gitUser config since git commit requires user info
-    if (!source && gitUser) {
+    if (!source && gitUser && !skipGitWorkspaceBootstrap) {
       await sdk.runCommand({
         cmd: "git",
         args: ["commit", "--allow-empty", "-m", "Initial commit"],

--- a/packages/sandbox/vercel/snapshot-refresh.test.ts
+++ b/packages/sandbox/vercel/snapshot-refresh.test.ts
@@ -82,6 +82,7 @@ describe("refreshBaseSnapshot", () => {
         options: {
           baseSnapshotId: "snap-current",
           timeout: 300_000,
+          skipGitWorkspaceBootstrap: true,
           ports: [3000, 5173],
         },
       },

--- a/packages/sandbox/vercel/snapshot-refresh.ts
+++ b/packages/sandbox/vercel/snapshot-refresh.ts
@@ -91,6 +91,7 @@ export async function refreshBaseSnapshot(
       options: {
         baseSnapshotId: options.baseSnapshotId,
         timeout: options.sandboxTimeoutMs,
+        skipGitWorkspaceBootstrap: true,
         ...(options.ports !== undefined && { ports: options.ports }),
         ...(options.env !== undefined && { env: options.env }),
       },

--- a/packages/sandbox/vercel/snapshot-refresh.ts
+++ b/packages/sandbox/vercel/snapshot-refresh.ts
@@ -86,6 +86,8 @@ export async function refreshBaseSnapshot(
 
   try {
     log(`Creating sandbox from base snapshot ${options.baseSnapshotId}.`);
+    // Skip git init so the new base image does not ship `.git` in /vercel/sandbox
+    // (would break `git clone … .` for agent sandboxes).
     sandbox = await connectSnapshotSandbox({
       state: { type: "vercel" },
       options: {

--- a/scripts/vercel-refresh-base-snapshot.ts
+++ b/scripts/vercel-refresh-base-snapshot.ts
@@ -1,5 +1,8 @@
 /**
  * Create a new sandbox base snapshot from the currently configured snapshot.
+ * Defaults (snapshot id, ports, timeouts) come from the web app sandbox config so
+ * this matches production; `refreshBaseSnapshot` skips workspace git bootstrap
+ * so the new image stays clone-ready (see `@open-harness/sandbox` snapshot-refresh).
  *
  * Usage:
  *   bun run scripts/vercel-refresh-base-snapshot.ts --command "apt-get update"


### PR DESCRIPTION
## Summary

- Adds `skipGitWorkspaceBootstrap` option to sandbox creation that skips `git init` and the initial empty commit
- Applies this option automatically in `refreshBaseSnapshot()` so base snapshots don't ship with a `.git` directory
- Fixes `git clone ... .` failures when agent sandboxes try to clone into `/vercel/sandbox` (which requires an empty directory)

## Test plan

- [x] Added test verifying git commands are skipped when `skipGitWorkspaceBootstrap: true`
- [x] Updated `snapshot-refresh.test.ts` expectations to include the new option
- [ ] Manual verification: refresh a base snapshot and confirm `/vercel/sandbox` has no `.git` directory


Made with [Cursor](https://cursor.com)