### PR TITLE
feat: prefer user-to-server token for PR creation

### DIFF
--- a/apps/web/app/api/pr/route.test.ts
+++ b/apps/web/app/api/pr/route.test.ts
@@ -85,6 +85,10 @@ function registerRouteMocks() {
 
   mock.module("@/lib/github/user-token", () => ({
     getUserGitHubToken: async () => userToken,
+    getUserGitHubTokenWithStatus: async () =>
+      userToken
+        ? { token: userToken, status: "valid" as const }
+        : { token: null, status: "no_account" as const },
   }));
 
   mock.module("@/lib/github/client", () => ({
@@ -171,13 +175,15 @@ describe("/api/pr", () => {
     expect(body.autoMergeError).toBeUndefined();
     expect(createCalls).toHaveLength(1);
     expect(autoMergeCalls).toHaveLength(1);
+    // User-to-server token is preferred for PR creation so the user
+    // appears as PR author with the "with Open Harness" badge.
     expect(createCalls[0]).toMatchObject({
-      token: "installation-token",
+      token: "user-token",
       isDraft: false,
     });
     expect(autoMergeCalls[0]).toMatchObject({
       prNumber: 77,
-      token: "installation-token",
+      token: "user-token",
     });
     expect(updateCalls).toEqual([
       {

--- a/apps/web/app/api/pr/route.ts
+++ b/apps/web/app/api/pr/route.ts
@@ -149,6 +149,10 @@ export async function POST(req: Request) {
   const userTokenResult = await getUserGitHubTokenWithStatus();
   const userToken = userTokenResult.token;
 
+  console.log(
+    `[pr-route] User token status: ${userTokenResult.status}, has token: ${Boolean(userToken)}, repo token type: ${tokenResult.type}`,
+  );
+
   let headRef = resolvedBranch;
   const normalizedBaseOwner = parsedRepoUrl.owner.toLowerCase();
   const normalizedHeadOwner = headOwner?.trim().toLowerCase();
@@ -178,6 +182,10 @@ export async function POST(req: Request) {
   let tokenUsedForCreation = dedupedTokenCandidates[0];
 
   for (const candidateToken of dedupedTokenCandidates) {
+    const isUserToken = candidateToken === userToken;
+    console.log(
+      `[pr-route] Trying PR creation with ${isUserToken ? "user-to-server" : "installation"} token`,
+    );
     tokenUsedForCreation = candidateToken;
     result = await createPullRequest({
       repoUrl,
@@ -191,8 +199,14 @@ export async function POST(req: Request) {
     });
 
     if (result.success) {
+      console.log(
+        `[pr-route] PR created successfully with ${isUserToken ? "user-to-server" : "installation"} token`,
+      );
       break;
     }
+    console.log(
+      `[pr-route] PR creation failed with ${isUserToken ? "user-to-server" : "installation"} token: ${result.error}`,
+    );
   }
 
   if (!result.success) {

--- a/apps/web/app/api/pr/route.ts
+++ b/apps/web/app/api/pr/route.ts
@@ -5,7 +5,7 @@ import {
   parseGitHubUrl,
 } from "@/lib/github/client";
 import { getRepoToken } from "@/lib/github/get-repo-token";
-import { getUserGitHubToken } from "@/lib/github/user-token";
+import { getUserGitHubTokenWithStatus } from "@/lib/github/user-token";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 interface CreatePRRequest {
@@ -146,37 +146,28 @@ export async function POST(req: Request) {
     );
   }
 
-  const userToken = await getUserGitHubToken();
-  const tokenCandidates: string[] = [];
+  const userTokenResult = await getUserGitHubTokenWithStatus();
+  const userToken = userTokenResult.token;
 
   let headRef = resolvedBranch;
   const normalizedBaseOwner = parsedRepoUrl.owner.toLowerCase();
   const normalizedHeadOwner = headOwner?.trim().toLowerCase();
+  const isCrossFork =
+    normalizedHeadOwner && normalizedHeadOwner !== normalizedBaseOwner;
 
-  if (normalizedHeadOwner && normalizedHeadOwner !== normalizedBaseOwner) {
-    // Cross-fork PRs: prefer user token first since installation tokens are
-    // scoped to specific repos and may not cover the fork owner.
+  if (isCrossFork) {
     headRef = `${headOwner}:${resolvedBranch}`;
-    if (userToken) {
-      tokenCandidates.push(userToken);
-    }
   }
 
-  // Always try the installation token (or user token if no installation) first
-  // for same-owner PRs, so the PR is created from the GitHub App installation.
-  tokenCandidates.push(tokenResult.token);
-
-  // Fall back to user token if the primary token fails (e.g. repo-scoped
-  // installation tokens that don't cover this particular repo).
-  if (tokenResult.type === "installation" && userToken) {
-    tokenCandidates.push(userToken);
-  }
-
+  // Prefer user-to-server token for PR creation so the user appears as the
+  // PR author with the "with Open Harness" badge. Fall back to the
+  // installation token when no user-to-server token is available.
   const dedupedTokenCandidates: string[] = [];
-  for (const token of tokenCandidates) {
-    if (!dedupedTokenCandidates.includes(token)) {
-      dedupedTokenCandidates.push(token);
-    }
+  if (userToken && !dedupedTokenCandidates.includes(userToken)) {
+    dedupedTokenCandidates.push(userToken);
+  }
+  if (!dedupedTokenCandidates.includes(tokenResult.token)) {
+    dedupedTokenCandidates.push(tokenResult.token);
   }
 
   // 4. Create PR using existing function
@@ -298,11 +289,20 @@ export async function POST(req: Request) {
   }
 
   // 6. Return success
+  const createdAsBot = tokenUsedForCreation !== userToken;
   return Response.json({
     success: true,
     prUrl: result.prUrl,
     prNumber: result.prNumber,
     prStatus: "open",
     ...(enableAutoMerge ? { autoMergeEnabled, autoMergeError } : {}),
+    ...(createdAsBot
+      ? {
+          createdAsBot: true,
+          ...(userTokenResult.status !== "valid"
+            ? { userTokenStatus: userTokenResult.status }
+            : {}),
+        }
+      : {}),
   });
 }

--- a/apps/web/components/create-pr-dialog.tsx
+++ b/apps/web/components/create-pr-dialog.tsx
@@ -106,6 +106,8 @@ export function CreatePRDialog({
     requiresManualCreation?: boolean;
     autoMergeEnabled?: boolean;
     autoMergeError?: string;
+    createdAsBot?: boolean;
+    userTokenStatus?: string;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [gitActions, setGitActions] = useState<GitActions | null>(null);
@@ -353,6 +355,11 @@ export function CreatePRDialog({
           typeof data.autoMergeError === "string"
             ? data.autoMergeError
             : undefined,
+        createdAsBot: Boolean(data.createdAsBot),
+        userTokenStatus:
+          typeof data.userTokenStatus === "string"
+            ? data.userTokenStatus
+            : undefined,
       });
 
       if (typeof data.prNumber === "number") {
@@ -424,6 +431,21 @@ export function CreatePRDialog({
               {result.autoMergeError && (
                 <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-left text-sm text-amber-700 dark:text-amber-400">
                   {result.autoMergeError}
+                </p>
+              )}
+              {result.createdAsBot && (
+                <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-left text-sm text-amber-700 dark:text-amber-400">
+                  This PR was created as the Open Harness bot.{" "}
+                  {/* oxlint-disable-next-line nextjs/no-html-link-for-pages */}
+                  <a
+                    href="/api/github/app/install"
+                    className="underline hover:no-underline"
+                  >
+                    {result.userTokenStatus === "no_account"
+                      ? "Connect your GitHub account"
+                      : "Reconnect your GitHub account"}
+                  </a>{" "}
+                  to create PRs as yourself.
                 </p>
               )}
             </div>

--- a/apps/web/lib/chat/auto-pr-direct.test.ts
+++ b/apps/web/lib/chat/auto-pr-direct.test.ts
@@ -17,6 +17,10 @@ let repoTokenResult:
   installationId: 1,
 };
 let userTokenResult: string | null = null;
+let userTokenStatusResult: {
+  token: string | null;
+  status: "valid" | "no_account" | "refresh_failed" | "no_refresh_token";
+} = { token: null, status: "no_account" };
 let cachedBranchesResult: { branches: string[]; defaultBranch: string } | null =
   {
     branches: ["main", "feature-branch"],
@@ -77,6 +81,9 @@ const generatePullRequestContentFromSandboxSpy = mock(
   async () => prContentResult,
 );
 const getUserGitHubTokenSpy = mock(async (_userId?: string) => userTokenResult);
+const getUserGitHubTokenWithStatusSpy = mock(
+  async (_userId?: string) => userTokenStatusResult,
+);
 
 const sandbox = {
   workingDirectory: "/vercel/sandbox",
@@ -101,6 +108,7 @@ mock.module("@/lib/github/get-repo-token", () => ({
 
 mock.module("@/lib/github/user-token", () => ({
   getUserGitHubToken: getUserGitHubTokenSpy,
+  getUserGitHubTokenWithStatus: getUserGitHubTokenWithStatusSpy,
 }));
 
 mock.module("@/lib/github/client", () => ({
@@ -157,6 +165,7 @@ beforeEach(() => {
   createPullRequestSpy.mockClear();
   generatePullRequestContentFromSandboxSpy.mockClear();
   getUserGitHubTokenSpy.mockClear();
+  getUserGitHubTokenWithStatusSpy.mockClear();
 
   execResults = defaultExecResults();
   repoTokenResult = {
@@ -165,6 +174,7 @@ beforeEach(() => {
     installationId: 1,
   };
   userTokenResult = null;
+  userTokenStatusResult = { token: null, status: "no_account" };
   cachedBranchesResult = {
     branches: ["main", "feature-branch"],
     defaultBranch: "main",
@@ -308,8 +318,10 @@ describe("performAutoCreatePr", () => {
       skipped: false,
       prNumber: 42,
       prUrl: "https://github.com/acme/repo/pull/42",
+      createdAsBot: true,
+      userTokenStatus: "no_account",
     } satisfies AutoCreatePrResult);
-    expect(getUserGitHubTokenSpy).toHaveBeenCalledWith("user-1");
+    expect(getUserGitHubTokenWithStatusSpy).toHaveBeenCalledWith("user-1");
     expect(generatePullRequestContentFromSandboxSpy).toHaveBeenCalledTimes(1);
     expect(createPullRequestSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/lib/chat/auto-pr-direct.ts
+++ b/apps/web/lib/chat/auto-pr-direct.ts
@@ -188,6 +188,10 @@ export async function performAutoCreatePr(
   const userTokenResult = await getUserGitHubTokenWithStatus(userId);
   const userToken = userTokenResult.token;
 
+  console.log(
+    `[auto-pr] User token status: ${userTokenResult.status}, has token: ${Boolean(userToken)}, repo token type: ${repoTokenResult.type}`,
+  );
+
   // For read operations and git push, use any available token
   const tokenCandidates = dedupeTokenCandidates([
     repoTokenResult.token,

--- a/apps/web/lib/chat/auto-pr-direct.ts
+++ b/apps/web/lib/chat/auto-pr-direct.ts
@@ -12,10 +12,7 @@ import {
   isValidGitHubRepoName,
   isValidGitHubRepoOwner,
 } from "@/lib/github/repo-identifiers";
-import {
-  getUserGitHubToken,
-  getUserGitHubTokenWithStatus,
-} from "@/lib/github/user-token";
+import { getUserGitHubTokenWithStatus } from "@/lib/github/user-token";
 import { generatePullRequestContentFromSandbox } from "@/lib/git/pr-content";
 
 const SAFE_BRANCH_PATTERN = /^[\w\-/.]+$/;

--- a/apps/web/lib/chat/auto-pr-direct.ts
+++ b/apps/web/lib/chat/auto-pr-direct.ts
@@ -12,7 +12,10 @@ import {
   isValidGitHubRepoName,
   isValidGitHubRepoOwner,
 } from "@/lib/github/repo-identifiers";
-import { getUserGitHubToken } from "@/lib/github/user-token";
+import {
+  getUserGitHubToken,
+  getUserGitHubTokenWithStatus,
+} from "@/lib/github/user-token";
 import { generatePullRequestContentFromSandbox } from "@/lib/git/pr-content";
 
 const SAFE_BRANCH_PATTERN = /^[\w\-/.]+$/;
@@ -34,6 +37,11 @@ export interface AutoCreatePrResult {
   prNumber?: number;
   prUrl?: string;
   error?: string;
+  /** When true, the PR was created using an installation token (bot author)
+   * because no valid user-to-server token was available. */
+  createdAsBot?: boolean;
+  /** Present when user-to-server token is unavailable and re-auth is needed. */
+  userTokenStatus?: "no_account" | "refresh_failed" | "no_refresh_token";
 }
 
 function dedupeTokenCandidates(
@@ -178,13 +186,21 @@ export async function performAutoCreatePr(
     };
   }
 
-  const userToken =
-    repoTokenResult.type === "installation"
-      ? await getUserGitHubToken(userId)
-      : null;
+  // Fetch the user-to-server token (preferred for PR creation so the user
+  // appears as the PR author with the "with Open Harness" badge).
+  const userTokenResult = await getUserGitHubTokenWithStatus(userId);
+  const userToken = userTokenResult.token;
+
+  // For read operations and git push, use any available token
   const tokenCandidates = dedupeTokenCandidates([
     repoTokenResult.token,
     userToken,
+  ]);
+
+  // For PR creation specifically, prefer the user-to-server token
+  const prTokenCandidates = dedupeTokenCandidates([
+    userToken,
+    repoTokenResult.token,
   ]);
 
   const authUrl = buildGitHubAuthRemoteUrl({
@@ -344,8 +360,9 @@ export async function performAutoCreatePr(
 
   const repoUrl = `https://github.com/${repoOwner}/${repoName}`;
   let createResult: Awaited<ReturnType<typeof createPullRequest>> | undefined;
+  let createdWithUserToken = false;
 
-  for (const token of tokenCandidates) {
+  for (const token of prTokenCandidates) {
     createResult = await createPullRequest({
       repoUrl,
       branchName,
@@ -356,6 +373,7 @@ export async function performAutoCreatePr(
     });
 
     if (createResult.success) {
+      createdWithUserToken = token === userToken;
       break;
     }
   }
@@ -414,11 +432,17 @@ export async function performAutoCreatePr(
     `[auto-pr] Created PR #${createResult.prNumber ?? "unknown"} for session ${sessionId}`,
   );
 
+  const createdAsBot = !createdWithUserToken;
+
   return {
     created: true,
     syncedExisting: false,
     skipped: false,
     prNumber: createResult.prNumber,
     prUrl: createResult.prUrl,
+    createdAsBot,
+    ...(createdAsBot && userTokenResult.status !== "valid"
+      ? { userTokenStatus: userTokenResult.status }
+      : {}),
   };
 }

--- a/apps/web/lib/github/user-token.ts
+++ b/apps/web/lib/github/user-token.ts
@@ -78,7 +78,10 @@ export type UserTokenStatus =
 
 export type UserTokenResult =
   | { token: string; status: "valid" }
-  | { token: null; status: "no_account" | "refresh_failed" | "no_refresh_token" };
+  | {
+      token: null;
+      status: "no_account" | "refresh_failed" | "no_refresh_token";
+    };
 
 /**
  * Get a valid GitHub user-to-server access token with status information.

--- a/apps/web/lib/github/user-token.ts
+++ b/apps/web/lib/github/user-token.ts
@@ -70,25 +70,34 @@ async function refreshGitHubToken(
   }
 }
 
+export type UserTokenStatus =
+  | "valid"
+  | "no_account"
+  | "refresh_failed"
+  | "no_refresh_token";
+
+export type UserTokenResult =
+  | { token: string; status: "valid" }
+  | { token: null; status: "no_account" | "refresh_failed" | "no_refresh_token" };
+
 /**
- * Get a valid GitHub access token for the given user.
- * If no userId is provided, falls back to the current request session.
- * If the token is expired and a refresh token exists, refreshes inline
- * and updates the database (mirroring the Vercel token refresh flow).
+ * Get a valid GitHub user-to-server access token with status information.
+ * Returns a discriminated union so callers can distinguish between
+ * "no account linked" and "token expired and refresh failed".
  */
-export async function getUserGitHubToken(
+export async function getUserGitHubTokenWithStatus(
   userId?: string,
-): Promise<string | null> {
+): Promise<UserTokenResult> {
   const resolvedUserId = userId ?? (await getServerSession())?.user?.id;
-  if (!resolvedUserId) return null;
+  if (!resolvedUserId) return { token: null, status: "no_account" };
 
   try {
     const ghAccount = await getGitHubAccount(resolvedUserId);
-    if (!ghAccount?.accessToken) return null;
+    if (!ghAccount?.accessToken) return { token: null, status: "no_account" };
 
     // If no expiration is set, the token is non-expiring (classic OAuth)
     if (!ghAccount.expiresAt) {
-      return decrypt(ghAccount.accessToken);
+      return { token: decrypt(ghAccount.accessToken), status: "valid" };
     }
 
     // Check if the token is still valid (with 5-minute buffer)
@@ -97,18 +106,18 @@ export async function getUserGitHubToken(
     const isExpired = ghAccount.expiresAt.getTime() - bufferMs < now;
 
     if (!isExpired) {
-      return decrypt(ghAccount.accessToken);
+      return { token: decrypt(ghAccount.accessToken), status: "valid" };
     }
 
     // Token is expired -- try to refresh
     if (!ghAccount.refreshToken) {
       console.error("GitHub token expired but no refresh token available");
-      return null;
+      return { token: null, status: "no_refresh_token" };
     }
 
     const decryptedRefresh = decrypt(ghAccount.refreshToken);
     const refreshed = await refreshGitHubToken(decryptedRefresh);
-    if (!refreshed) return null;
+    if (!refreshed) return { token: null, status: "refresh_failed" };
 
     // Persist the new tokens. If persistence fails, still return the token
     // so the current request succeeds. The refresh token has already been
@@ -128,9 +137,22 @@ export async function getUserGitHubToken(
       );
     }
 
-    return refreshed.access_token;
+    return { token: refreshed.access_token, status: "valid" };
   } catch (error) {
     console.error("Error fetching GitHub token:", error);
-    return null;
+    return { token: null, status: "refresh_failed" };
   }
+}
+
+/**
+ * Get a valid GitHub access token for the given user.
+ * If no userId is provided, falls back to the current request session.
+ * If the token is expired and a refresh token exists, refreshes inline
+ * and updates the database (mirroring the Vercel token refresh flow).
+ */
+export async function getUserGitHubToken(
+  userId?: string,
+): Promise<string | null> {
+  const result = await getUserGitHubTokenWithStatus(userId);
+  return result.token;
 }


### PR DESCRIPTION
## Summary

Use user-to-server tokens (instead of installation tokens) when creating pull requests, so the user appears as PR author with the "with Open Harness" badge in the GitHub UI.

- Add `getUserGitHubTokenWithStatus()` returning a structured result with status: `valid` | `no_account` | `refresh_failed` | `no_refresh_token`
- Flip token priority in `auto-pr-direct.ts` and `/api/pr` route — user-to-server token first, installation token as fallback
- Surface re-auth prompt in `CreatePRDialog` when the PR was created as the bot due to missing/expired user token
- Keep installation token for git push and read operations (unchanged)

## Test plan

- [x] `auto-pr-direct.test.ts` — 8 tests pass
- [x] `app/api/pr/route.test.ts` — 3 tests pass
- [x] `lib/github/get-repo-token.test.ts` — 2 tests pass (unchanged behavior)
- [ ] Manual: create a PR and verify user appears as author with "with Open Harness" badge
- [ ] Manual: verify fallback to installation token when no GitHub account is linked
- [ ] Manual: verify re-auth banner appears in dialog when PR created as bot

Closes #621