### PR TITLE
feat: download shared conversation as markdown

### DIFF
--- a/apps/web/app/shared/[shareId]/conversation-to-markdown.test.ts
+++ b/apps/web/app/shared/[shareId]/conversation-to-markdown.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import type { WebAgentUIMessage } from "@/app/types";
+import { conversationToMarkdown } from "./conversation-to-markdown";
+import type { MessageWithTiming } from "./shared-chat-content";
+
+function makeMessage(
+  role: WebAgentUIMessage["role"],
+  parts: ReadonlyArray<unknown>,
+): MessageWithTiming {
+  return {
+    message: {
+      id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+      role,
+      parts,
+    } as unknown as WebAgentUIMessage,
+    durationMs: null,
+  };
+}
+
+const SHARED_AT = new Date("2026-04-13T15:00:00.000Z");
+
+describe("conversationToMarkdown", () => {
+  test("emits header with title and share id", () => {
+    const md = conversationToMarkdown({
+      title: "Fixing the flaky test",
+      shareId: "abc123",
+      sharedAt: SHARED_AT,
+      chats: [],
+    });
+    expect(md).toContain("# Fixing the flaky test");
+    expect(md).toContain("Share ID: abc123");
+    expect(md).toContain("Shared from Open Agents - 2026-04-13T15:00:00.000Z");
+  });
+
+  test("falls back to default title when missing", () => {
+    const md = conversationToMarkdown({
+      title: null,
+      shareId: "xyz",
+      sharedAt: SHARED_AT,
+      chats: [],
+    });
+    expect(md.startsWith("# Shared Chat")).toBe(true);
+  });
+
+  test("renders user and agent text messages with headings", () => {
+    const md = conversationToMarkdown({
+      title: "Example",
+      shareId: "abc",
+      sharedAt: SHARED_AT,
+      chats: [
+        {
+          title: null,
+          messages: [
+            makeMessage("user", [{ type: "text", text: "Please add a retry" }]),
+            makeMessage("assistant", [
+              { type: "text", text: "Done. Wired retry into handleTimeout." },
+            ]),
+          ],
+        },
+      ],
+    });
+    expect(md).toContain("## User");
+    expect(md).toContain("Please add a retry");
+    expect(md).toContain("## Agent");
+    expect(md).toContain("Done. Wired retry into handleTimeout.");
+  });
+
+  test("renders dynamic-tool parts with the actual toolName", () => {
+    const md = conversationToMarkdown({
+      title: "Example",
+      shareId: "abc",
+      sharedAt: SHARED_AT,
+      chats: [
+        {
+          title: null,
+          messages: [
+            makeMessage("assistant", [
+              {
+                type: "dynamic-tool",
+                toolName: "mcp__context7__resolve-library-id",
+                toolCallId: "call-dyn-1",
+                state: "output-available",
+                input: { libraryName: "react" },
+                output: { id: "/facebook/react" },
+              },
+            ]),
+          ],
+        },
+      ],
+    });
+    expect(md).toContain(
+      "### Tool call: mcp__context7__resolve-library-id (output-available)",
+    );
+    expect(md).not.toContain("### Tool call: dynamic-tool");
+    expect(md).toContain('"libraryName": "react"');
+  });
+
+  test("renders tool calls in fenced blocks with name", () => {
+    const md = conversationToMarkdown({
+      title: "Example",
+      shareId: "abc",
+      sharedAt: SHARED_AT,
+      chats: [
+        {
+          title: null,
+          messages: [
+            makeMessage("assistant", [
+              {
+                type: "tool-read",
+                toolCallId: "call-1",
+                state: "output-available",
+                input: { path: "README.md" },
+                output: { text: "hello" },
+              },
+            ]),
+          ],
+        },
+      ],
+    });
+    expect(md).toContain("### Tool call: read");
+    expect(md).toContain("```json");
+    expect(md).toContain('"path": "README.md"');
+  });
+
+  test("replaces non-text data parts with placeholder", () => {
+    const md = conversationToMarkdown({
+      title: null,
+      shareId: "abc",
+      sharedAt: SHARED_AT,
+      chats: [
+        {
+          title: null,
+          messages: [
+            makeMessage("assistant", [
+              { type: "data-commit", data: { sha: "abc123" } },
+            ]),
+          ],
+        },
+      ],
+    });
+    expect(md).toContain("[attachment: commit]");
+  });
+
+  test("skips messages with no renderable parts", () => {
+    const md = conversationToMarkdown({
+      title: "Empty",
+      shareId: "abc",
+      sharedAt: SHARED_AT,
+      chats: [
+        {
+          title: null,
+          messages: [makeMessage("assistant", [{ type: "text", text: "   " }])],
+        },
+      ],
+    });
+    expect(md).not.toContain("## Agent");
+  });
+
+  test("prepends chat title when multiple chats exist", () => {
+    const md = conversationToMarkdown({
+      title: "Example",
+      shareId: "abc",
+      sharedAt: SHARED_AT,
+      chats: [
+        {
+          title: "Initial planning",
+          messages: [
+            makeMessage("user", [{ type: "text", text: "First message" }]),
+          ],
+        },
+        {
+          title: "Follow-up work",
+          messages: [
+            makeMessage("user", [{ type: "text", text: "Follow up" }]),
+          ],
+        },
+      ],
+    });
+    expect(md).toContain("# Initial planning");
+    expect(md).toContain("# Follow-up work");
+    expect(md).toContain("First message");
+    expect(md).toContain("Follow up");
+  });
+
+  test("does not prepend chat title when only one chat", () => {
+    const md = conversationToMarkdown({
+      title: "Example",
+      shareId: "abc",
+      sharedAt: SHARED_AT,
+      chats: [
+        {
+          title: "Single",
+          messages: [
+            makeMessage("user", [{ type: "text", text: "Only message" }]),
+          ],
+        },
+      ],
+    });
+    expect(md).not.toContain("# Single");
+    expect(md).toContain("Only message");
+  });
+});

--- a/apps/web/app/shared/[shareId]/conversation-to-markdown.ts
+++ b/apps/web/app/shared/[shareId]/conversation-to-markdown.ts
@@ -1,0 +1,146 @@
+import { isReasoningUIPart, isToolUIPart } from "ai";
+import { getToolName } from "@/app/lib/render-tool";
+import type { WebAgentUIMessage, WebAgentUIMessagePart } from "@/app/types";
+import type { MessageWithTiming } from "./shared-chat-content";
+
+type SerializeInput = {
+  title: string | null;
+  shareId: string;
+  sharedAt: Date;
+  chats: ReadonlyArray<{
+    title: string | null;
+    messages: ReadonlyArray<MessageWithTiming>;
+  }>;
+};
+
+function renderRoleHeading(role: WebAgentUIMessage["role"]): string {
+  switch (role) {
+    case "user":
+      return "## User";
+    case "assistant":
+      return "## Agent";
+    case "system":
+      return "## System";
+    default:
+      return `## ${String(role)}`;
+  }
+}
+
+function renderTextPart(part: WebAgentUIMessagePart): string | null {
+  if (part.type === "text" && "text" in part && typeof part.text === "string") {
+    const trimmed = part.text.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+}
+
+function renderToolPart(part: WebAgentUIMessagePart): string {
+  if (!isToolUIPart(part)) {
+    return "";
+  }
+  const name = getToolName(part);
+  const state = "state" in part ? String(part.state ?? "") : "";
+  const header = state ? `Tool call: ${name} (${state})` : `Tool call: ${name}`;
+  const details: string[] = [];
+  if ("input" in part && part.input !== undefined) {
+    details.push(`input:\n${JSON.stringify(part.input, null, 2)}`);
+  }
+  if ("output" in part && part.output !== undefined) {
+    details.push(`output:\n${JSON.stringify(part.output, null, 2)}`);
+  }
+  const body = details.join("\n\n");
+  if (body.length === 0) {
+    return `### ${header}\n`;
+  }
+  return `### ${header}\n\n\`\`\`json\n${body}\n\`\`\`\n`;
+}
+
+function renderReasoningPart(part: WebAgentUIMessagePart): string | null {
+  if (!isReasoningUIPart(part)) {
+    return null;
+  }
+  const text =
+    "text" in part && typeof part.text === "string" ? part.text.trim() : "";
+  if (text.length === 0) {
+    return null;
+  }
+  return `<details><summary>Agent reasoning</summary>\n\n${text}\n\n</details>`;
+}
+
+function renderOtherPart(part: WebAgentUIMessagePart): string | null {
+  if (part.type.startsWith("data-")) {
+    const label = part.type.replace(/^data-/, "");
+    return `[attachment: ${label}]`;
+  }
+  if (part.type === "file") {
+    return "[attachment: file]";
+  }
+  if (part.type === "source-url" || part.type === "source-document") {
+    return `[attachment: ${part.type}]`;
+  }
+  return null;
+}
+
+function renderMessage(item: MessageWithTiming): string {
+  const { message } = item;
+  const lines: string[] = [renderRoleHeading(message.role)];
+  const body: string[] = [];
+
+  for (const part of message.parts) {
+    const text = renderTextPart(part);
+    if (text !== null) {
+      body.push(text);
+      continue;
+    }
+    const reasoning = renderReasoningPart(part);
+    if (reasoning !== null) {
+      body.push(reasoning);
+      continue;
+    }
+    if (isToolUIPart(part)) {
+      body.push(renderToolPart(part));
+      continue;
+    }
+    const other = renderOtherPart(part);
+    if (other !== null) {
+      body.push(other);
+    }
+  }
+
+  if (body.length === 0) {
+    return "";
+  }
+  lines.push("", body.join("\n\n"));
+  return lines.join("\n");
+}
+
+export function conversationToMarkdown(input: SerializeInput): string {
+  const headingTitle =
+    input.title && input.title.trim().length > 0
+      ? input.title.trim()
+      : "Shared Chat";
+  const header = [
+    `# ${headingTitle}`,
+    "",
+    `Shared from Open Agents - ${input.sharedAt.toISOString()}`,
+    `Share ID: ${input.shareId}`,
+  ];
+
+  const sections: string[] = [header.join("\n")];
+
+  for (const chat of input.chats) {
+    if (input.chats.length > 1) {
+      const chatHeading =
+        chat.title && chat.title.trim().length > 0 ? chat.title.trim() : "Chat";
+      sections.push(`# ${chatHeading}`);
+    }
+    for (const item of chat.messages) {
+      const rendered = renderMessage(item);
+      if (rendered.length > 0) {
+        sections.push(rendered);
+      }
+    }
+  }
+
+  return `${sections.join("\n\n")}\n`;
+}

--- a/apps/web/app/shared/[shareId]/download-markdown-button.tsx
+++ b/apps/web/app/shared/[shareId]/download-markdown-button.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { conversationToMarkdown } from "./conversation-to-markdown";
+import type { MessageWithTiming } from "./shared-chat-content";
+
+type ChatInput = {
+  title: string | null;
+  messages: ReadonlyArray<MessageWithTiming>;
+};
+
+type DownloadMarkdownButtonProps = {
+  chats: ReadonlyArray<ChatInput>;
+  shareId: string;
+  title: string | null;
+};
+
+function safeFileSlug(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug.slice(0, 60) : "";
+}
+
+export function DownloadMarkdownButton({
+  chats,
+  shareId,
+  title,
+}: DownloadMarkdownButtonProps) {
+  const [pending, setPending] = useState(false);
+
+  const handleClick = useCallback(() => {
+    setPending(true);
+    try {
+      const markdown = conversationToMarkdown({
+        title,
+        shareId,
+        sharedAt: new Date(),
+        chats,
+      });
+      const blob = new Blob([markdown], {
+        type: "text/markdown;charset=utf-8",
+      });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      const slug = title ? safeFileSlug(title) : "";
+      const base = slug ? `open-agents-${slug}` : `open-agents-${shareId}`;
+      anchor.download = `${base}.md`;
+      document.body.append(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } finally {
+      setPending(false);
+    }
+  }, [chats, shareId, title]);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      disabled={pending}
+      className="gap-1.5"
+    >
+      <Download className="h-3.5 w-3.5" />
+      Download as Markdown
+    </Button>
+  );
+}

--- a/apps/web/app/shared/[shareId]/shared-chat-content.tsx
+++ b/apps/web/app/shared/[shareId]/shared-chat-content.tsx
@@ -29,6 +29,7 @@ import { Button } from "@/components/ui/button";
 import type { Chat } from "@/lib/db/schema";
 import { streamdownPlugins } from "@/lib/streamdown-config";
 import { cn } from "@/lib/utils";
+import { DownloadMarkdownButton } from "./download-markdown-button";
 import { SharedChatStatus } from "./shared-chat-status";
 import "streamdown/styles.css";
 
@@ -218,30 +219,40 @@ export function SharedChatContent({
               </div>
             </div>
 
-            {/* Right: shared by user */}
-            {sharedBy && (
-              <div className="flex shrink-0 items-center gap-2">
-                <Avatar size="sm">
-                  {sharedBy.avatarUrl && (
-                    <AvatarImage
-                      src={sharedBy.avatarUrl}
-                      alt={sharedBy.name ?? sharedBy.username}
-                    />
-                  )}
-                  <AvatarFallback>
-                    {(sharedBy.name ?? sharedBy.username)
-                      .charAt(0)
-                      .toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                <span className="text-sm text-muted-foreground">
-                  Shared by{" "}
-                  <span className="font-medium text-foreground">
-                    {sharedBy.name ?? sharedBy.username}
+            {/* Right: download + shared by user */}
+            <div className="flex shrink-0 items-center gap-3">
+              <DownloadMarkdownButton
+                chats={chats.map((c) => ({
+                  title: c.chat.title,
+                  messages: c.messagesWithTiming,
+                }))}
+                shareId={shareId}
+                title={session.title}
+              />
+              {sharedBy && (
+                <div className="flex items-center gap-2">
+                  <Avatar size="sm">
+                    {sharedBy.avatarUrl && (
+                      <AvatarImage
+                        src={sharedBy.avatarUrl}
+                        alt={sharedBy.name ?? sharedBy.username}
+                      />
+                    )}
+                    <AvatarFallback>
+                      {(sharedBy.name ?? sharedBy.username)
+                        .charAt(0)
+                        .toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-sm text-muted-foreground">
+                    Shared by{" "}
+                    <span className="font-medium text-foreground">
+                      {sharedBy.name ?? sharedBy.username}
+                    </span>
                   </span>
-                </span>
-              </div>
-            )}
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary

Add a "Download as Markdown" button to the shared chat header. Click it and you get a `.md` file with the full conversation (user turns, agent replies, tool calls, non-text attachments).

No new route, no new storage. The messages are already on the page from `getChatMessages`, so the button serializes them client-side via `Blob` + object URL.

## Why this matters

@nicoalbanese's #515 flags that maintainers want shared conversations to be portable:

> We want reviewers to be able to ask follow-up questions like: Why was this approach chosen? What alternatives were considered? Why did the agent make this particular change?

#515 proposes a CLI `openharness conversation <snapshot-id>` for that. This PR is a small web-facing complement: anyone viewing a shared chat can save the transcript locally without waiting on the CLI direction to land.

## Changes

- `apps/web/app/shared/[shareId]/conversation-to-markdown.ts` (new): pure serializer, typed against `MessageWithTiming`. Walks messages + parts, uses `isToolUIPart` / `isReasoningUIPart` from `ai`, maps roles to headings, fences tool calls as JSON, wraps reasoning in `<details>`, and emits `[attachment: type]` placeholders for non-text data parts.
- `apps/web/app/shared/[shareId]/download-markdown-button.tsx` (new): client component. On click, builds a `Blob({ type: "text/markdown;charset=utf-8" })`, creates an object URL, clicks a hidden `<a>`, revokes the URL.
- `apps/web/app/shared/[shareId]/conversation-to-markdown.test.ts` (new): 8 tests covering title/fallback, user+agent headings, tool-call fencing, `data-*` placeholders, empty-part skip, and single vs multi-chat output.
- `apps/web/app/shared/[shareId]/shared-chat-content.tsx`: renders the button next to the title in the hero header. Passes through `chats`, `shareId`, and `session.title`.

## Output shape

```
# Add retry to handleTimeout

Shared from Open Agents - 2026-04-14T12:00:00.000Z
Share ID: a1b2c3

## User

The API client times out on slow networks. Can you add a retry with backoff to handleTimeout()?

## Agent

Looking at `client.py:handleTimeout()` now.

### Tool call: read (output-available)

```json
input:
{ "path": "client.py" }
output:
{ "lines": 48 }
```

[attachment: commit]

Commit 9f3a7c1 on branch `fix/retry-timeout`. Tests pass.
```

Redaction stays where it already is upstream (`redactSharedEnvContent` runs in `page.tsx` before the messages reach `SharedChatContent`), so the download inherits the same redaction without a second pass.

## Verification

- `bun run ci` passes: `ultracite check`, `turbo typecheck` across all packages, `bun run test:isolated`, and `bun run --cwd apps/web db:check`.
- 8 new unit tests, 0 failures.

## Demo

I don't have the OAuth/GitHub App stack set up locally, so I can't run a real shared page. The reel below shows (1) a markdown file produced by the serializer against a representative message sequence and (2) the button integration in `shared-chat-content.tsx`:

![Demo](https://litter.catbox.moe/e9pe04.gif)

A durable mirror of the same GIF is at https://raw.githubusercontent.com/mvanhorn/open-agents/evidence/markdown-download-demo.gif in case the catbox link expires.

## Out of scope

No session-storage changes. No CLI snapshot system. No new server route. This does not preempt the broader snapshot direction in #515.

Relates to #515.

---

This contribution was developed with AI assistance (Claude Code).
