### PR TITLE
feat: add scrollable max-height to task list containers

### DIFF
--- a/apps/web/components/pinned-todo-panel.tsx
+++ b/apps/web/components/pinned-todo-panel.tsx
@@ -155,7 +155,7 @@ export function PinnedTodoPanel({ todos }: PinnedTodoPanelProps) {
 
       {/* Expanded todo list */}
       {!isMinimized && (
-        <div className="border-t border-border/40 px-3 py-2">
+        <div className="max-h-48 overflow-y-auto border-t border-border/40 px-3 py-2">
           <div className="space-y-1">
             {todos.map((todo, index) => {
               if (!todo) return null;

--- a/apps/web/components/tool-call/renderers/todo-renderer.tsx
+++ b/apps/web/components/tool-call/renderers/todo-renderer.tsx
@@ -147,7 +147,7 @@ export function TodoRenderer({
 
   const expandedContent =
     todos.length > 0 ? (
-      <div className="space-y-0.5 pl-6">
+      <div className="max-h-48 space-y-0.5 overflow-y-auto pl-6">
         {todos.map((todo, i) => (
           <TodoItem key={todo.id ?? i} todo={todo} />
         ))}


### PR DESCRIPTION
## Summary

Adds scrollable max-height styling to task list containers to improve handling of long lists and prevent layout overflow in pinned panels and tool renderers.

## Changes

**UI Components (`apps/web/components/pinned-todo-panel.tsx`)**

- Add max-height styling to enable scrolling behavior for task list container

**UI Components (`apps/web/components/tool-call/renderers/todo-renderer.tsx`)**

- Add max-height styling to enable scrolling behavior for task list container

---

[Chat](https://open-agents.dev/sessions/LwD_x_BuhOSj5EHhrA3ka/chats/NjgQwurT1Za4WoLSMSE1t) - Built with guidance from [Will Sather](https://github.com/willsather)