### PR TITLE
docs: clarify message limit error language with deployment context

### DIFF
--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -322,7 +322,7 @@ describe("/api/chat route", () => {
 
     expect(response.status).toBe(403);
     expect(body.error).toBe(
-      "This hosted deployment has a 5 message limit. Deploy your own copy for no limit.",
+      "This hosted deployment has a 5 message limit. Deploy your own copy for no limit at open-agents.dev/deploy-your-own.",
     );
     expect(startCalls).toHaveLength(0);
   });

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -322,7 +322,7 @@ describe("/api/chat route", () => {
 
     expect(response.status).toBe(403);
     expect(body.error).toBe(
-      "This hosted deployment includes 5 trial messages for non-Vercel accounts. Deploy your own copy for more.",
+      "This hosted deployment has a 5 message limit. Deploy your own copy for no limit.",
     );
     expect(startCalls).toHaveLength(0);
   });

--- a/apps/web/lib/managed-template-trial.ts
+++ b/apps/web/lib/managed-template-trial.ts
@@ -9,7 +9,7 @@ const MANAGED_TEMPLATE_HOSTS = new Set([
 export const MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT = 5;
 export const MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT = 1;
 export const MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT_ERROR =
-  "This hosted deployment includes 5 trial messages for non-Vercel accounts. Deploy your own copy for more.";
+  "This hosted deployment has a 5 message limit. Deploy your own copy for no limit.";
 export const MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT_ERROR =
   "This hosted deployment includes 1 trial session for non-Vercel accounts. Deploy your own copy to start more.";
 export const MANAGED_TEMPLATE_TRIAL_DELETE_MESSAGE_ERROR =

--- a/apps/web/lib/managed-template-trial.ts
+++ b/apps/web/lib/managed-template-trial.ts
@@ -9,7 +9,7 @@ const MANAGED_TEMPLATE_HOSTS = new Set([
 export const MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT = 5;
 export const MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT = 1;
 export const MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT_ERROR =
-  "This hosted deployment has a 5 message limit. Deploy your own copy for no limit.";
+  "This hosted deployment has a 5 message limit. Deploy your own copy for no limit at open-agents.dev/deploy-your-own.";
 export const MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT_ERROR =
   "This hosted deployment includes 1 trial session for non-Vercel accounts. Deploy your own copy to start more.";
 export const MANAGED_TEMPLATE_TRIAL_DELETE_MESSAGE_ERROR =


### PR DESCRIPTION
## Summary

Clarifies message limit error messages by adding deployment URL context and updating trial-related error text to better inform users about message limit restrictions.

## Changes

**Tests (`apps/web/app/api/chat/route.test.ts`)**

- Updated test expectations for clarified message limit error message

**Configuration (`apps/web/lib/managed-template-trial.ts`)**

- Updated trial message limit error text to include deployment URL context

---

[Chat](https://open-agents.dev/sessions/GCBWZLt6miCweyre8D1yd/chats/06rdWD5HMQ0sGohpBYUHJ) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)