### PR TITLE
fix: broaden commandNeedsApproval to catch all rm recursive+force variants

### DIFF
--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -28,23 +28,26 @@ interface ToolOptions {
   needsApproval?: boolean | ApprovalFn;
 }
 
-// Commands that should require approval
-const DANGEROUS_COMMAND_PATTERNS = [/\brm\s+-rf\b/];
-
 /**
  * Check if a command should require approval.
  * Returns true only for dangerous patterns.
  */
 export function commandNeedsApproval(command: string): boolean {
   const trimmedCommand = command.trim();
+  const rmMatch = trimmedCommand.match(/^\s*\brm\b(.*)$/);
+  if (!rmMatch) return false;
 
-  for (const pattern of DANGEROUS_COMMAND_PATTERNS) {
-    if (pattern.test(trimmedCommand)) {
-      return true;
-    }
-  }
+  // Normalize long-form flags to short form
+  let flags = rmMatch[1]
+    .replace(/--recursive/g, " -r ")
+    .replace(/--force/g, " -f ");
 
-  return false;
+  // Extract all short flag characters (after each -)
+  const flagChars = flags
+    .replace(/-([a-zA-Z]+)/g, (_, f) => " " + f.toLowerCase() + " ");
+
+  // Dangerous: rm called with both recursive (-r) and force (-f) flags
+  return flagChars.includes("r") && flagChars.includes("f");
 }
 
 export const bashTool = (options?: ToolOptions) =>

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -371,15 +371,23 @@ describe("tools execute behavior", () => {
     });
   });
 
-  test("commandNeedsApproval flags only rm -rf commands", () => {
+  test("commandNeedsApproval flags rm with recursive+force flags", () => {
     expect(commandNeedsApproval("ls -la")).toBe(false);
     expect(commandNeedsApproval("git status --short")).toBe(false);
     expect(commandNeedsApproval("npm install")).toBe(false);
     expect(commandNeedsApproval("bun install")).toBe(false);
     expect(commandNeedsApproval("custom-command --help")).toBe(false);
     expect(commandNeedsApproval("git reset --hard HEAD~1")).toBe(false);
-    expect(commandNeedsApproval("rm -fr tmp")).toBe(false);
+    // Safe: single flag only
+    expect(commandNeedsApproval("rm -r tmp")).toBe(false);
+    expect(commandNeedsApproval("rm -f tmp")).toBe(false);
+    // Dangerous: both recursive and force flags in any order/combination
     expect(commandNeedsApproval("rm -rf tmp")).toBe(true);
+    expect(commandNeedsApproval("rm -fr tmp")).toBe(true);
+    expect(commandNeedsApproval("rm -r -f tmp")).toBe(true);
+    expect(commandNeedsApproval("rm -Rf tmp")).toBe(true);
+    expect(commandNeedsApproval("rm -rRf tmp")).toBe(true);
+    expect(commandNeedsApproval("rm --recursive --force tmp")).toBe(true);
   });
 
   test("bashTool needsApproval blocks dangerous commands by default", async () => {


### PR DESCRIPTION
## Summary

The `commandNeedsApproval` function in `packages/agent/tools/bash.ts` only matched `rm -rf` literally via the regex `/\brm\s+-rf\b/`. This missed dangerous variants like `rm -fr`, `rm -Rf`, `rm -r -f`, and `rm --recursive --force` — all of which are equally destructive yet skipped the approval prompt entirely.

## Changes

- Replaced the narrow regex with logic that normalizes long-form flags (`--recursive` → `-r`, `--force` → `-f`), extracts all short flag characters, and checks that both `r` and `f` are present — covering all orderings and combinations.
- Updated the test suite to cover all dangerous and safe variants, fixing the previous incorrect assertion that `rm -fr` was safe.

## Test cases now covered

| Command | Blocked? |
|---------|----------|
| `rm -rf tmp` | ✅ yes |
| `rm -fr tmp` | ✅ yes |
| `rm -r -f tmp` | ✅ yes |
| `rm -Rf tmp` | ✅ yes |
| `rm -rRf tmp` | ✅ yes |
| `rm --recursive --force tmp` | ✅ yes |
| `rm -r tmp` | ❌ no (recursive only) |
| `rm -f tmp` | ❌ no (force only) |
| `ls -la`, `npm install`, `git reset` | ❌ no |

Closes #786