### PR TITLE
feat: restrict code editor access for managed-template trial users

### DIFF
--- a/apps/web/app/api/sessions/[sessionId]/code-editor/route.test.ts
+++ b/apps/web/app/api/sessions/[sessionId]/code-editor/route.test.ts
@@ -18,6 +18,13 @@ let processListOutput = "";
 let portProbeStatusCode: string | null = null;
 let lastLaunchCommand: string | null = null;
 let lastLaunchCwd: string | null = null;
+let currentAuthSession: {
+  authProvider?: "vercel" | "github";
+  user: {
+    id: string;
+    email?: string;
+  };
+} | null = null;
 
 function successResult(stdout = "") {
   return {
@@ -126,6 +133,10 @@ mock.module("@open-harness/sandbox", () => ({
   connectSandbox: connectSandboxMock,
 }));
 
+mock.module("@/lib/session/get-server-session", () => ({
+  getServerSession: async () => currentAuthSession,
+}));
+
 const routeModulePromise = import("./route");
 
 function createRouteContext(sessionId = "session-1") {
@@ -142,6 +153,7 @@ describe("/api/sessions/[sessionId]/code-editor", () => {
     portProbeStatusCode = null;
     lastLaunchCommand = null;
     lastLaunchCwd = null;
+    currentAuthSession = null;
     currentSessionRecord.sandboxState.expiresAt = Date.now() + 60_000;
     requireAuthenticatedUserMock.mockClear();
     requireOwnedSessionWithSandboxGuardMock.mockClear();
@@ -219,6 +231,35 @@ describe("/api/sessions/[sessionId]/code-editor", () => {
       url: "https://sb-8000.vercel.run",
       port: 8000,
     });
+    expect(execDetachedMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("POST returns 403 for managed-template trial users", async () => {
+    currentAuthSession = {
+      authProvider: "vercel",
+      user: {
+        id: "user-1",
+        email: "person@example.com",
+      },
+    };
+    const { POST } = await routeModulePromise;
+    const expectedError =
+      "This hosted deployment does not allow the code editor for non-Vercel trial accounts. Deploy your own copy for full controls.";
+
+    const response = await POST(
+      new Request(
+        "https://open-agents.dev/api/sessions/session-1/code-editor",
+        {
+          method: "POST",
+        },
+      ),
+      createRouteContext(),
+    );
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe(expectedError);
+    expect(connectSandboxMock).toHaveBeenCalledTimes(0);
     expect(execDetachedMock).toHaveBeenCalledTimes(0);
   });
 

--- a/apps/web/app/api/sessions/[sessionId]/code-editor/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/code-editor/route.ts
@@ -3,7 +3,12 @@ import {
   requireAuthenticatedUser,
   requireOwnedSessionWithSandboxGuard,
 } from "@/app/api/sessions/_lib/session-context";
+import {
+  isManagedTemplateTrialUser,
+  MANAGED_TEMPLATE_TRIAL_CODE_EDITOR_ERROR,
+} from "@/lib/managed-template-trial";
 import { CODE_SERVER_PORT, DEFAULT_SANDBOX_PORTS } from "@/lib/sandbox/config";
+import { getServerSession } from "@/lib/session/get-server-session";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 
 type RouteContext = {
@@ -232,10 +237,18 @@ export async function GET(_req: Request, context: RouteContext) {
   }
 }
 
-export async function POST(_req: Request, context: RouteContext) {
+export async function POST(req: Request, context: RouteContext) {
   const authResult = await requireAuthenticatedUser();
   if (!authResult.ok) {
     return authResult.response;
+  }
+
+  const session = await getServerSession();
+  if (isManagedTemplateTrialUser(session, req.url)) {
+    return Response.json(
+      { error: MANAGED_TEMPLATE_TRIAL_CODE_EDITOR_ERROR },
+      { status: 403 },
+    );
   }
 
   const { sessionId } = await context.params;

--- a/apps/web/app/codespace/[sessionId]/layout.tsx
+++ b/apps/web/app/codespace/[sessionId]/layout.tsx
@@ -1,6 +1,8 @@
+import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { getSessionByIdCached } from "@/lib/db/sessions-cache";
+import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
 import { getServerSession } from "@/lib/session/get-server-session";
 import { CodespaceProvider } from "./codespace-context";
 
@@ -30,6 +32,11 @@ export default async function CodespaceLayout({
 
   if (sessionRecord.userId !== session.user.id) {
     redirect("/");
+  }
+
+  const requestHost = (await headers()).get("host") ?? "";
+  if (isManagedTemplateTrialUser(session, requestHost)) {
+    redirect(`/sessions/${sessionId}`);
   }
 
   return (

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/page.tsx
@@ -20,6 +20,10 @@ import {
   sanitizeSelectedModelIdForSession,
   sanitizeUserPreferencesForSession,
 } from "@/lib/model-access";
+import {
+  isManagedTemplateTrialUser,
+  MANAGED_TEMPLATE_TRIAL_CODE_EDITOR_ERROR,
+} from "@/lib/managed-template-trial";
 import { getAllVariants } from "@/lib/model-variants";
 import { fetchAvailableLanguageModelsWithContext } from "@/lib/models-with-context";
 import { getServerSession } from "@/lib/session/get-server-session";
@@ -158,6 +162,12 @@ export default async function SessionChatPage({
   const lastUserMessageSentAt = lastUserMessage
     ? lastUserMessage.createdAt.toISOString()
     : null;
+  const codeEditorDisabledReason = isManagedTemplateTrialUser(
+    session,
+    requestHost,
+  )
+    ? MANAGED_TEMPLATE_TRIAL_CODE_EDITOR_ERROR
+    : null;
   const preferences = sanitizeUserPreferencesForSession(
     rawPreferences,
     session,
@@ -203,6 +213,7 @@ export default async function SessionChatPage({
           messageDurationMap={messageDurationMap}
           messageStartedAtMap={messageStartedAtMap}
           lastUserMessageSentAt={lastUserMessageSentAt}
+          codeEditorDisabledReason={codeEditorDisabledReason}
         />
       </SessionChatProvider>
     </DiffsProvider>

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -1005,6 +1005,7 @@ export function SessionChatContent({
   messageDurationMap,
   messageStartedAtMap,
   lastUserMessageSentAt,
+  codeEditorDisabledReason,
 }: {
   initialIsOnlyChatInSession: boolean;
   /** Pre-computed generation duration (ms) per assistant message ID */
@@ -1013,6 +1014,7 @@ export function SessionChatContent({
   messageStartedAtMap: Record<string, string>;
   /** Fallback: last user message's createdAt, for refresh-during-stream */
   lastUserMessageSentAt: string | null;
+  codeEditorDisabledReason: string | null;
 }) {
   const router = useRouter();
   const [input, setInput] = useState("");
@@ -2773,13 +2775,14 @@ export function SessionChatContent({
     !isRestoringSnapshot &&
     !isReconnectingSandbox &&
     !isHibernatingUi;
+  const canUseCodeEditor = codeEditorDisabledReason === null;
   const devServer = useDevServer({
     sessionId: session.id,
     canRun: canRunDevServer,
   });
   const codeEditor = useCodeEditor({
     sessionId: session.id,
-    canRun: canRunDevServer,
+    canRun: canRunDevServer && canUseCodeEditor,
   });
 
   const hasRepo = Boolean(session.cloneUrl);
@@ -3068,6 +3071,7 @@ export function SessionChatContent({
                       className="hidden h-7 w-7 sm:inline-flex"
                       onClick={() => void codeEditor.handleOpen()}
                       disabled={
+                        !canUseCodeEditor ||
                         codeEditor.state.status === "starting" ||
                         codeEditor.state.status === "stopping"
                       }
@@ -3080,7 +3084,7 @@ export function SessionChatContent({
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
-                    {codeEditor.menuLabel}
+                    {codeEditorDisabledReason ?? codeEditor.menuLabel}
                   </TooltipContent>
                 </Tooltip>
                 <div className="hidden h-7 items-center sm:flex">
@@ -4397,6 +4401,7 @@ export function SessionChatContent({
           codeEditor.state.status === "starting" ||
           codeEditor.state.status === "stopping"
         }
+        editorDisabledReason={codeEditorDisabledReason}
         onOpenInEditor={(filePath) => {
           void codeEditor.handleOpenFile(filePath);
         }}

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -2784,6 +2784,10 @@ export function SessionChatContent({
     sessionId: session.id,
     canRun: canRunDevServer && canUseCodeEditor,
   });
+  const isCodeEditorActionDisabled =
+    !canUseCodeEditor ||
+    codeEditor.state.status === "starting" ||
+    codeEditor.state.status === "stopping";
 
   const hasRepo = Boolean(session.cloneUrl);
   const hasExistingPr = session.prNumber != null;
@@ -3065,25 +3069,26 @@ export function SessionChatContent({
               <>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="hidden h-7 w-7 sm:inline-flex"
-                      onClick={() => void codeEditor.handleOpen()}
-                      disabled={
-                        !canUseCodeEditor ||
-                        codeEditor.state.status === "starting" ||
-                        codeEditor.state.status === "stopping"
-                      }
-                    >
-                      {codeEditor.state.status === "starting" ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <Code2 className="h-3.5 w-3.5" />
-                      )}
-                    </Button>
+                    <span className="hidden sm:inline-flex">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        onClick={() => void codeEditor.handleOpen()}
+                        disabled={isCodeEditorActionDisabled}
+                      >
+                        {codeEditor.state.status === "starting" ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Code2 className="h-3.5 w-3.5" />
+                        )}
+                      </Button>
+                    </span>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">
+                  <TooltipContent
+                    side="bottom"
+                    className="max-w-72 text-pretty"
+                  >
                     {codeEditorDisabledReason ?? codeEditor.menuLabel}
                   </TooltipContent>
                 </Tooltip>

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/workspace-file-viewer.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/workspace-file-viewer.tsx
@@ -26,6 +26,7 @@ import { cn } from "@/lib/utils";
 
 type WorkspaceFileViewerProps = {
   editorBusy?: boolean;
+  editorDisabledReason?: string | null;
   filePath: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -95,6 +96,7 @@ function CopyButton({
 
 function ViewerBody({
   editorBusy,
+  editorDisabledReason,
   errorMessage,
   filePath,
   isLoading,
@@ -105,6 +107,7 @@ function ViewerBody({
   response,
 }: {
   editorBusy?: boolean;
+  editorDisabledReason?: string | null;
   errorMessage: string | null;
   filePath: string;
   isLoading: boolean;
@@ -119,6 +122,9 @@ function ViewerBody({
     ? { ...defaultFileOptions, overflow: "wrap" as const }
     : defaultFileOptions;
   const contentRef = useRef<HTMLDivElement>(null);
+  const openInEditorTitle = editorBusy
+    ? "Starting editor…"
+    : (editorDisabledReason ?? "Open in code editor");
 
   return (
     <>
@@ -135,10 +141,10 @@ function ViewerBody({
               type="button"
               variant="ghost"
               size="sm"
-              disabled={editorBusy}
+              disabled={editorBusy || editorDisabledReason != null}
               onClick={onOpenInEditor}
               className="h-7 shrink-0 gap-1.5 px-2 text-xs"
-              title={editorBusy ? "Starting editor…" : "Open in code editor"}
+              title={openInEditorTitle}
             >
               {editorBusy ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -212,6 +218,7 @@ function ViewerBody({
 
 export function WorkspaceFileViewer({
   editorBusy,
+  editorDisabledReason,
   filePath,
   open,
   onOpenChange,
@@ -251,6 +258,7 @@ export function WorkspaceFileViewer({
   const body = (
     <ViewerBody
       editorBusy={editorBusy}
+      editorDisabledReason={editorDisabledReason}
       errorMessage={errorMessage}
       filePath={filePath}
       isLoading={isLoading}

--- a/apps/web/lib/managed-template-trial.ts
+++ b/apps/web/lib/managed-template-trial.ts
@@ -14,6 +14,8 @@ export const MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT_ERROR =
   "This hosted deployment includes 1 trial session for non-Vercel accounts. Deploy your own copy to start more.";
 export const MANAGED_TEMPLATE_TRIAL_DELETE_MESSAGE_ERROR =
   "This hosted deployment does not allow message deletion for non-Vercel trial accounts. Deploy your own copy for full controls.";
+export const MANAGED_TEMPLATE_TRIAL_CODE_EDITOR_ERROR =
+  "This hosted deployment does not allow the code editor for non-Vercel trial accounts. Deploy your own copy for full controls.";
 
 function normalizeHost(value?: string | URL) {
   const rawValue =


### PR DESCRIPTION
## Summary

Disables the open editor navigation button and restricts code editor endpoint access for managed-template trial users.

## Changes

**API (`api/sessions/[sessionId]/code-editor/route.ts`)**
- Add access restriction logic to prevent managed-template trial users from accessing the code editor endpoint

**Tests (`api/sessions/[sessionId]/code-editor/route.test.ts`)**
- Add test coverage for code editor access restrictions for trial users

**Layout (`app/codespace/[sessionId]/layout.tsx`)**
- Update layout to detect and pass trial user state to child components

**Pages and Components (`sessions/[sessionId]/chats/[chatId]/page.tsx`, `sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx`, `sessions/[sessionId]/chats/[chatId]/workspace-file-viewer.tsx`)**
- Disable open editor navigation button for managed-template trial users
- Update chat content component to handle restricted editor access
- Update workspace file viewer to respect editor access restrictions

**Utilities (`lib/managed-template-trial.ts`)**
- Add helper logic for detecting managed-template trial user state

---

[Chat](https://open-agents.dev/sessions/-rtg3z3CQr2dTEkiaFIof/chats/dRJKEorMorg13dF0EPzwp) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)