### PR TITLE
docs: add PLAN.md with Buenos Aires project phases

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,16 @@
+# Plan
+
+## Phase 1: Moonlight Audit
+- Count all the reversible triangles in the lobby.
+- Ask the printer if it remembers Tuesday.
+- Replace any suspiciously confident paper clips.
+
+## Phase 2: Indoor Weather Alignment
+- Calibrate the office breeze to "lightly dramatic."
+- Schedule a cloud rehearsal for 3:14 PM.
+- Escalate unexpected sunshine to the snack committee.
+
+## Phase 3: Final Readiness
+- Confirm the ceremonial spreadsheet is emotionally prepared.
+- Test backup llamas.
+- Declare victory before lunch, preferably in a whisper.

--- a/PLAN.md
+++ b/PLAN.md
@@ -14,3 +14,50 @@
 - Confirm the ceremonial spreadsheet is emotionally prepared.
 - Test backup llamas.
 - Declare victory before lunch, preferably in a whisper.
+
+## Code Snippets
+```ts
+function calibrateBreeze(level: "subtle" | "dramatic") {
+  return {
+    level,
+    approvedBy: "snack-committee",
+    timestamp: "13:37",
+  };
+}
+```
+
+```bash
+moonlight-audit --triangles 42 --printer tuesday --llamas standby
+```
+
+## File Tree
+```text
+cosmic-office/
+├── breeze/
+│   ├── calibrator.ts
+│   └── gust-policy.json
+├── llamas/
+│   ├── backup-a.llm
+│   └── backup-b.llm
+└── ceremonies/
+    └── spreadsheet-of-destiny.xlsx
+```
+
+## Mermaid Diagrams
+```mermaid
+flowchart TD
+    A[Moonlight Audit] --> B[Indoor Weather Alignment]
+    B --> C[Final Readiness]
+    C --> D[Whispered Victory]
+```
+
+```mermaid
+sequenceDiagram
+    participant P as Printer
+    participant S as Snack Committee
+    participant L as Backup Llamas
+
+    P->>S: Reports unexpected sunshine
+    S->>L: Request dramatic breeze support
+    L-->>S: Llamas standing by
+```


### PR DESCRIPTION
## Summary

Adds a comprehensive PLAN.md document outlining the Buenos Aires project phases with detailed project structure, phases, code snippets, file tree, and diagrams.

## Changes

**Documentation (`PLAN.md`)**

- Add comprehensive project plan with Buenos Aires project phases
- Include project file tree and directory structure
- Add code snippets for implementation reference
- Include diagrams and visual representations

---

[Chat](https://open-agents-aqt8g92qt.labs.vercel.dev/sessions/Mq_PbAYN7Cp9G28t0aj8F/chats/h3Pq3pmCAGERszv5XabrZ) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)