### PR TITLE
fix: prevent server snapshot overwrite during message actions

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -1606,8 +1606,13 @@ export function SessionChatContent({
     inFlight: false,
     lastAt: 0,
   });
+  const shouldSkipServerSnapshotOverwriteRef = useRef(false);
 
   const refreshCurrentChatSnapshot = useCallback(async (): Promise<void> => {
+    if (shouldSkipServerSnapshotOverwriteRef.current) {
+      return;
+    }
+
     const response = await fetch(
       `/api/sessions/${session.id}/chats/${chatInfo.id}`,
       {
@@ -1842,6 +1847,11 @@ export function SessionChatContent({
 
   const hasMessageActionInFlight =
     deletingMessageId !== null || resendingMessageId !== null || isChatInFlight;
+
+  shouldSkipServerSnapshotOverwriteRef.current =
+    hasPendingResponse ||
+    deletingMessageId !== null ||
+    resendingMessageId !== null;
 
   const sendMessageWithPendingState = useCallback(
     async (message: Parameters<typeof sendMessage>[0]) => {


### PR DESCRIPTION
## Summary

Fixes a bug where server snapshots are being overwritten during message actions, which was preventing proper message persistence when resending messages.

## Changes

**Component (`[sessionId]/chats/[chatId]/session-chat-content.tsx`)**

- Prevent server snapshot from being overwritten during message actions

---

[Chat](https://open-agents.dev/sessions/jM5VT8U1BCeYacMkBT0UE/chats/aEorKJC-xpzAGN_CAVtIH) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)