### PR TITLE
Add code-server to base sandbox snapshot

### DIFF
--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -35,11 +35,12 @@ export const DEFAULT_WORKING_DIRECTORY = "/vercel/sandbox";
 
 /**
  * Base snapshot for fresh cloud sandboxes.
- * - Current snapshot includes: bun + jq + agent-browser + chromium
- * - Previous snapshot includes: bun + jq
+ * - Current snapshot includes: bun + jq + agent-browser + chromium + code-server
+ * - Previous snapshot includes: bun + jq + agent-browser + chromium
  */
 export const DEFAULT_SANDBOX_BASE_SNAPSHOT_ID =
   process.env.VERCEL_SANDBOX_BASE_SNAPSHOT_ID ??
   // Previous snapshot (bun + jq): "snap_MQ0NqdLL5qEXiYusgWL3K0yaMmql"
-  // Current snapshot (bun + jq + agent-browser + chromium):
-  "snap_C8tUFhwRXZky4MaFvTuwO7DH66wx";
+  // Previous snapshot (bun + jq + agent-browser + chromium): "snap_C8tUFhwRXZky4MaFvTuwO7DH66wx"
+  // Current snapshot (bun + jq + agent-browser + chromium + code-server):
+  "snap_EjsphVxi07bFKrfojljJdIS41KHT";


### PR DESCRIPTION
## Summary

- Adds code-server to the base sandbox snapshot for IDE access in sandboxes
- Updates `DEFAULT_SANDBOX_BASE_SNAPSHOT_ID` to new snapshot `snap_EjsphVxi07bFKrfojljJdIS41KHT`
- Previous snapshot preserved as comment for rollback if needed

## Test plan

- [ ] Verify new sandboxes can run code-server
- [ ] Confirm existing sandbox functionality is unaffected


Made with [Cursor](https://cursor.com)