### PR TITLE
fix: treat blank REDIS_URL and KV_URL as not configured

### DIFF
--- a/apps/web/lib/redis.test.ts
+++ b/apps/web/lib/redis.test.ts
@@ -1,5 +1,26 @@
-import { describe, expect, test } from "bun:test";
-import { getRedisConnectionOptions } from "./redis";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  getRedisConnectionOptions,
+  getRedisUrl,
+  isRedisConfigured,
+} from "./redis";
+
+const originalRedisUrl = process.env.REDIS_URL;
+const originalKvUrl = process.env.KV_URL;
+
+afterEach(() => {
+  if (originalRedisUrl === undefined) {
+    delete process.env.REDIS_URL;
+  } else {
+    process.env.REDIS_URL = originalRedisUrl;
+  }
+
+  if (originalKvUrl === undefined) {
+    delete process.env.KV_URL;
+  } else {
+    process.env.KV_URL = originalKvUrl;
+  }
+});
 
 describe("getRedisConnectionOptions", () => {
   test("parses bare host and port values without requiring a scheme", () => {
@@ -62,5 +83,23 @@ describe("getRedisConnectionOptions", () => {
       db: 3,
       connectionName: "skills-cache",
     });
+  });
+});
+
+describe("redis configuration", () => {
+  test("treats blank environment values as not configured", () => {
+    process.env.REDIS_URL = "";
+    process.env.KV_URL = "   ";
+
+    expect(getRedisUrl()).toBeNull();
+    expect(isRedisConfigured()).toBe(false);
+  });
+
+  test("falls back to KV_URL when REDIS_URL is blank", () => {
+    process.env.REDIS_URL = " ";
+    process.env.KV_URL = "redis://localhost:6379";
+
+    expect(getRedisUrl()).toBe("redis://localhost:6379");
+    expect(isRedisConfigured()).toBe(true);
   });
 });

--- a/apps/web/lib/redis.ts
+++ b/apps/web/lib/redis.ts
@@ -58,7 +58,13 @@ function applyRedisQueryOptions(
 }
 
 export function getRedisUrl(): string | null {
-  return process.env.REDIS_URL ?? process.env.KV_URL ?? null;
+  const redisUrl = process.env.REDIS_URL?.trim();
+  if (redisUrl) return redisUrl;
+
+  const kvUrl = process.env.KV_URL?.trim();
+  if (kvUrl) return kvUrl;
+
+  return null;
 }
 
 export function getRedisConnectionOptions(url: string): RedisConnectionOptions {


### PR DESCRIPTION
## Summary

Fixes a startup error that occurs when `REDIS_URL` (or `KV_URL`) is present in `.env.local` but left blank — a common situation when copying an env template and only filling in what's required.

The previous implementation used `??` (nullish coalescing), which only skips `null` or `undefined`. A blank string like `REDIS_URL=` passes through, preventing fallback to `KV_URL` and ultimately causing `createRedisClient` to throw:

```
Error: REDIS_URL or KV_URL environment variable is required
```

`getRedisUrl()` now trims each candidate and skips it if empty, so a blank `REDIS_URL` correctly falls back to `KV_URL`.

## Changes

**`apps/web/lib/redis.ts`**
- `getRedisUrl()`: skip blank/whitespace-only env values instead of returning them

**`apps/web/lib/redis.test.ts`**
- Added tests covering blank env values and fallback behavior
- Added `afterEach` to restore env vars between tests