### PR TITLE
feat: add session unarchive button to sidebar

### DIFF
--- a/apps/web/app/sessions/sessions-route-shell.tsx
+++ b/apps/web/app/sessions/sessions-route-shell.tsx
@@ -72,6 +72,7 @@ export function SessionsRouteShell({
     createSession,
     renameSession,
     archiveSession,
+    unarchiveSession,
   } = useSessions({
     enabled: true,
     includeArchived: false,
@@ -166,6 +167,17 @@ export function SessionsRouteShell({
     [archiveSession, routeSessionId, router, startNavigationTransition],
   );
 
+  const handleUnarchiveSession = useCallback(
+    async (targetSessionId: string) => {
+      await unarchiveSession(targetSessionId);
+
+      if (targetSessionId === routeSessionId) {
+        window.location.reload();
+      }
+    },
+    [routeSessionId, unarchiveSession],
+  );
+
   const handleCreateSessionForRepo = useCallback(
     async (repoOwner: string, repoName: string) => {
       try {
@@ -257,6 +269,7 @@ export function SessionsRouteShell({
               onSessionPrefetch={handleSessionPrefetch}
               onRenameSession={handleRenameSession}
               onArchiveSession={handleArchiveSession}
+              onUnarchiveSession={handleUnarchiveSession}
               onOpenNewSession={openNewSessionDialog}
               onCreateSessionForRepo={handleCreateSessionForRepo}
               onCreateSessionFromBranch={handleCreateSessionFromBranch}

--- a/apps/web/components/inbox-sidebar.tsx
+++ b/apps/web/components/inbox-sidebar.tsx
@@ -59,6 +59,7 @@ type InboxSidebarProps = {
   onSessionPrefetch: (session: SessionWithUnread) => void;
   onRenameSession?: (sessionId: string, title: string) => Promise<void>;
   onArchiveSession: (sessionId: string) => Promise<void>;
+  onUnarchiveSession: (sessionId: string) => Promise<void>;
   onOpenNewSession: () => void;
   onCreateSessionForRepo: (repoOwner: string, repoName: string) => void;
   onCreateSessionFromBranch: (
@@ -345,6 +346,7 @@ type SessionRowProps = {
   onSessionPrefetch: (session: SessionWithUnread) => void;
   onRenameSession?: (sessionId: string, title: string) => Promise<void>;
   onArchiveSession: (session: SessionWithUnread) => void;
+  onUnarchiveSession: (session: SessionWithUnread) => void;
 };
 
 const SessionRow = memo(function SessionRow({
@@ -355,6 +357,7 @@ const SessionRow = memo(function SessionRow({
   onSessionPrefetch,
   onRenameSession,
   onArchiveSession,
+  onUnarchiveSession,
 }: SessionRowProps) {
   const isMobile = useIsMobile();
   const [isHovered, setIsHovered] = useState(false);
@@ -382,8 +385,7 @@ const SessionRow = memo(function SessionRow({
   }, [isRenaming]);
 
   const hasDiff = session.linesAdded !== null || session.linesRemoved !== null;
-  const showActionButtons =
-    isHovered && (Boolean(onRenameSession) || session.status !== "archived");
+  const showActionButtons = isHovered;
 
   const handleMouseEnter = useCallback(() => {
     if (leaveTimeoutRef.current) {
@@ -545,26 +547,34 @@ const SessionRow = memo(function SessionRow({
                 </TooltipContent>
               </Tooltip>
             ) : null}
-            {session.status !== "archived" ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-                    aria-label="Archive session"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onArchiveSession(session);
-                    }}
-                  >
-                    <Archive className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top" sideOffset={4}>
-                  Archive session
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+                  aria-label={
+                    session.status === "archived"
+                      ? "Unarchive session"
+                      : "Archive session"
+                  }
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    if (session.status === "archived") {
+                      onUnarchiveSession(session);
+                      return;
+                    }
+                    onArchiveSession(session);
+                  }}
+                >
+                  <Archive className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                {session.status === "archived"
+                  ? "Unarchive session"
+                  : "Archive session"}
+              </TooltipContent>
+            </Tooltip>
           </>
         ) : hasDiff ? (
           <DiffStats
@@ -637,6 +647,7 @@ export function InboxSidebar({
   onSessionPrefetch,
   onRenameSession,
   onArchiveSession,
+  onUnarchiveSession,
   onOpenNewSession,
   onCreateSessionForRepo,
   onCreateSessionFromBranch,
@@ -841,6 +852,22 @@ export function InboxSidebar({
       console.error("Failed to archive session:", err);
     }
   }, [archiveConfirmSession, archivedCount, onArchiveSession]);
+
+  const handleUnarchiveSession = useCallback(
+    async (session: SessionWithUnread) => {
+      try {
+        await onUnarchiveSession(session.id);
+        setArchivedSessions((current) =>
+          current.filter(
+            (existingSession) => existingSession.id !== session.id,
+          ),
+        );
+      } catch (err) {
+        console.error("Failed to unarchive session:", err);
+      }
+    },
+    [onUnarchiveSession],
+  );
 
   const handleLoadMoreArchivedSessions = useCallback(() => {
     if (archivedSessionsLoading) {
@@ -1094,6 +1121,7 @@ export function InboxSidebar({
                               onSessionPrefetch={handleSessionPrefetch}
                               onRenameSession={onRenameSession}
                               onArchiveSession={handleArchiveSession}
+                              onUnarchiveSession={handleUnarchiveSession}
                             />
                           ))}
                         </div>

--- a/apps/web/hooks/use-sessions.ts
+++ b/apps/web/hooks/use-sessions.ts
@@ -370,6 +370,90 @@ export function useSessions(options?: {
     [data, includeArchived, mutate],
   );
 
+  const unarchiveSession = useCallback(
+    async (sessionId: string) => {
+      const previousData = cloneSessionsResponse(data);
+      const nextArchivedCount = Math.max(
+        (previousData?.archivedCount ?? 0) - 1,
+        0,
+      );
+
+      await mutate(
+        (current) => {
+          const source = current ?? previousData;
+          if (!source) {
+            return source;
+          }
+
+          return {
+            ...source,
+            archivedCount: nextArchivedCount,
+            sessions: includeArchived
+              ? source.sessions.map((session) =>
+                  session.id === sessionId
+                    ? { ...session, status: "running" }
+                    : session,
+                )
+              : source.sessions,
+          };
+        },
+        { revalidate: false },
+      );
+
+      try {
+        const res = await fetch(`/api/sessions/${sessionId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "running" }),
+        });
+
+        const responseData = (await res.json()) as {
+          session?: Session;
+          error?: string;
+        };
+
+        if (!res.ok || !responseData.session) {
+          throw new Error(responseData.error ?? "Failed to unarchive session");
+        }
+
+        const updatedSession = responseData.session;
+
+        if (includeArchived) {
+          await mutate(
+            (current) => {
+              if (!current) {
+                return current;
+              }
+
+              return {
+                ...current,
+                sessions: current.sessions.map((session) =>
+                  session.id === sessionId
+                    ? mergeSessionWithSummary(session, updatedSession)
+                    : session,
+                ),
+              };
+            },
+            { revalidate: false },
+          );
+        } else {
+          await mutate();
+        }
+
+        return responseData.session;
+      } catch (error) {
+        if (previousData) {
+          await mutate(previousData, { revalidate: false });
+        } else {
+          void mutate();
+        }
+
+        throw error;
+      }
+    },
+    [data, includeArchived, mutate],
+  );
+
   return {
     sessions,
     archivedCount,
@@ -378,6 +462,7 @@ export function useSessions(options?: {
     createSession,
     renameSession,
     archiveSession,
+    unarchiveSession,
     refreshSessions: mutate,
   };
 }


### PR DESCRIPTION
## Summary

This PR adds session unarchive functionality to the sidebar, allowing users to restore archived sessions directly from the inbox sidebar with a new unarchive button.

## Changes

**Hooks (`apps/web/hooks/use-sessions.ts`)**

- Add new `use-sessions` hook with unarchive session functionality
- Implements session state management and API integration for unarchiving

**Components (`apps/web/components/inbox-sidebar.tsx`)**

- Add unarchive button to archived sessions in the sidebar
- Update sidebar UI to display unarchive action for archived session items
- Improve archived session display and interaction handling

**Routes (`apps/web/app/sessions/sessions-route-shell.tsx`)**

- Integrate session unarchive hook into route shell
- Set up necessary props and handlers for unarchive button functionality

---

[Chat](https://open-agents.dev/sessions/68WZm9s5o1rOYNcQOt5NU/chats/nhrmTkJl422ogC9zE7gXB) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)