### PR TITLE
refactor: remove metadata from home page

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,14 +1,8 @@
-import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { SESSION_COOKIE_NAME } from "@/lib/session/constants";
 import { getServerSession } from "@/lib/session/get-server-session";
 import { HomePage } from "./home-page";
-
-export const metadata: Metadata = {
-  title: "Dashboard",
-  description: "Review recent runs and start new sessions in Open Agents.",
-};
 
 export default async function Home() {
   const session = await getServerSession();


### PR DESCRIPTION
## Summary

Removes metadata configuration from the home page to resolve issues with landing page meta tags. This streamlines the page configuration.

## Changes

**Pages (`apps/web/app/page.tsx`)**

- Remove metadata export from home page (6 lines deleted)

---

[Chat](https://open-agents.dev/sessions/s8AVvD7pfiWP1sLa5o44-/chats/S7H2SlwnDf9mndN3hZ0rH) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)