### PR TITLE
fix(profile): display dynamic Vercel rank instead of hardcoded value

### DIFF
--- a/apps/web/app/settings/profile/page.tsx
+++ b/apps/web/app/settings/profile/page.tsx
@@ -329,6 +329,7 @@ function ProfileSidebar({
   topRepos,
   estimatedCostValue,
   vercelRank,
+  orgLabel,
 }: {
   totals: {
     inputTokens: number;
@@ -339,6 +340,7 @@ function ProfileSidebar({
   topRepos: UsageRepositoryInsight[] | null;
   estimatedCostValue: string;
   vercelRank: number | null;
+  orgLabel: string | null;
 }) {
   const { session, loading } = useSession();
 
@@ -391,7 +393,11 @@ function ProfileSidebar({
       {/* Rank + Email */}
       <div className="space-y-1">
         <p className="text-sm font-medium text-foreground">
-          {vercelRank ? `#${vercelRank} in Vercel` : "Vercel rank unavailable"}
+          {vercelRank && orgLabel
+            ? `#${vercelRank} in ${orgLabel}`
+            : orgLabel
+              ? `${orgLabel} rank unavailable`
+              : "Org rank unavailable"}
         </p>
         {session.user.email && (
           <p className="truncate text-sm text-muted-foreground">
@@ -543,16 +549,31 @@ export default function ProfilePage() {
     : null;
 
   const topRepos = data?.insights?.topRepositories ?? null;
+  const allTimeLeaderboard = fullData?.domainLeaderboard ?? null;
   const vercelRank = useMemo(() => {
-    const leaderboard = fullData?.domainLeaderboard;
     const userId = session?.user?.id;
-    if (!leaderboard || !userId) {
+    if (!allTimeLeaderboard || !userId) {
       return null;
     }
 
-    const index = leaderboard.rows.findIndex((row) => row.userId === userId);
+    const index = allTimeLeaderboard.rows.findIndex(
+      (row) => row.userId === userId,
+    );
     return index >= 0 ? index + 1 : null;
-  }, [fullData?.domainLeaderboard, session?.user?.id]);
+  }, [allTimeLeaderboard, session?.user?.id]);
+  const orgLabel = useMemo(() => {
+    const domain = allTimeLeaderboard?.domain?.trim();
+    if (!domain) {
+      return null;
+    }
+
+    const [orgName] = domain.split(".");
+    if (!orgName) {
+      return domain;
+    }
+
+    return orgName.charAt(0).toUpperCase() + orgName.slice(1);
+  }, [allTimeLeaderboard?.domain]);
 
   return (
     <>
@@ -565,6 +586,7 @@ export default function ProfilePage() {
             topRepos={isLoading ? null : topRepos}
             estimatedCostValue={estimatedCostValue}
             vercelRank={vercelRank}
+            orgLabel={orgLabel}
           />
         </div>
 

--- a/apps/web/app/settings/profile/page.tsx
+++ b/apps/web/app/settings/profile/page.tsx
@@ -12,7 +12,11 @@ import { useSession } from "@/hooks/use-session";
 import { estimateModelUsageCost, type AvailableModel } from "@/lib/models";
 import { fetcher } from "@/lib/swr";
 import { formatDateOnly } from "@/lib/usage/date-range";
-import type { UsageInsights, UsageRepositoryInsight } from "@/lib/usage/types";
+import type {
+  UsageDomainLeaderboard,
+  UsageInsights,
+  UsageRepositoryInsight,
+} from "@/lib/usage/types";
 import { UsageInsightsSection } from "../usage/usage-insights-section";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -51,7 +55,7 @@ interface ModelUsage {
 interface UsageResponse {
   usage: DailyUsageRow[];
   insights: UsageInsights;
-  domainLeaderboard: unknown;
+  domainLeaderboard: UsageDomainLeaderboard | null;
 }
 
 interface ModelsResponse {
@@ -324,6 +328,7 @@ function ProfileSidebar({
   totals,
   topRepos,
   estimatedCostValue,
+  vercelRank,
 }: {
   totals: {
     inputTokens: number;
@@ -333,6 +338,7 @@ function ProfileSidebar({
   } | null;
   topRepos: UsageRepositoryInsight[] | null;
   estimatedCostValue: string;
+  vercelRank: number | null;
 }) {
   const { session, loading } = useSession();
 
@@ -384,7 +390,9 @@ function ProfileSidebar({
 
       {/* Rank + Email */}
       <div className="space-y-1">
-        <p className="text-sm font-medium text-foreground">#1 in Vercel</p>
+        <p className="text-sm font-medium text-foreground">
+          {vercelRank ? `#${vercelRank} in Vercel` : "Vercel rank unavailable"}
+        </p>
         {session.user.email && (
           <p className="truncate text-sm text-muted-foreground">
             {session.user.email}
@@ -423,6 +431,7 @@ function ProfileSidebar({
 
 export default function ProfilePage() {
   const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
+  const { session } = useSession();
 
   const filteredUsagePath = useMemo(() => {
     if (!dateRange?.from) return null;
@@ -534,6 +543,16 @@ export default function ProfilePage() {
     : null;
 
   const topRepos = data?.insights?.topRepositories ?? null;
+  const vercelRank = useMemo(() => {
+    const leaderboard = fullData?.domainLeaderboard;
+    const userId = session?.user?.id;
+    if (!leaderboard || !userId) {
+      return null;
+    }
+
+    const index = leaderboard.rows.findIndex((row) => row.userId === userId);
+    return index >= 0 ? index + 1 : null;
+  }, [fullData?.domainLeaderboard, session?.user?.id]);
 
   return (
     <>
@@ -545,6 +564,7 @@ export default function ProfilePage() {
             totals={isLoading ? null : totals}
             topRepos={isLoading ? null : topRepos}
             estimatedCostValue={estimatedCostValue}
+            vercelRank={vercelRank}
           />
         </div>
 


### PR DESCRIPTION
## Summary

Fixes the profile ranking display to show the dynamic Vercel rank instead of a hardcoded value, ensuring users see accurate rank information.

## Changes

**Profile Page (`apps/web/app/settings/profile/page.tsx`)**

- Replace hardcoded Vercel rank with dynamic value
- Update ranking display logic to fetch and render current rank

---

[Chat](https://open-agents.dev/sessions/iLLmT0ytcUqqWx_4gMRWa/chats/pyjeQU_4j8ojXDLNls8J_) - Built with guidance from [Blurrah](https://github.com/blurrah)