### PR TITLE
refactor: restrict fetch tool to GET requests only

### DIFF
--- a/packages/agent/tools/fetch.ts
+++ b/packages/agent/tools/fetch.ts
@@ -4,45 +4,37 @@ import { z } from "zod";
 const fetchInputSchema = z.object({
   url: z.string().url().describe("The URL to fetch"),
   method: z
-    .enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
+    .literal("GET")
     .optional()
-    .describe("HTTP method. Default: GET"),
+    .describe("HTTP method. Only GET is supported."),
   headers: z
     .record(z.string(), z.string())
     .optional()
     .describe("Optional HTTP headers as key-value pairs"),
-  body: z
-    .string()
-    .optional()
-    .describe("Optional request body (for POST/PUT/PATCH)"),
 });
 
 export const webFetchTool = tool({
-  description: `Fetch a URL from the web.
+  description: `Fetch a URL from the web using GET requests only.
 
 USAGE:
-- Make HTTP requests to external URLs
-- Supports GET, POST, PUT, PATCH, DELETE, and HEAD methods
+- Make GET requests to external URLs
+- Optional headers are supported
 - Returns the response status, headers, and body text
 - Body is truncated to 20000 characters to avoid overwhelming context
 
 EXAMPLES:
 - Simple GET: url: "https://api.example.com/data"
-- POST with JSON: url: "https://api.example.com/items", method: "POST", headers: {"Content-Type": "application/json"}, body: "{\\"name\\":\\"item\\"}"`,
+- GET with headers: url: "https://api.example.com/data", headers: {"Accept": "application/json"}`,
   inputSchema: fetchInputSchema,
-  execute: async ({ url, method = "GET", headers, body }) => {
+  execute: async ({ url, headers }) => {
     try {
       const MAX_BODY_LENGTH = 20000;
 
-      const init: RequestInit = {
-        method,
+      const response = await fetch(url, {
+        method: "GET",
         headers,
         signal: AbortSignal.timeout(30000),
-      };
-      if (method !== "GET" && method !== "HEAD" && body) {
-        init.body = body;
-      }
-      const response = await fetch(url, init);
+      });
 
       const responseHeaders: Record<string, string> = {};
       response.headers.forEach((value, key) => {

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -422,6 +422,32 @@ describe("tools execute behavior", () => {
     sandboxRegistry.clear();
   });
 
+  test("webFetchTool only accepts GET requests", async () => {
+    const fetchCalls: Array<Parameters<typeof fetch>> = [];
+    globalThis.fetch = ((...args: Parameters<typeof fetch>) => {
+      fetchCalls.push(args);
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    }) as unknown as typeof fetch;
+
+    await webFetchTool.execute?.(
+      {
+        url: "https://example.com",
+        method: "POST",
+        headers: { Accept: "application/json" },
+      } as never,
+      executionOptions(),
+    );
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]).toEqual([
+      "https://example.com",
+      expect.objectContaining({
+        method: "GET",
+        headers: { Accept: "application/json" },
+      }),
+    ]);
+  });
+
   test("webFetchTool truncates oversized response bodies", async () => {
     globalThis.fetch = ((..._args: Parameters<typeof fetch>) =>
       Promise.resolve(
@@ -435,7 +461,6 @@ describe("tools execute behavior", () => {
     const result = await webFetchTool.execute?.(
       {
         url: "https://example.com",
-        method: "GET",
       },
       executionOptions(),
     );


### PR DESCRIPTION
## Summary

Restricts the fetch tool to only accept GET requests, improving security by limiting the operations it can perform.

## Changes

**Tools (`packages/agent/tools/fetch.ts`)**

- Refactored fetch tool to restrict requests to GET method only
- Removed support for other HTTP methods
- Simplified request handling logic

**Tests (`packages/agent/tools/tools.test.ts`)**

- Added test cases validating GET request handling
- Added tests for GET-only restriction enforcement
- Expanded test coverage for fetch tool behavior

---

[Chat](https://open-agents.dev/sessions/3V1Tk1GTD8S2-yqF18po3/chats/2WkYhCRxttd7xiNo90IX9) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)