### PR TITLE
chore: disable Vercel secrets passing

### DIFF
--- a/apps/web/app/api/sandbox/route.test.ts
+++ b/apps/web/app/api/sandbox/route.test.ts
@@ -269,7 +269,7 @@ describe("/api/sandbox lifecycle kicks", () => {
     expect(connectConfigs[0]?.state.source).not.toHaveProperty("token");
   });
 
-  test("new vercel sandbox writes linked Development env vars to .env.local", async () => {
+  test("new vercel sandbox does not sync linked Development env vars while code is commented out", async () => {
     const { POST } = await routeModulePromise;
 
     const request = new Request("http://localhost/api/sandbox", {
@@ -294,18 +294,8 @@ describe("/api/sandbox lifecycle kicks", () => {
     expect(connectConfigs[0]?.options?.gitUser?.email).toBe(
       "12345+nico-gh@users.noreply.github.com",
     );
-    expect(dotenvSyncCalls).toEqual([
-      {
-        token: "vercel-token",
-        projectIdOrName: "project-1",
-        teamId: "team-1",
-      },
-    ]);
+    expect(dotenvSyncCalls).toHaveLength(0);
     expect(writeFileCalls).toEqual([
-      {
-        path: "/vercel/sandbox/.env.local",
-        content: 'API_KEY="secret"\n',
-      },
       {
         path: "/root/.local/share/com.vercel.cli/auth.json",
         content:
@@ -326,7 +316,7 @@ describe("/api/sandbox lifecycle kicks", () => {
     expect(payload.mode).toBe("vercel");
   });
 
-  test("env sync failures do not block sandbox creation", async () => {
+  test("commented-out env sync does not run during sandbox creation", async () => {
     const { POST } = await routeModulePromise;
 
     currentDotenvError = new Error("boom");
@@ -349,7 +339,7 @@ describe("/api/sandbox lifecycle kicks", () => {
         reason: "sandbox-created",
       },
     ]);
-    expect(dotenvSyncCalls).toHaveLength(1);
+    expect(dotenvSyncCalls).toHaveLength(0);
     expect(writeFileCalls).toEqual([
       {
         path: "/root/.local/share/com.vercel.cli/auth.json",

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -214,6 +214,7 @@ export async function POST(req: Request) {
     });
 
     if (sessionRecord) {
+      // TODO: Re-enable this once we have a solid exfiltration defense strategy.
       // try {
       //   await syncVercelProjectEnvVarsToSandbox({
       //     userId: session.user.id,

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -30,8 +30,8 @@ import {
   hasResumableSandboxState,
 } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
-import { buildDevelopmentDotenvFromVercelProject } from "@/lib/vercel/projects";
-import { getUserVercelToken } from "@/lib/vercel/token";
+// import { buildDevelopmentDotenvFromVercelProject } from "@/lib/vercel/projects";
+// import { getUserVercelToken } from "@/lib/vercel/token";
 
 interface CreateSandboxRequest {
   repoUrl?: string;
@@ -41,35 +41,35 @@ interface CreateSandboxRequest {
   sandboxType?: "vercel";
 }
 
-async function syncVercelProjectEnvVarsToSandbox(params: {
-  userId: string;
-  sessionRecord: SessionRecord;
-  sandbox: Awaited<ReturnType<typeof connectSandbox>>;
-}): Promise<void> {
-  if (!params.sessionRecord.vercelProjectId) {
-    return;
-  }
-
-  const token = await getUserVercelToken(params.userId);
-  if (!token) {
-    return;
-  }
-
-  const dotenvContent = await buildDevelopmentDotenvFromVercelProject({
-    token,
-    projectIdOrName: params.sessionRecord.vercelProjectId,
-    teamId: params.sessionRecord.vercelTeamId,
-  });
-  if (!dotenvContent) {
-    return;
-  }
-
-  await params.sandbox.writeFile(
-    `${params.sandbox.workingDirectory}/.env.local`,
-    dotenvContent,
-    "utf-8",
-  );
-}
+// async function syncVercelProjectEnvVarsToSandbox(params: {
+//   userId: string;
+//   sessionRecord: SessionRecord;
+//   sandbox: Awaited<ReturnType<typeof connectSandbox>>;
+// }): Promise<void> {
+//   if (!params.sessionRecord.vercelProjectId) {
+//     return;
+//   }
+//
+//   const token = await getUserVercelToken(params.userId);
+//   if (!token) {
+//     return;
+//   }
+//
+//   const dotenvContent = await buildDevelopmentDotenvFromVercelProject({
+//     token,
+//     projectIdOrName: params.sessionRecord.vercelProjectId,
+//     teamId: params.sessionRecord.vercelTeamId,
+//   });
+//   if (!dotenvContent) {
+//     return;
+//   }
+//
+//   await params.sandbox.writeFile(
+//     `${params.sandbox.workingDirectory}/.env.local`,
+//     dotenvContent,
+//     "utf-8",
+//   );
+// }
 
 async function syncVercelCliAuthForSandbox(params: {
   userId: string;
@@ -214,18 +214,18 @@ export async function POST(req: Request) {
     });
 
     if (sessionRecord) {
-      try {
-        await syncVercelProjectEnvVarsToSandbox({
-          userId: session.user.id,
-          sessionRecord,
-          sandbox,
-        });
-      } catch (error) {
-        console.error(
-          `Failed to sync Vercel env vars for session ${sessionRecord.id}:`,
-          error,
-        );
-      }
+      // try {
+      //   await syncVercelProjectEnvVarsToSandbox({
+      //     userId: session.user.id,
+      //     sessionRecord,
+      //     sandbox,
+      //   });
+      // } catch (error) {
+      //   console.error(
+      //     `Failed to sync Vercel env vars for session ${sessionRecord.id}:`,
+      //     error,
+      //   );
+      // }
 
       try {
         await syncVercelCliAuthForSandbox({


### PR DESCRIPTION
## Summary

Disable passing Vercel secrets to the sandbox API pending implementation of a more robust defense strategy.

## Changes

**API (`apps/web/app/api/sandbox/route.ts`)**

- Disabled Vercel secrets environment variable passing
- Refactored route handler logic to remove secret passing functionality

**Tests (`apps/web/app/api/sandbox/route.test.ts`)**

- Updated test cases to reflect disabled secrets passing
- Simplified test assertions for sandbox route

---

[Chat](https://open-agents.dev/sessions/9hoa_Xle2L5o1J2vdbKd_/chats/ZTyLoNG2vf_8_vrThxNO4) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)