### PR TITLE
feat: filter sessions in the inbox sidebar

### DIFF
--- a/apps/web/components/inbox-sidebar-search.test.ts
+++ b/apps/web/components/inbox-sidebar-search.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import type { SessionWithUnread } from "@/hooks/use-sessions";
+import { matchesSessionQuery } from "./inbox-sidebar-search";
+
+function makeSession(
+  overrides: Partial<SessionWithUnread> = {},
+): SessionWithUnread {
+  return {
+    id: "session-1",
+    title: "Add sidebar filter",
+    status: "idle",
+    repoOwner: "vercel-labs",
+    repoName: "open-agents",
+    branch: "main",
+    linesAdded: null,
+    linesRemoved: null,
+    prNumber: null,
+    prStatus: null,
+    createdAt: new Date("2026-04-13T00:00:00Z"),
+    hasUnread: false,
+    hasStreaming: false,
+    latestChatId: null,
+    lastActivityAt: new Date("2026-04-13T00:00:00Z"),
+    ...overrides,
+  } as SessionWithUnread;
+}
+
+describe("matchesSessionQuery", () => {
+  test("returns true for empty query", () => {
+    expect(matchesSessionQuery(makeSession(), "")).toBe(true);
+  });
+
+  test("returns true for whitespace-only query", () => {
+    expect(matchesSessionQuery(makeSession(), "   ")).toBe(true);
+  });
+
+  test("matches session title case-insensitively", () => {
+    expect(matchesSessionQuery(makeSession(), "SIDEBAR")).toBe(true);
+    expect(matchesSessionQuery(makeSession(), "filter")).toBe(true);
+  });
+
+  test("matches by trimming whitespace around query", () => {
+    expect(matchesSessionQuery(makeSession(), "  sidebar  ")).toBe(true);
+  });
+
+  test("matches repo owner and name", () => {
+    expect(matchesSessionQuery(makeSession(), "vercel")).toBe(true);
+    expect(matchesSessionQuery(makeSession(), "open-agents")).toBe(true);
+  });
+
+  test("matches branch name", () => {
+    expect(
+      matchesSessionQuery(makeSession({ branch: "feat/xyz" }), "xyz"),
+    ).toBe(true);
+  });
+
+  test("returns false for unrelated query", () => {
+    expect(matchesSessionQuery(makeSession(), "unrelated")).toBe(false);
+  });
+
+  test("ignores sessions with missing optional fields", () => {
+    const session = makeSession({
+      repoOwner: null,
+      repoName: null,
+      branch: null,
+    });
+    expect(matchesSessionQuery(session, "sidebar")).toBe(true);
+    expect(matchesSessionQuery(session, "vercel")).toBe(false);
+  });
+});

--- a/apps/web/components/inbox-sidebar-search.tsx
+++ b/apps/web/components/inbox-sidebar-search.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { X } from "lucide-react";
+import type { ChangeEvent, KeyboardEvent } from "react";
+import type { SessionWithUnread } from "@/hooks/use-sessions";
+
+type InboxSidebarSearchProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function InboxSidebarSearch({
+  value,
+  onChange,
+}: InboxSidebarSearchProps) {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    onChange(event.target.value);
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onChange("");
+      event.currentTarget.blur();
+    }
+  }
+
+  return (
+    <div className="relative px-2 pt-2">
+      <input
+        type="text"
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder="Filter sessions"
+        aria-label="Filter sessions"
+        className="w-full rounded-md border border-border/60 bg-background px-3 py-1.5 pr-7 text-xs text-foreground placeholder:text-muted-foreground focus:border-border focus:outline-none"
+      />
+      {value.length > 0 ? (
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          aria-label="Clear filter"
+          className="-translate-y-1/2 absolute top-1/2 right-3.5 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function matchesSessionQuery(
+  session: SessionWithUnread,
+  query: string,
+): boolean {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) {
+    return true;
+  }
+
+  const haystacks: string[] = [];
+  if (session.title) {
+    haystacks.push(session.title);
+  }
+  if (session.repoOwner) {
+    haystacks.push(session.repoOwner);
+  }
+  if (session.repoName) {
+    haystacks.push(session.repoName);
+  }
+  if (session.branch) {
+    haystacks.push(session.branch);
+  }
+
+  return haystacks.some((value) => value.toLowerCase().includes(trimmed));
+}

--- a/apps/web/components/inbox-sidebar.tsx
+++ b/apps/web/components/inbox-sidebar.tsx
@@ -19,6 +19,10 @@ import type { CSSProperties } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { BranchPickerDialog } from "@/components/branch-picker-dialog";
 import { getValidRenameTitle } from "@/components/inbox-sidebar-rename";
+import {
+  InboxSidebarSearch,
+  matchesSessionQuery,
+} from "@/components/inbox-sidebar-search";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -648,6 +652,7 @@ export function InboxSidebar({
     useLeaderboardRank();
   const { isMobile, setOpenMobile } = useSidebar();
   const [showArchived, setShowArchived] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [archivedSessions, setArchivedSessions] = useState<SessionWithUnread[]>(
     [],
   );
@@ -738,7 +743,20 @@ export function InboxSidebar({
   }, [archivedCount, fetchArchivedSessionsPage, showArchived]);
 
   const activeSessions = sessions;
-  const displayedSessions = showArchived ? archivedSessions : activeSessions;
+  const rawDisplayedSessions = showArchived ? archivedSessions : activeSessions;
+  const showSearch = !showArchived && activeSessions.length >= 10;
+  const effectiveSearchQuery = showSearch ? searchQuery : "";
+  const filteredSessions = useMemo(() => {
+    const trimmed = effectiveSearchQuery.trim();
+    if (!trimmed) {
+      return rawDisplayedSessions;
+    }
+    return rawDisplayedSessions.filter((session) =>
+      matchesSessionQuery(session, trimmed),
+    );
+  }, [effectiveSearchQuery, rawDisplayedSessions]);
+  const displayedSessions = filteredSessions;
+  const hasActiveSearch = effectiveSearchQuery.trim().length > 0;
   const showLoadingSkeleton =
     (!showArchived && sessionsLoading && sessions.length === 0) ||
     (showArchived && archivedSessionsLoading && archivedSessions.length === 0);
@@ -954,6 +972,10 @@ export function InboxSidebar({
         </div>
       </div>
 
+      {showSearch ? (
+        <InboxSidebarSearch value={searchQuery} onChange={setSearchQuery} />
+      ) : null}
+
       <div className="min-h-0 flex-1 overflow-y-auto">
         {showLoadingSkeleton ? (
           <div className="space-y-1 p-2">
@@ -966,9 +988,11 @@ export function InboxSidebar({
           </div>
         ) : displayedSessions.length === 0 ? (
           <div className="px-4 py-12 text-center text-sm text-muted-foreground">
-            {showArchived
-              ? (archivedSessionsError ?? "No archived sessions")
-              : "No sessions yet"}
+            {hasActiveSearch
+              ? "No sessions match your filter"
+              : showArchived
+                ? (archivedSessionsError ?? "No archived sessions")
+                : "No sessions yet"}
             {showArchived && archivedSessionsError ? (
               <div className="mt-3">
                 <Button


### PR DESCRIPTION
## Summary

Small addition to the inbox sidebar: a client-side filter input that appears when there are 10+ active sessions. Type to narrow the list by session title, repo owner/name, or branch. Empty query is a no-op.

No schema, no API, no data-model change.

## Why this matters

@nicoalbanese's #518 flags this directly:

> If every external invocation creates a visible top-level session, the sidebar will quickly become noisy and hard to manage.

#518 proposes a larger organizational rethink. This PR is orthogonal: it keeps the existing sidebar usable while that redesign lands.

## Changes

- `apps/web/components/inbox-sidebar-search.tsx` (new): `InboxSidebarSearch` input + `matchesSessionQuery` predicate. Colocated per the separate-file-per-concern rule in AGENTS.md.
- `apps/web/components/inbox-sidebar.tsx`: adds a `searchQuery` state, memoizes a filtered list, renders the input above the scroll container when `activeSessions.length >= 10`, shows a "No sessions match your filter" empty state.
- `apps/web/components/inbox-sidebar-search.test.ts` (new): unit tests for `matchesSessionQuery` covering empty query, whitespace, case-insensitive matching on title/repo/branch, and sessions with missing fields.

## UX notes

- Only renders on the Active tab. Archive tab is unchanged.
- Clear (×) control resets the query. `Esc` while focused also clears and blurs.
- Filters on title, repoOwner, repoName, and branch. Case-insensitive, trimmed.
- Grouping, collapse state, pagination, and archived-fetching behavior are untouched.

## Verification

- `bun run ci` passes: `ultracite check`, `turbo typecheck` across all packages, `bun run test:isolated`, and `bun run --cwd apps/web db:check` (migrations in sync).
- 8 unit tests for `matchesSessionQuery`, 0 failures.

## Simulated Demo

I don't have the OAuth/GitHub App stack set up locally, so I can't produce a live recording with 10+ real sessions. Here's a Remotion-rendered simulated demo showing the filter behavior. Labeled honestly as simulated:

![Simulated demo](https://litter.catbox.moe/9fp8vy.gif)

A durable mirror of the same GIF lives at https://raw.githubusercontent.com/mvanhorn/open-agents/evidence/sidebar-search-demo.gif in case the catbox link expires.

## Out of scope

No session-organization model changes. No grouping/pinning/archiving affordances. No new server route. This does not preempt the v1 direction in #518.

Relates to #518.

---

This contribution was developed with AI assistance (Claude Code).
