### PR TITLE
feat: bypass managed template trial limits for Vercel team members

### DIFF
--- a/apps/web/app/api/auth/vercel/callback/route.test.ts
+++ b/apps/web/app/api/auth/vercel/callback/route.test.ts
@@ -37,9 +37,15 @@ mock.module("next/headers", () => ({
   }),
 }));
 
+const hasAccessToVercelTeamSlugMock = mock(async () => false);
+
 mock.module("@/lib/vercel/oauth", () => ({
   exchangeVercelCode: exchangeVercelCodeMock,
   getVercelUserInfo: getVercelUserInfoMock,
+}));
+
+mock.module("@/lib/vercel/projects", () => ({
+  hasAccessToVercelTeamSlug: hasAccessToVercelTeamSlugMock,
 }));
 
 mock.module("@/lib/db/users", () => ({
@@ -85,6 +91,7 @@ beforeEach(() => {
 
   exchangeVercelCodeMock.mockClear();
   getVercelUserInfoMock.mockClear();
+  hasAccessToVercelTeamSlugMock.mockClear();
   upsertUserMock.mockClear();
   encryptMock.mockClear();
   encryptJWEMock.mockClear();
@@ -151,6 +158,34 @@ describe("GET /api/auth/vercel/callback", () => {
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("/sessions");
     expect(upsertUserMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("includes isAllowedTeamMember in the encrypted session", async () => {
+    hasAccessToVercelTeamSlugMock.mockResolvedValueOnce(true);
+
+    const { GET } = await routeModulePromise;
+    await GET(createRequest());
+
+    expect(hasAccessToVercelTeamSlugMock).toHaveBeenCalledWith(
+      "access-token",
+      "vercel",
+    );
+    const sessionArg = (
+      encryptJWEMock.mock.calls as unknown as [Record<string, unknown>][]
+    )[0][0];
+    expect(sessionArg.isAllowedTeamMember).toBe(true);
+  });
+
+  test("sets isAllowedTeamMember to false for non-team users", async () => {
+    hasAccessToVercelTeamSlugMock.mockResolvedValueOnce(false);
+
+    const { GET } = await routeModulePromise;
+    await GET(createRequest());
+
+    const sessionArg = (
+      encryptJWEMock.mock.calls as unknown as [Record<string, unknown>][]
+    )[0][0];
+    expect(sessionArg.isAllowedTeamMember).toBe(false);
   });
 
   test("allows non-Vercel emails on self-hosted deployments", async () => {

--- a/apps/web/app/api/auth/vercel/callback/route.ts
+++ b/apps/web/app/api/auth/vercel/callback/route.ts
@@ -4,7 +4,9 @@ import { encrypt } from "@/lib/crypto";
 import { upsertUser } from "@/lib/db/users";
 import { encryptJWE } from "@/lib/jwe/encrypt";
 import { SESSION_COOKIE_NAME } from "@/lib/session/constants";
+import { ALLOWED_VERCEL_TEAM_SLUG } from "@/lib/managed-template-trial";
 import { exchangeVercelCode, getVercelUserInfo } from "@/lib/vercel/oauth";
+import { hasAccessToVercelTeamSlug } from "@/lib/vercel/projects";
 
 function clearVercelOauthCookies(store: Awaited<ReturnType<typeof cookies>>) {
   store.delete("vercel_auth_state");
@@ -49,7 +51,10 @@ export async function GET(req: NextRequest): Promise<Response> {
       redirectUri,
     });
 
-    const userInfo = await getVercelUserInfo(tokens.access_token);
+    const [userInfo, isAllowedTeamMember] = await Promise.all([
+      getVercelUserInfo(tokens.access_token),
+      hasAccessToVercelTeamSlug(tokens.access_token, ALLOWED_VERCEL_TEAM_SLUG),
+    ]);
 
     const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
@@ -74,6 +79,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     const session = {
       created: Date.now(),
       authProvider: "vercel" as const,
+      isAllowedTeamMember,
       user: {
         id: userId,
         username,

--- a/apps/web/app/api/sessions/route.test.ts
+++ b/apps/web/app/api/sessions/route.test.ts
@@ -3,6 +3,7 @@ import type { VercelProjectSelection } from "@/lib/vercel/types";
 
 let currentSession: {
   authProvider?: "vercel" | "github";
+  isAllowedTeamMember?: boolean;
   user: {
     id: string;
     username: string;
@@ -145,6 +146,37 @@ describe("/api/sessions POST vercel project linking", () => {
       "This hosted deployment includes 1 trial session for non-Vercel accounts. Deploy your own copy to start more.",
     );
     expect(createCalls).toHaveLength(0);
+  });
+
+  test("allows additional sessions for Vercel team members on the managed deployment", async () => {
+    const { POST } = await routeModulePromise;
+
+    currentSession = {
+      authProvider: "vercel",
+      user: {
+        id: "user-1",
+        username: "nico",
+        name: "Nico",
+        email: "person@example.com",
+      },
+      isAllowedTeamMember: true,
+    };
+    existingSessionCount = 5;
+
+    const response = await POST(
+      createJsonRequest(
+        {
+          branch: "main",
+          cloneUrl: "https://github.com/vercel/open-harness",
+          repoOwner: "vercel",
+          repoName: "open-harness",
+        },
+        "https://open-agents.dev/api/sessions",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createCalls).toHaveLength(1);
   });
 
   test("explicit Vercel project is validated against live repo matches before it is persisted", async () => {

--- a/apps/web/lib/managed-template-trial.ts
+++ b/apps/web/lib/managed-template-trial.ts
@@ -1,6 +1,7 @@
 import type { Session } from "@/lib/session/types";
 
 const ALLOWED_VERCEL_EMAIL_DOMAIN = "vercel.com";
+export const ALLOWED_VERCEL_TEAM_SLUG = "vercel";
 const MANAGED_TEMPLATE_HOSTS = new Set([
   "open-agents.dev",
   "www.open-agents.dev",
@@ -60,12 +61,16 @@ export function hasAllowedManagedTemplateEmail(email?: string) {
 }
 
 export function isManagedTemplateTrialUser(
-  session: Pick<Session, "authProvider" | "user"> | null | undefined,
+  session:
+    | Pick<Session, "authProvider" | "user" | "isAllowedTeamMember">
+    | null
+    | undefined,
   url: string | URL,
 ) {
   return (
     session?.authProvider === "vercel" &&
     isManagedTemplateDeployment(url) &&
+    !session.isAllowedTeamMember &&
     !hasAllowedManagedTemplateEmail(session.user.email)
   );
 }

--- a/apps/web/lib/session/server.ts
+++ b/apps/web/lib/session/server.ts
@@ -12,6 +12,7 @@ export async function getSessionFromCookie(
       return {
         created: decrypted.created,
         authProvider: decrypted.authProvider,
+        isAllowedTeamMember: decrypted.isAllowedTeamMember,
         user: decrypted.user,
       };
     }

--- a/apps/web/lib/session/types.ts
+++ b/apps/web/lib/session/types.ts
@@ -1,6 +1,7 @@
 export interface Session {
   created: number;
   authProvider: "vercel" | "github";
+  isAllowedTeamMember?: boolean;
   user: {
     id: string;
     username: string;

--- a/apps/web/lib/vercel/projects.ts
+++ b/apps/web/lib/vercel/projects.ts
@@ -158,6 +158,19 @@ async function listAccessibleVercelTeams(
     }));
 }
 
+export async function hasAccessToVercelTeamSlug(
+  token: string,
+  slug: string,
+): Promise<boolean> {
+  try {
+    const teams = await listAccessibleVercelTeams(token);
+    return teams.some((team) => team.teamSlug === slug);
+  } catch (error) {
+    console.error("[hasAccessToVercelTeamSlug] failed:", error);
+    return false;
+  }
+}
+
 async function listProjectsForScope(params: {
   token: string;
   repoUrl: string;


### PR DESCRIPTION
## Summary

Grants Vercel team members unlimited access on the managed deployment (open-agents.dev) by detecting team membership at login and bypassing trial limits. Team membership is checked once during OAuth via the Vercel API and persisted in the session token — no per-request overhead.

## Changes

**Session (`apps/web/lib/session/types.ts`, `apps/web/lib/session/server.ts`)**

- Add `isAllowedTeamMember` boolean to the `Session` interface
- Pass through the new field when decrypting the session from the cookie

**Auth Callback (`apps/web/app/api/auth/vercel/callback/route.ts`)**

- Check Vercel team membership in parallel with user info fetch during OAuth callback
- Store `isAllowedTeamMember` in the encrypted session token

**Trial Logic (`apps/web/lib/managed-template-trial.ts`)**

- Export `ALLOWED_VERCEL_TEAM_SLUG` constant
- Exclude allowed team members from `isManagedTemplateTrialUser` — bypasses session, message, and deletion limits

**Vercel API (`apps/web/lib/vercel/projects.ts`)**

- Add `hasAccessToVercelTeamSlug` helper that checks team list for a matching slug (fails closed on error)

**Tests (`apps/web/app/api/auth/vercel/callback/route.test.ts`, `apps/web/app/api/sessions/route.test.ts`)**

- Verify `isAllowedTeamMember` is set correctly for team and non-team users
- Verify team members can create sessions beyond the trial limit on the managed deployment