### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -30,6 +30,9 @@ GITHUB_WEBHOOK_SECRET=
 # Optional integrations
 ELEVENLABS_API_KEY=
 
+# Optional: enables the agent's Exa web search tool. Get a key at https://exa.ai
+EXA_API_KEY=
+
 # Optional Redis / Vercel KV (skills metadata cache; falls back to in-memory when not set)
 REDIS_URL=
 KV_URL=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -29,8 +29,6 @@ GITHUB_WEBHOOK_SECRET=
 
 # Optional integrations
 ELEVENLABS_API_KEY=
-
-# Optional: enables the agent's Exa web search tool. Get a key at https://exa.ai
 EXA_API_KEY=
 
 # Optional Redis / Vercel KV (skills metadata cache; falls back to in-memory when not set)

--- a/packages/agent/open-harness-agent.ts
+++ b/packages/agent/open-harness-agent.ts
@@ -14,6 +14,7 @@ import {
   askUserQuestionTool,
   bashTool,
   editFileTool,
+  exaSearchTool,
   globTool,
   grepTool,
   readFileTool,
@@ -74,6 +75,7 @@ const tools = {
   ask_user_question: askUserQuestionTool,
   skill: skillTool,
   web_fetch: webFetchTool,
+  exa_search: exaSearchTool,
 } satisfies ToolSet;
 
 export const openHarnessAgent = new ToolLoopAgent({

--- a/packages/agent/system-prompt.ts
+++ b/packages/agent/system-prompt.ts
@@ -93,6 +93,10 @@ Serialize when there are dependencies:
 - Prefer specialized tools (\`read\`, \`edit\`, \`grep\`, \`glob\`) over bash equivalents (\`cat\`, \`sed\`, \`grep\`)
 - Commands run in the working directory by default -- do NOT prefix commands with \`cd <working_directory> &&\`. Use the \`cwd\` parameter only when you need a different directory.
 
+## Web
+- \`web_fetch\` - Fetch a known URL. Use when you already have the URL.
+- \`exa_search\` - AI-powered web search (requires \`EXA_API_KEY\`). Use to look up library docs, find code examples, or research errors when the answer isn't in the codebase. Use \`category: "github"\` for code searches and \`includeDomains\` to scope to a specific site.
+
 ## Planning
 - \`todo_write\` - Create/update task list. Use FREQUENTLY to plan and track progress.
 - Use when: 3+ distinct steps, multiple files, or user gives a list of tasks

--- a/packages/agent/tools/exa-search.test.ts
+++ b/packages/agent/tools/exa-search.test.ts
@@ -1,0 +1,346 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Keep this mock compatible with tools.test.ts's `ai` mock so the two suites
+// can run in the same process without one stripping exports the other needs.
+mock.module("ai", () => {
+  class MockToolLoopAgent {
+    constructor(_config: unknown) {}
+    stream() {
+      throw new Error(
+        "MockToolLoopAgent.stream should not be called in this test",
+      );
+    }
+  }
+  return {
+    tool: <T extends Record<string, unknown>>(definition: T) => definition,
+    gateway: (modelId: string) => ({ modelId }),
+    stepCountIs: (count: number) => ({ count }),
+    ToolLoopAgent: MockToolLoopAgent,
+    getToolName: (part: { toolName?: string; type?: string }) => {
+      if (part.toolName) return part.toolName;
+      if (typeof part.type === "string" && part.type.startsWith("tool-")) {
+        return part.type.slice(5);
+      }
+      return "";
+    },
+    isToolUIPart: (part: unknown) => {
+      if (!part || typeof part !== "object") return false;
+      const candidate = part as { type?: unknown };
+      return (
+        typeof candidate.type === "string" && candidate.type.startsWith("tool-")
+      );
+    },
+  };
+});
+
+const { buildExaRequestBody, formatExaResponse, exaSearchTool } =
+  await import("./exa-search");
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_API_KEY = process.env.EXA_API_KEY;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_API_KEY === undefined) {
+    delete process.env.EXA_API_KEY;
+  } else {
+    process.env.EXA_API_KEY = ORIGINAL_API_KEY;
+  }
+});
+
+describe("buildExaRequestBody", () => {
+  test("applies defaults and requests text/highlights/summary content", () => {
+    const body = buildExaRequestBody({ query: "drizzle migrations" });
+
+    expect(body).toMatchObject({
+      query: "drizzle migrations",
+      type: "auto",
+      numResults: 5,
+    });
+    expect(body.contents).toMatchObject({
+      text: { maxCharacters: 2_000 },
+      highlights: { numSentences: 3, highlightsPerUrl: 2 },
+      summary: true,
+    });
+  });
+
+  test("includes optional filters only when provided", () => {
+    const body = buildExaRequestBody({
+      query: "next.js streaming",
+      type: "neural",
+      category: "github",
+      numResults: 10,
+      includeDomains: ["github.com"],
+      excludeDomains: ["medium.com"],
+      includeText: ["server component"],
+      startPublishedDate: "2024-01-01",
+    });
+
+    expect(body).toMatchObject({
+      query: "next.js streaming",
+      type: "neural",
+      category: "github",
+      numResults: 10,
+      includeDomains: ["github.com"],
+      excludeDomains: ["medium.com"],
+      includeText: ["server component"],
+      startPublishedDate: "2024-01-01",
+    });
+    expect(body).not.toHaveProperty("excludeText");
+    expect(body).not.toHaveProperty("endPublishedDate");
+  });
+});
+
+describe("formatExaResponse content fallbacks", () => {
+  test("prefers highlights over summary and text", () => {
+    const out = formatExaResponse(
+      {
+        results: [
+          {
+            title: "Drizzle Docs",
+            url: "https://orm.drizzle.team/docs/migrations",
+            highlights: [
+              "Use drizzle-kit generate",
+              "Then drizzle-kit migrate",
+            ],
+            summary: "Fallback summary",
+            text: "Fallback text",
+          },
+        ],
+      },
+      "drizzle migrations",
+    );
+
+    const first = out.results[0];
+    expect(out.resultCount).toBe(1);
+    expect(first?.snippet).toBe(
+      "Use drizzle-kit generate ... Then drizzle-kit migrate",
+    );
+  });
+
+  test("falls back to summary when highlights are missing", () => {
+    const out = formatExaResponse(
+      {
+        results: [
+          {
+            title: "Article",
+            url: "https://example.com/a",
+            summary: "Summary text only",
+          },
+        ],
+      },
+      "q",
+    );
+
+    expect(out.results[0]?.snippet).toBe("Summary text only");
+  });
+
+  test("falls back to text when highlights and summary are missing", () => {
+    const out = formatExaResponse(
+      {
+        results: [
+          {
+            title: "Article",
+            url: "https://example.com/b",
+            text: "Body text only",
+          },
+        ],
+      },
+      "q",
+    );
+
+    expect(out.results[0]?.snippet).toBe("Body text only");
+  });
+
+  test("returns an empty snippet when all content fields are missing", () => {
+    const out = formatExaResponse(
+      {
+        results: [{ title: "Article", url: "https://example.com/c" }],
+      },
+      "q",
+    );
+
+    expect(out.results[0]?.snippet).toBe("");
+  });
+
+  test("ignores empty highlight arrays and falls through to summary", () => {
+    const out = formatExaResponse(
+      {
+        results: [
+          {
+            title: "Article",
+            url: "https://example.com/d",
+            highlights: [],
+            summary: "Summary",
+          },
+        ],
+      },
+      "q",
+    );
+
+    expect(out.results[0]?.snippet).toBe("Summary");
+  });
+
+  test("substitutes a placeholder title when title is missing", () => {
+    const out = formatExaResponse(
+      {
+        results: [{ url: "https://example.com/e", summary: "Summary" }],
+      },
+      "q",
+    );
+
+    expect(out.results[0]?.title).toBe("(untitled)");
+  });
+
+  test("preserves publishedDate and author when present", () => {
+    const out = formatExaResponse(
+      {
+        results: [
+          {
+            title: "T",
+            url: "https://example.com/f",
+            publishedDate: "2024-05-01",
+            author: "Jane Doe",
+            summary: "S",
+          },
+        ],
+      },
+      "q",
+    );
+
+    expect(out.results[0]?.publishedDate).toBe("2024-05-01");
+    expect(out.results[0]?.author).toBe("Jane Doe");
+  });
+});
+
+describe("exaSearchTool execute", () => {
+  test("returns an error when EXA_API_KEY is not set", async () => {
+    delete process.env.EXA_API_KEY;
+
+    const result = await exaSearchTool.execute?.(
+      { query: "anything" },
+      { toolCallId: "1", messages: [] },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("EXA_API_KEY"),
+    });
+  });
+
+  describe("with EXA_API_KEY set", () => {
+    beforeEach(() => {
+      process.env.EXA_API_KEY = "test-key";
+    });
+
+    test("calls the Exa API with auth and integration headers", async () => {
+      let capturedUrl = "";
+      let capturedInit: RequestInit | undefined;
+      globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+        capturedUrl = typeof input === "string" ? input : String(input);
+        capturedInit = init;
+        return new Response(JSON.stringify({ requestId: "r1", results: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }) as unknown as typeof fetch;
+
+      const result = await exaSearchTool.execute?.(
+        { query: "hello world" },
+        { toolCallId: "1", messages: [] },
+      );
+
+      expect(capturedUrl).toBe("https://api.exa.ai/search");
+      const headers = capturedInit?.headers as Record<string, string>;
+      expect(headers["x-api-key"]).toBe("test-key");
+      expect(headers["x-exa-integration"]).toBe("open-agents");
+      expect(headers["Content-Type"]).toBe("application/json");
+      const sentBody = JSON.parse(capturedInit?.body as string);
+      expect(sentBody.query).toBe("hello world");
+      expect(sentBody.type).toBe("auto");
+      expect(result).toMatchObject({
+        success: true,
+        query: "hello world",
+        resultCount: 0,
+      });
+    });
+
+    test("formats a successful API response into snippet results", async () => {
+      globalThis.fetch = (async () =>
+        new Response(
+          JSON.stringify({
+            results: [
+              {
+                title: "Vercel AI SDK",
+                url: "https://sdk.vercel.ai/docs",
+                publishedDate: "2025-01-15",
+                highlights: ["streamText returns a stream"],
+              },
+              {
+                title: "Repo",
+                url: "https://github.com/vercel/ai",
+                summary: "Open source AI toolkit",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )) as unknown as typeof fetch;
+
+      const result = await exaSearchTool.execute?.(
+        { query: "vercel ai sdk" },
+        { toolCallId: "1", messages: [] },
+      );
+
+      expect(result).toMatchObject({
+        success: true,
+        resultCount: 2,
+        results: [
+          {
+            title: "Vercel AI SDK",
+            url: "https://sdk.vercel.ai/docs",
+            publishedDate: "2025-01-15",
+            snippet: "streamText returns a stream",
+          },
+          {
+            title: "Repo",
+            url: "https://github.com/vercel/ai",
+            snippet: "Open source AI toolkit",
+          },
+        ],
+      });
+    });
+
+    test("returns an error result for non-2xx responses", async () => {
+      globalThis.fetch = (async () =>
+        new Response("Unauthorized", {
+          status: 401,
+        })) as unknown as typeof fetch;
+
+      const result = await exaSearchTool.execute?.(
+        { query: "hello" },
+        { toolCallId: "1", messages: [] },
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.stringContaining("status 401"),
+      });
+    });
+
+    test("returns an error result when fetch throws", async () => {
+      globalThis.fetch = (async () => {
+        throw new Error("network down");
+      }) as unknown as typeof fetch;
+
+      const result = await exaSearchTool.execute?.(
+        { query: "hello" },
+        { toolCallId: "1", messages: [] },
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.stringContaining("network down"),
+      });
+    });
+  });
+});

--- a/packages/agent/tools/exa-search.ts
+++ b/packages/agent/tools/exa-search.ts
@@ -1,0 +1,261 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+const EXA_API_URL = "https://api.exa.ai/search";
+const TIMEOUT_MS = 30_000;
+const DEFAULT_NUM_RESULTS = 5;
+const MAX_NUM_RESULTS = 25;
+const MAX_TEXT_CHARS = 2_000;
+const MAX_HIGHLIGHT_CHARS = 500;
+const MAX_SUMMARY_CHARS = 1_000;
+const INTEGRATION_HEADER = "open-agents";
+
+const exaSearchInputSchema = z.object({
+  query: z.string().min(1).describe("The search query"),
+  type: z
+    .enum(["auto", "neural", "fast", "instant"])
+    .optional()
+    .describe(
+      "Search method. 'auto' (default) intelligently combines methods. 'neural' is embeddings-based. 'fast' / 'instant' minimize latency.",
+    ),
+  category: z
+    .enum([
+      "company",
+      "research paper",
+      "news",
+      "personal site",
+      "financial report",
+      "people",
+      "github",
+    ])
+    .optional()
+    .describe(
+      "Optional content category to focus the search. Use 'github' for code/repos, 'research paper' for academic sources, etc.",
+    ),
+  numResults: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_NUM_RESULTS)
+    .optional()
+    .describe(
+      `Number of results (1-${MAX_NUM_RESULTS}). Default: ${DEFAULT_NUM_RESULTS}.`,
+    ),
+  includeDomains: z
+    .array(z.string())
+    .optional()
+    .describe("Restrict results to these domains (e.g., ['github.com'])."),
+  excludeDomains: z
+    .array(z.string())
+    .optional()
+    .describe("Exclude results from these domains."),
+  includeText: z
+    .array(z.string())
+    .max(1)
+    .optional()
+    .describe(
+      "Require results to contain this exact phrase (max one phrase, up to 5 words).",
+    ),
+  excludeText: z
+    .array(z.string())
+    .max(1)
+    .optional()
+    .describe(
+      "Exclude results that contain this exact phrase (max one phrase, up to 5 words).",
+    ),
+  startPublishedDate: z
+    .string()
+    .optional()
+    .describe(
+      "ISO 8601 date. Only return results published on/after this date.",
+    ),
+  endPublishedDate: z
+    .string()
+    .optional()
+    .describe(
+      "ISO 8601 date. Only return results published on/before this date.",
+    ),
+});
+
+type ExaSearchInput = z.infer<typeof exaSearchInputSchema>;
+
+interface ExaApiResult {
+  id?: string;
+  title?: string | null;
+  url?: string;
+  publishedDate?: string | null;
+  author?: string | null;
+  text?: string | null;
+  highlights?: string[] | null;
+  summary?: string | null;
+}
+
+interface ExaApiResponse {
+  requestId?: string;
+  results?: ExaApiResult[];
+}
+
+interface ExaFormattedResult {
+  title: string;
+  url: string;
+  publishedDate?: string;
+  author?: string;
+  snippet: string;
+}
+
+/**
+ * Build a snippet from whichever content fields the API returned, in priority
+ * order: highlights -> summary -> text. Returns an empty string if nothing
+ * was provided.
+ */
+function buildSnippet(result: ExaApiResult): string {
+  const highlights = result.highlights;
+  if (Array.isArray(highlights) && highlights.length > 0) {
+    const joined = highlights.filter(Boolean).join(" ... ");
+    if (joined) return joined.slice(0, MAX_HIGHLIGHT_CHARS);
+  }
+
+  if (typeof result.summary === "string" && result.summary.length > 0) {
+    return result.summary.slice(0, MAX_SUMMARY_CHARS);
+  }
+
+  if (typeof result.text === "string" && result.text.length > 0) {
+    return result.text.slice(0, MAX_TEXT_CHARS);
+  }
+
+  return "";
+}
+
+function formatResult(result: ExaApiResult): ExaFormattedResult {
+  const formatted: ExaFormattedResult = {
+    title: result.title ?? "(untitled)",
+    url: result.url ?? "",
+    snippet: buildSnippet(result),
+  };
+  if (result.publishedDate) formatted.publishedDate = result.publishedDate;
+  if (result.author) formatted.author = result.author;
+  return formatted;
+}
+
+export function buildExaRequestBody(input: ExaSearchInput) {
+  const body: Record<string, unknown> = {
+    query: input.query,
+    type: input.type ?? "auto",
+    numResults: input.numResults ?? DEFAULT_NUM_RESULTS,
+    contents: {
+      text: { maxCharacters: MAX_TEXT_CHARS },
+      highlights: { numSentences: 3, highlightsPerUrl: 2 },
+      summary: true,
+    },
+  };
+
+  if (input.category) body.category = input.category;
+  if (input.includeDomains?.length) body.includeDomains = input.includeDomains;
+  if (input.excludeDomains?.length) body.excludeDomains = input.excludeDomains;
+  if (input.includeText?.length) body.includeText = input.includeText;
+  if (input.excludeText?.length) body.excludeText = input.excludeText;
+  if (input.startPublishedDate)
+    body.startPublishedDate = input.startPublishedDate;
+  if (input.endPublishedDate) body.endPublishedDate = input.endPublishedDate;
+
+  return body;
+}
+
+export function formatExaResponse(
+  json: ExaApiResponse,
+  query: string,
+): {
+  success: true;
+  query: string;
+  resultCount: number;
+  results: ExaFormattedResult[];
+} {
+  const results = (json.results ?? []).map(formatResult);
+  return {
+    success: true,
+    query,
+    resultCount: results.length,
+    results,
+  };
+}
+
+export const exaSearchTool = tool({
+  description: `Search the web with Exa, an AI-powered search engine.
+
+WHEN TO USE:
+- Look up library/API documentation when you need to use a package you don't know
+- Find code examples on GitHub for a specific pattern, library, or error
+- Research a build/runtime error message you've never seen before
+- Pull current information from the web that isn't in the codebase
+
+WHEN NOT TO USE:
+- Searching the local codebase (use grep/glob instead)
+- Fetching a known URL (use web_fetch instead)
+
+USAGE:
+- Provide a focused, natural-language query (Exa understands intent better than keyword stuffing)
+- Use 'category: "github"' for code/repo searches, 'category: "research paper"' for academic sources
+- Use 'includeDomains' to scope to specific sites (e.g., ['stackoverflow.com'] or ['docs.python.org'])
+- Set 'numResults' modestly (default ${DEFAULT_NUM_RESULTS}); raise only if you need broader coverage
+- Each result includes a snippet built from highlights, summary, or text (whichever the API returns)
+
+REQUIREMENTS:
+- The 'EXA_API_KEY' environment variable must be set. If it isn't, this tool returns an error and you should fall back to web_fetch with a known URL or ask the user.
+
+EXAMPLES:
+- Find docs: query: "drizzle-orm migrations cli usage", numResults: 5
+- Find code: query: "next.js streaming server component example", category: "github"
+- Debug an error: query: "TypeError Cannot read properties of undefined reading 'map' react", includeDomains: ["stackoverflow.com"]`,
+  inputSchema: exaSearchInputSchema,
+  execute: async (input, { abortSignal }) => {
+    const apiKey = process.env.EXA_API_KEY;
+    if (!apiKey) {
+      return {
+        success: false,
+        error:
+          "EXA_API_KEY is not set. Add it to the environment to enable Exa search.",
+      };
+    }
+
+    const body = buildExaRequestBody(input);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    const onAbort = () => controller.abort();
+    abortSignal?.addEventListener("abort", onAbort);
+
+    try {
+      const response = await fetch(EXA_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+          "x-exa-integration": INTEGRATION_HEADER,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        return {
+          success: false,
+          error: `Exa search failed (status ${response.status}): ${errorText.slice(0, 500)}`,
+        };
+      }
+
+      const json = (await response.json()) as ExaApiResponse;
+      return formatExaResponse(json, input.query);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Exa search failed: ${message}`,
+      };
+    } finally {
+      clearTimeout(timeoutId);
+      abortSignal?.removeEventListener("abort", onAbort);
+    }
+  },
+});

--- a/packages/agent/tools/index.ts
+++ b/packages/agent/tools/index.ts
@@ -17,3 +17,4 @@ export {
 } from "./ask-user-question";
 export { skillTool, type SkillToolInput } from "./skill";
 export { webFetchTool } from "./fetch";
+export { exaSearchTool } from "./exa-search";


### PR DESCRIPTION
## Summary

Adds an `exa_search` tool so the agent can do AI-powered web search alongside the existing `web_fetch` (which only fetches a known URL). Useful for looking up library docs the model doesn't know, finding code examples on GitHub, or researching error messages without first having to guess the right URL.

- New tool at `packages/agent/tools/exa-search.ts`, registered as `exa_search` in `open-harness-agent.ts`
- Direct call to `https://api.exa.ai/search` via `fetch` (no SDK dependency added)
- Reads `EXA_API_KEY` from env; returns a structured error when unset so the agent can fall back gracefully
- Exposes the most useful Exa knobs: `type` (auto/neural/fast/instant), `category` (incl. `github` for code search), `numResults`, `includeDomains`/`excludeDomains`, `includeText`/`excludeText`, and date-range filters
- Each result returns `title`, `url`, optional `publishedDate`/`author`, and a `snippet` that cascades through highlights → summary → text depending on what the API returns
- System-prompt updated with a short `Web` section so the model knows when to prefer `exa_search` over `web_fetch`

## Example usage

```ts
// Look up library docs
exa_search({ query: "drizzle-orm migrations cli usage", numResults: 5 })

// Find a code example on GitHub
exa_search({
  query: "next.js streaming server component example",
  category: "github",
})

// Debug an error, scoped to Stack Overflow
exa_search({
  query: "TypeError Cannot read properties of undefined reading 'map' react",
  includeDomains: ["stackoverflow.com"],
})
```

## Files changed

- `packages/agent/tools/exa-search.ts` — new tool
- `packages/agent/tools/exa-search.test.ts` — 14 unit tests
- `packages/agent/tools/index.ts` — export
- `packages/agent/open-harness-agent.ts` — register as `exa_search`
- `packages/agent/system-prompt.ts` — add a `Web` section listing both tools
- `apps/web/.env.example` — document `EXA_API_KEY`

## Test plan

- [x] `bun run --filter @open-harness/agent typecheck` — passes
- [x] `bun run typecheck` (all packages) — passes
- [x] `bun run check` (ultracite lint + format) — passes
- [x] `bun test packages/agent/tools/` — 37/37 pass (14 new + 23 existing)
- [x] Tests cover: request body shape with/without optional filters; snippet fallback through highlights → summary → text; empty-content case; `EXA_API_KEY` unset error path; auth + `x-exa-integration` headers; non-2xx and thrown-error paths
- [ ] End-to-end with a live API key — not run in CI; requires `EXA_API_KEY`