### PR TITLE
feat: optimize repo selector pagination with early stopping

### DIFF
--- a/apps/web/components/repo-selector-compact.tsx
+++ b/apps/web/components/repo-selector-compact.tsx
@@ -195,7 +195,7 @@ export function RepoSelectorCompact({
   } = useInstallationRepos({
     installationId: currentInstallation?.installationId ?? null,
     query: debouncedRepoSearch,
-    limit: 50,
+    limit: 25,
   });
 
   // Sort repos: by updated_at desc if available, otherwise alphabetical
@@ -512,7 +512,7 @@ export function RepoSelectorCompact({
           </div>
         ) : (
           <div className="divide-y divide-border/50 dark:divide-white/[0.06]">
-            {sortedRepos.slice(0, 50).map((repo) => (
+            {sortedRepos.slice(0, 25).map((repo) => (
               <div
                 key={repo.full_name}
                 className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent/30 dark:hover:bg-white/[0.03]"
@@ -539,9 +539,9 @@ export function RepoSelectorCompact({
                 </button>
               </div>
             ))}
-            {sortedRepos.length === 50 && !debouncedRepoSearch && (
+            {sortedRepos.length === 25 && !debouncedRepoSearch && (
               <div className="px-4 py-2.5 text-center text-xs text-muted-foreground">
-                Showing first 50 results. Use search to narrow.
+                Showing first 25 results. Use search to narrow.
               </div>
             )}
           </div>

--- a/apps/web/components/repo-selector.tsx
+++ b/apps/web/components/repo-selector.tsx
@@ -95,7 +95,7 @@ export function RepoSelector({
   } = useInstallationRepos({
     installationId: selectedInstallation?.installationId ?? null,
     query: debouncedRepoSearch,
-    limit: 50,
+    limit: 25,
   });
 
   useEffect(() => {
@@ -322,7 +322,7 @@ export function RepoSelector({
                     : "No repositories found."}
               </CommandEmpty>
               <CommandGroup>
-                {repos.slice(0, 50).map((repo) => (
+                {repos.slice(0, 25).map((repo) => (
                   <CommandItem
                     key={repo.full_name}
                     value={repo.name}
@@ -342,9 +342,9 @@ export function RepoSelector({
                     )}
                   </CommandItem>
                 ))}
-                {repos.length === 50 && !debouncedRepoSearch && (
+                {repos.length === 25 && !debouncedRepoSearch && (
                   <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                    Showing first 50 results. Use search to narrow.
+                    Showing first 25 results. Use search to narrow.
                   </div>
                 )}
               </CommandGroup>

--- a/apps/web/lib/github/installation-repos.test.ts
+++ b/apps/web/lib/github/installation-repos.test.ts
@@ -25,7 +25,7 @@ function createPage(
 ) {
   return [
     ...repositories,
-    ...Array.from({ length: 100 - repositories.length }, (_, index) =>
+    ...Array.from({ length: 25 - repositories.length }, (_, index) =>
       createRepository(
         `filler-${page}-${index}`,
         `2023-01-${`${(index % 28) + 1}`.padStart(2, "0")}T00:00:00Z`,
@@ -47,6 +47,8 @@ describe("installation-repos", () => {
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = new URL(input.toString());
       const page = url.searchParams.get("page");
+
+      expect(url.searchParams.get("per_page")).toBe("25");
 
       if (page === "1") {
         return Response.json({
@@ -83,6 +85,8 @@ describe("installation-repos", () => {
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = new URL(input.toString());
       const page = url.searchParams.get("page");
+
+      expect(url.searchParams.get("per_page")).toBe("25");
 
       if (page === "1") {
         return Response.json({

--- a/apps/web/lib/github/installation-repos.test.ts
+++ b/apps/web/lib/github/installation-repos.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { listUserInstallationRepositories } from "./installation-repos";
+
+const originalFetch = globalThis.fetch;
+
+function createRepository(name: string, updatedAt: string) {
+  return {
+    name,
+    full_name: `acme/${name}`,
+    description: null,
+    private: false,
+    clone_url: `https://github.com/acme/${name}.git`,
+    updated_at: updatedAt,
+    language: null,
+    owner: {
+      login: "acme",
+    },
+  };
+}
+
+function createPage(
+  repositories: ReturnType<typeof createRepository>[],
+  page: number,
+) {
+  return [
+    ...repositories,
+    ...Array.from({ length: 100 - repositories.length }, (_, index) =>
+      createRepository(
+        `filler-${page}-${index}`,
+        `2023-01-${`${(index % 28) + 1}`.padStart(2, "0")}T00:00:00Z`,
+      ),
+    ),
+  ];
+}
+
+describe("installation-repos", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("stops paging once it has enough matches to satisfy the limit", async () => {
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = new URL(input.toString());
+      const page = url.searchParams.get("page");
+
+      if (page === "1") {
+        return Response.json({
+          repositories: createPage(
+            [
+              createRepository("zeta", "2024-01-01T00:00:00Z"),
+              createRepository("alpha", "2024-03-01T00:00:00Z"),
+              createRepository("beta", "2024-02-01T00:00:00Z"),
+            ],
+            1,
+          ),
+        });
+      }
+
+      return Response.json({
+        repositories: [createRepository("omega", "2024-04-01T00:00:00Z")],
+      });
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const repos = await listUserInstallationRepositories({
+      installationId: 123,
+      userToken: "token",
+      owner: "acme",
+      limit: 2,
+    });
+
+    expect(repos.map((repo) => repo.name)).toEqual(["alpha", "beta"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("continues paging until a query has enough matches", async () => {
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = new URL(input.toString());
+      const page = url.searchParams.get("page");
+
+      if (page === "1") {
+        return Response.json({
+          repositories: createPage(
+            [
+              createRepository("docs", "2024-01-01T00:00:00Z"),
+              createRepository("frontend", "2024-02-01T00:00:00Z"),
+            ],
+            1,
+          ),
+        });
+      }
+
+      if (page === "2") {
+        return Response.json({
+          repositories: createPage(
+            [
+              createRepository("docs-site", "2024-03-01T00:00:00Z"),
+              createRepository("infra", "2024-04-01T00:00:00Z"),
+            ],
+            2,
+          ),
+        });
+      }
+
+      return Response.json({
+        repositories: [createRepository("docs-api", "2024-05-01T00:00:00Z")],
+      });
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const repos = await listUserInstallationRepositories({
+      installationId: 123,
+      userToken: "token",
+      owner: "acme",
+      query: "docs",
+      limit: 2,
+    });
+
+    expect(repos.map((repo) => repo.name)).toEqual(["docs-site", "docs"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/github/installation-repos.ts
+++ b/apps/web/lib/github/installation-repos.ts
@@ -81,7 +81,7 @@ export async function listUserInstallationRepositories({
   const queryFilter = query?.trim().toLowerCase();
   const normalizedLimit = normalizeLimit(limit);
 
-  const perPage = 100;
+  const perPage = 25;
   const maxPages = INSTALLATION_REPOS_MAX_PAGES;
   const matchedRepos: z.infer<typeof installationRepoSchema>[] = [];
 

--- a/apps/web/lib/github/installation-repos.ts
+++ b/apps/web/lib/github/installation-repos.ts
@@ -130,6 +130,10 @@ export async function listUserInstallationRepositories({
 
     matchedRepos.push(...pageMatches);
 
+    if (matchedRepos.length >= normalizedLimit) {
+      break;
+    }
+
     if (parsed.data.repositories.length < perPage) {
       break;
     }


### PR DESCRIPTION
## Summary

This PR optimizes the repository selector fetch logic by reducing page sizes to 25, implementing early pagination stopping when the repo limit is reached, and adding comprehensive tests for the installation repos functionality.

## Changes

**Components (`apps/web/components/repo-selector.tsx`)**

- Reduce result limit to 25 repositories

**Components (`apps/web/components/repo-selector-compact.tsx`)**

- Reduce result limit to 25 repositories

**Logic (`apps/web/lib/github/installation-repos.ts`)**

- Reduce installation repos page size to 25
- Implement early pagination stopping when repo limit is reached

**Tests (`apps/web/lib/github/installation-repos.test.ts`)**

- Add comprehensive test suite for installation repos pagination logic
- Test early pagination stopping behavior

---

[Chat](https://open-agents.dev/sessions/Q5F7q8c6NjdgSGRWoUjJl/chats/SW-lmBhvBfNsrcZR23ypj) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)