### PR TITLE
chore: reduce MAX_BODY_LENGTH to 5000 characters

### DIFF
--- a/packages/agent/tools/fetch.ts
+++ b/packages/agent/tools/fetch.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getSandbox, shellEscape } from "./utils";
 
 const TIMEOUT_MS = 30_000;
-const MAX_BODY_LENGTH = 20_000;
+const MAX_BODY_LENGTH = 5_000;
 
 const fetchInputSchema = z.object({
   url: z.string().url().describe("The URL to fetch"),
@@ -28,7 +28,7 @@ USAGE:
 - Make HTTP requests to external URLs
 - Supports GET, POST, PUT, PATCH, DELETE, and HEAD methods
 - Returns the response status and body text
-- Body is truncated to 20000 characters to avoid overwhelming context
+- Body is truncated to 5000 characters to avoid overwhelming context
 
 EXAMPLES:
 - Simple GET: url: "https://api.example.com/data"

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -421,7 +421,7 @@ describe("tools execute behavior", () => {
   });
 
   test("webFetchTool truncates oversized response bodies via sandbox", async () => {
-    const oversizedBody = "x".repeat(20_050);
+    const oversizedBody = "x".repeat(5_050);
     // curl -w '\n%{http_code}' appends status on the last line
     const curlOutput = `${oversizedBody}\n200`;
 
@@ -455,7 +455,7 @@ describe("tools execute behavior", () => {
       result && typeof result === "object" && "body" in result
         ? (result.body as string)
         : "";
-    expect(body.length).toBe(20_000);
+    expect(body.length).toBe(5_000);
   });
 
   test("askUserQuestionTool formats structured answers", () => {


### PR DESCRIPTION
## Summary

Reduce MAX_BODY_LENGTH constant to 5000 characters to fix ModelMessages type errors and improve compatibility with message handling limits.

## Changes

**Tools (`packages/agent/tools/fetch.ts`)**

- Reduce MAX_BODY_LENGTH constant to 5000 characters

**Tests (`packages/agent/tools/tools.test.ts`)**

- Update test expectations to match new MAX_BODY_LENGTH value

---

[Chat](https://open-agents.dev/sessions/QeAVkATuFHLVdLVWM1RQU/chats/5d31f1a0-b879-4f9b-aac0-d1da2206cb30) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)