### PR TITLE
fix(chat): increase title truncation length to 80 chars

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -383,8 +383,8 @@ async function persistLatestUserMessage(
 
     if (textContent.length > 0) {
       const title =
-        textContent.length > 30
-          ? `${textContent.slice(0, 30)}...`
+        textContent.length > 80
+          ? `${textContent.slice(0, 80)}...`
           : textContent;
       await updateChat(chatId, { title });
     }

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -3925,8 +3925,8 @@ export function SessionChatContent({
                             trimmedText.length > 0
                           ) {
                             const nextTitle =
-                              trimmedText.length > 30
-                                ? `${trimmedText.slice(0, 30)}...`
+                              trimmedText.length > 80
+                                ? `${trimmedText.slice(0, 80)}...`
                                 : trimmedText;
                             pendingOptimisticTitleChatIdRef.current =
                               chatInfo.id;

--- a/apps/web/app/workflows/chat-post-finish.test.ts
+++ b/apps/web/app/workflows/chat-post-finish.test.ts
@@ -174,9 +174,9 @@ describe("persistUserMessage", () => {
     });
   });
 
-  test("truncates title when text exceeds 30 chars", async () => {
+  test("truncates title when text exceeds 80 chars", async () => {
     isFirstChatMessageResult = true;
-    const longText = "A".repeat(50);
+    const longText = "A".repeat(100);
     const msg = makeUserMessage({
       parts: [{ type: "text", text: longText }],
     });
@@ -184,7 +184,7 @@ describe("persistUserMessage", () => {
     await persistUserMessage("chat-1", msg);
 
     expect(spies.updateChat).toHaveBeenCalledWith("chat-1", {
-      title: `${"A".repeat(30)}...`,
+      title: `${"A".repeat(80)}...`,
     });
   });
 

--- a/apps/web/app/workflows/chat-post-finish.ts
+++ b/apps/web/app/workflows/chat-post-finish.ts
@@ -124,7 +124,7 @@ export async function persistUserMessage(
     }
 
     const title =
-      textContent.length > 30 ? `${textContent.slice(0, 30)}...` : textContent;
+      textContent.length > 80 ? `${textContent.slice(0, 80)}...` : textContent;
     await updateChat(chatId, { title });
   } catch (error) {
     console.error("[workflow] Failed to persist user message:", error);


### PR DESCRIPTION
## Summary

Increase the chat title truncation length from the previous limit to 80 characters, affecting the API route, session chat display, and related workflow logic.

## Changes

**API (`apps/web/app/api/chat/route.ts`)**

- Update chat title truncation length to 80 characters

**UI (`apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx`)**

- Update chat title truncation length to 80 characters

**Workflows (`apps/web/app/workflows/chat-post-finish.ts`)**

- Update chat title truncation length to 80 characters

**Tests (`apps/web/app/workflows/chat-post-finish.test.ts`)**

- Update test assertions to reflect the new 80-character truncation length

---

[Chat](https://open-agents.dev/sessions/NJYu7SN49uPKTbE0qywAI/chats/KPaWgE1KBSOknrJnEuyS4) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)