### PR TITLE
feat: add co-author trailer for agent in commits

### DIFF
--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -351,7 +351,7 @@ Respond with ONLY the commit message, nothing else.`,
     }
 
     const escapedMessage = commitMessage.replace(/'/g, "'\\''");
-    const coAuthorTrailer = getAppCoAuthorTrailer();
+    const coAuthorTrailer = await getAppCoAuthorTrailer();
     const trailerArg = coAuthorTrailer
       ? ` -m '${coAuthorTrailer.replace(/'/g, "'\\''")}'`
       : "";

--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -16,6 +16,7 @@ import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { buildGitHubAuthRemoteUrl } from "@/lib/github/repo-identifiers";
 import { generatePullRequestContentFromSandbox } from "@/lib/git/pr-content";
 import { getUserGitHubToken } from "@/lib/github/user-token";
+import { getAppCoAuthorTrailer } from "@/lib/github/app-auth";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 
@@ -336,11 +337,8 @@ Respond with ONLY the commit message, nothing else.`,
     // by ending the quote, adding an escaped single quote, and starting a new quote
     //
     // Set the git author identity to the authenticated user so the commit is
-    // attributed to them. When the GitHub App rewrites the committer on push it
-    // will still show the user as the author. Do NOT add a Co-Authored-By trailer
-    // for the bot — the bot is already attributed as PR creator/committer, and
-    // adding the trailer causes it to appear twice (as committer + co-author) on
-    // squash-merged PRs, resulting in 3 authors instead of 2.
+    // attributed to them. A Co-Authored-By trailer is appended for the GitHub
+    // App bot so the agent's involvement is visible in the commit history.
     const githubAccount = await getGitHubAccount(session.user.id);
     if (githubAccount?.externalUserId && githubAccount.username) {
       const userEmail = `${githubAccount.externalUserId}+${githubAccount.username}@users.noreply.github.com`;
@@ -353,10 +351,14 @@ Respond with ONLY the commit message, nothing else.`,
     }
 
     const escapedMessage = commitMessage.replace(/'/g, "'\\''");
+    const coAuthorTrailer = getAppCoAuthorTrailer();
+    const trailerArg = coAuthorTrailer
+      ? ` -m '${coAuthorTrailer.replace(/'/g, "'\\''")}'`
+      : "";
     const commitCommand =
       useManualCommitMessage && normalizedManualBody.length > 0
-        ? `git commit -m '${escapedMessage}' -m '${normalizedManualBody.replace(/'/g, "'\\''")}'`
-        : `git commit -m '${escapedMessage}'`;
+        ? `git commit -m '${escapedMessage}' -m '${normalizedManualBody.replace(/'/g, "'\\''")}'${trailerArg}`
+        : `git commit -m '${escapedMessage}'${trailerArg}`;
     const commitResult = await sandbox.exec(commitCommand, cwd, 10000);
 
     if (!commitResult.success) {

--- a/apps/web/app/api/github/create-repo/_lib/create-repo-workflow.ts
+++ b/apps/web/app/api/github/create-repo/_lib/create-repo-workflow.ts
@@ -1,6 +1,7 @@
 import type { Sandbox } from "@open-harness/sandbox";
 import { gateway, generateText } from "ai";
 import { getGitHubAccount } from "@/lib/db/accounts";
+import { getAppCoAuthorTrailer } from "@/lib/github/app-auth";
 import { createRepository } from "@/lib/github/client";
 
 // Escape shell metacharacters to prevent command injection
@@ -212,12 +213,14 @@ Respond with ONLY the commit message, nothing else.`,
     commitMessage = "feat: initial commit";
   }
 
-  // 13. Create commit
-  // Do not add extra co-author trailers here; the commit should remain
-  // attributed only to the authenticated GitHub user.
+  // 13. Create commit with Co-Authored-By trailer for the agent app
   const escapedMessage = commitMessage.replace(/'/g, "'\\''");
+  const coAuthorTrailer = getAppCoAuthorTrailer();
+  const trailerArg = coAuthorTrailer
+    ? ` -m '${coAuthorTrailer.replace(/'/g, "'\\''")}'`
+    : "";
   const commitResult = await sandbox.exec(
-    `git commit -m '${escapedMessage}'`,
+    `git commit -m '${escapedMessage}'${trailerArg}`,
     cwd,
     10000,
   );

--- a/apps/web/app/api/github/create-repo/_lib/create-repo-workflow.ts
+++ b/apps/web/app/api/github/create-repo/_lib/create-repo-workflow.ts
@@ -215,7 +215,7 @@ Respond with ONLY the commit message, nothing else.`,
 
   // 13. Create commit with Co-Authored-By trailer for the agent app
   const escapedMessage = commitMessage.replace(/'/g, "'\\''");
-  const coAuthorTrailer = getAppCoAuthorTrailer();
+  const coAuthorTrailer = await getAppCoAuthorTrailer();
   const trailerArg = coAuthorTrailer
     ? ` -m '${coAuthorTrailer.replace(/'/g, "'\\''")}'`
     : "";

--- a/apps/web/lib/chat/auto-commit-direct.ts
+++ b/apps/web/lib/chat/auto-commit-direct.ts
@@ -3,6 +3,7 @@ import { generateText } from "ai";
 import { gateway } from "@open-harness/agent";
 import { getGitHubAccount } from "@/lib/db/accounts";
 import { buildGitHubAuthRemoteUrl } from "@/lib/github/repo-identifiers";
+import { getAppCoAuthorTrailer } from "@/lib/github/app-auth";
 import { getUserGitHubToken } from "@/lib/github/user-token";
 
 export interface AutoCommitParams {
@@ -78,10 +79,14 @@ export async function performAutoCommit(
     await sandbox.exec(`git config user.email '${userEmail}'`, cwd, 5000);
   }
 
-  // 6. Commit
+  // 6. Commit with Co-Authored-By trailer for the agent app
   const escapedMessage = commitMessage.replace(/'/g, "'\\''");
+  const coAuthorTrailer = getAppCoAuthorTrailer();
+  const trailerArg = coAuthorTrailer
+    ? ` -m '${coAuthorTrailer.replace(/'/g, "'\\''")}'`
+    : "";
   const commitResult = await sandbox.exec(
-    `git commit -m '${escapedMessage}'`,
+    `git commit -m '${escapedMessage}'${trailerArg}`,
     cwd,
     10000,
   );

--- a/apps/web/lib/chat/auto-commit-direct.ts
+++ b/apps/web/lib/chat/auto-commit-direct.ts
@@ -81,7 +81,7 @@ export async function performAutoCommit(
 
   // 6. Commit with Co-Authored-By trailer for the agent app
   const escapedMessage = commitMessage.replace(/'/g, "'\\''");
-  const coAuthorTrailer = getAppCoAuthorTrailer();
+  const coAuthorTrailer = await getAppCoAuthorTrailer();
   const trailerArg = coAuthorTrailer
     ? ` -m '${coAuthorTrailer.replace(/'/g, "'\\''")}'`
     : "";

--- a/apps/web/lib/github/app-auth.ts
+++ b/apps/web/lib/github/app-auth.ts
@@ -45,19 +45,51 @@ export function isGitHubAppConfigured(): boolean {
 }
 
 /**
+ * Cached co-author trailer so we only hit the GitHub API once per process.
+ * `undefined` = not yet fetched.
+ */
+let cachedTrailer: string | null | undefined;
+
+/**
  * Returns a git commit trailer for co-authoring with the GitHub App bot, e.g.:
- *   Co-Authored-By: open-agents[bot] <12345+open-agents[bot]@users.noreply.github.com>
+ *   Co-Authored-By: open-agents[bot] <260704009+open-agents[bot]@users.noreply.github.com>
  *
- * GitHub uses this to display "user and bot committed" on commits.
+ * The numeric prefix is the bot's **user** ID (not the app ID) so that GitHub
+ * can resolve the account and display the bot avatar inline on PR commits.
+ *
+ * The result is cached for the lifetime of the process.
  * Returns null if the app is not configured.
  */
-export function getAppCoAuthorTrailer(): string | null {
-  const appId = process.env.GITHUB_APP_ID;
+export async function getAppCoAuthorTrailer(): Promise<string | null> {
+  if (cachedTrailer !== undefined) return cachedTrailer;
+
   const slug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG;
-  if (!appId || !slug) return null;
+  if (!slug) {
+    cachedTrailer = null;
+    return null;
+  }
+
   const botName = `${slug}[bot]`;
-  const botEmail = `${appId}+${botName}@users.noreply.github.com`;
-  return `Co-Authored-By: ${botName} <${botEmail}>`;
+  let botUserId: number | null = null;
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/users/${encodeURIComponent(botName)}`,
+      { headers: { Accept: "application/vnd.github+json" } },
+    );
+    if (res.ok) {
+      const data = (await res.json()) as { id?: number };
+      botUserId = data.id ?? null;
+    }
+  } catch {
+    // Fall back to email without numeric prefix
+  }
+
+  const botEmail = botUserId
+    ? `${botUserId}+${botName}@users.noreply.github.com`
+    : `${botName}@users.noreply.github.com`;
+  cachedTrailer = `Co-Authored-By: ${botName} <${botEmail}>`;
+  return cachedTrailer;
 }
 
 export async function getInstallationToken(


### PR DESCRIPTION
## Summary

Adds support for co-author trailers in commits to properly attribute agent contributions alongside human authors. This enables tracking agent participation in code generation workflows across PR creation and direct commit flows.

## Changes

**API (`apps/web/app/api/generate-pr/route.ts`)**

- Integrate co-author trailer generation for agent-created pull requests
- Update PR creation logic to include agent attribution in commit metadata

**API (`apps/web/app/api/github/create-repo/_lib/create-repo-workflow.ts`)**

- Modify repo creation workflow to support co-author trailers
- Enhance commit workflow to include agent as co-author in initial commits

**Commits (`apps/web/lib/chat/auto-commit-direct.ts`)**

- Add co-author trailer support to direct auto-commit functionality
- Ensure agent attribution is included in commit messages for chat-driven commits

---

[Chat](https://open-agents.dev/sessions/BxSF44tkv4M2EswXECHZd/chats/53QqYi-0A84hBJ55z-eIH) - Built with guidance from [Will Sather](https://github.com/willsather)