### PR TITLE
fix: cap chat route maxDuration for hobby deploys

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -33,7 +33,7 @@ import { createChatRuntime } from "./_lib/runtime";
 import { runAgentWorkflow } from "@/app/workflows/chat";
 import { persistAssistantMessagesWithToolResults } from "./_lib/persist-tool-results";
 
-export const maxDuration = 800;
+export const maxDuration = 300;
 
 type WebAgentUIMessageChunk = InferUIMessageChunk<WebAgentUIMessage>;
 

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -15,6 +15,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 - After schema edits, review generated Drizzle migrations for unrelated schema drift changes before committing (for example defaults on untouched columns), since `drizzle-kit generate` can include those alongside intended changes.
 - `bunx @vercel/config validate` executes the CLI under Node via its shebang and cannot parse TypeScript-style `vercel.ts` imports; use `bunx --bun @vercel/config validate` (or `bun node_modules/@vercel/config/dist/cli.js validate`) for reliable local validation.
 - Successful Vercel CLI auth (`vercel whoami`, team/project REST APIs, `.vercel` linking) does **not** guarantee Workflow observability access. `workflow inspect ... --backend vercel` can still fail with `401 {"error":{"code":"unauthorized","message":"You are not allowed to access this endpoint."}}` when the user/token lacks the Vercel product permission documented as `Vercel Workflow` (and possibly related Observability access), even if `WORKFLOW_VERCEL_AUTH_TOKEN` is passed explicitly from the Vercel CLI auth file.
+- Vercel build errors that name an invalid Serverless Function `maxDuration` usually come from a route file’s static export (for example `app/api/.../route.ts`), and Hobby plan deployments require that value to stay between `1` and `300`.
 
 ## Next.js
 


### PR DESCRIPTION
## Summary
- cap `app/api/chat` `maxDuration` at 300 seconds so Vercel Hobby deployments pass validation
- document the route-level `maxDuration` constraint in agent lessons learned

## Testing
- bun run ci