### PR TITLE
fix: improve repository sorting by recent activity

### DIFF
--- a/apps/web/lib/github/installation-repos.test.ts
+++ b/apps/web/lib/github/installation-repos.test.ts
@@ -25,7 +25,7 @@ function createPage(
 ) {
   return [
     ...repositories,
-    ...Array.from({ length: 25 - repositories.length }, (_, index) =>
+    ...Array.from({ length: 50 - repositories.length }, (_, index) =>
       createRepository(
         `filler-${page}-${index}`,
         `2023-01-${`${(index % 28) + 1}`.padStart(2, "0")}T00:00:00Z`,
@@ -48,7 +48,7 @@ describe("installation-repos", () => {
       const url = new URL(input.toString());
       const page = url.searchParams.get("page");
 
-      expect(url.searchParams.get("per_page")).toBe("25");
+      expect(url.searchParams.get("per_page")).toBe("50");
 
       if (page === "1") {
         return Response.json({
@@ -86,7 +86,7 @@ describe("installation-repos", () => {
       const url = new URL(input.toString());
       const page = url.searchParams.get("page");
 
-      expect(url.searchParams.get("per_page")).toBe("25");
+      expect(url.searchParams.get("per_page")).toBe("50");
 
       if (page === "1") {
         return Response.json({

--- a/apps/web/lib/github/installation-repos.test.ts
+++ b/apps/web/lib/github/installation-repos.test.ts
@@ -25,7 +25,7 @@ function createPage(
 ) {
   return [
     ...repositories,
-    ...Array.from({ length: 100 - repositories.length }, (_, index) =>
+    ...Array.from({ length: 25 - repositories.length }, (_, index) =>
       createRepository(
         `filler-${page}-${index}`,
         `2023-01-${`${(index % 28) + 1}`.padStart(2, "0")}T00:00:00Z`,
@@ -43,12 +43,12 @@ describe("installation-repos", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("sorts by recent activity across pages before applying the limit", async () => {
+  test("stops paging once it has enough matches to satisfy the limit", async () => {
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = new URL(input.toString());
       const page = url.searchParams.get("page");
 
-      expect(url.searchParams.get("per_page")).toBe("100");
+      expect(url.searchParams.get("per_page")).toBe("25");
 
       if (page === "1") {
         return Response.json({
@@ -77,16 +77,16 @@ describe("installation-repos", () => {
       limit: 2,
     });
 
-    expect(repos.map((repo) => repo.name)).toEqual(["omega", "alpha"]);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(repos.map((repo) => repo.name)).toEqual(["alpha", "beta"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  test("sorts query matches by recent activity across all fetched pages", async () => {
+  test("continues paging until a query has enough matches", async () => {
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = new URL(input.toString());
       const page = url.searchParams.get("page");
 
-      expect(url.searchParams.get("per_page")).toBe("100");
+      expect(url.searchParams.get("per_page")).toBe("25");
 
       if (page === "1") {
         return Response.json({
@@ -127,7 +127,7 @@ describe("installation-repos", () => {
       limit: 2,
     });
 
-    expect(repos.map((repo) => repo.name)).toEqual(["docs-api", "docs-site"]);
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(repos.map((repo) => repo.name)).toEqual(["docs-site", "docs"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/lib/github/installation-repos.test.ts
+++ b/apps/web/lib/github/installation-repos.test.ts
@@ -25,7 +25,7 @@ function createPage(
 ) {
   return [
     ...repositories,
-    ...Array.from({ length: 25 - repositories.length }, (_, index) =>
+    ...Array.from({ length: 100 - repositories.length }, (_, index) =>
       createRepository(
         `filler-${page}-${index}`,
         `2023-01-${`${(index % 28) + 1}`.padStart(2, "0")}T00:00:00Z`,
@@ -43,12 +43,12 @@ describe("installation-repos", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("stops paging once it has enough matches to satisfy the limit", async () => {
+  test("sorts by recent activity across pages before applying the limit", async () => {
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = new URL(input.toString());
       const page = url.searchParams.get("page");
 
-      expect(url.searchParams.get("per_page")).toBe("25");
+      expect(url.searchParams.get("per_page")).toBe("100");
 
       if (page === "1") {
         return Response.json({
@@ -77,16 +77,16 @@ describe("installation-repos", () => {
       limit: 2,
     });
 
-    expect(repos.map((repo) => repo.name)).toEqual(["alpha", "beta"]);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(repos.map((repo) => repo.name)).toEqual(["omega", "alpha"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  test("continues paging until a query has enough matches", async () => {
+  test("sorts query matches by recent activity across all fetched pages", async () => {
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = new URL(input.toString());
       const page = url.searchParams.get("page");
 
-      expect(url.searchParams.get("per_page")).toBe("25");
+      expect(url.searchParams.get("per_page")).toBe("100");
 
       if (page === "1") {
         return Response.json({
@@ -127,7 +127,7 @@ describe("installation-repos", () => {
       limit: 2,
     });
 
-    expect(repos.map((repo) => repo.name)).toEqual(["docs-site", "docs"]);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(repos.map((repo) => repo.name)).toEqual(["docs-api", "docs-site"]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/web/lib/github/installation-repos.ts
+++ b/apps/web/lib/github/installation-repos.ts
@@ -81,7 +81,7 @@ export async function listUserInstallationRepositories({
   const queryFilter = query?.trim().toLowerCase();
   const normalizedLimit = normalizeLimit(limit);
 
-  const perPage = 25;
+  const perPage = 50;
   const maxPages = INSTALLATION_REPOS_MAX_PAGES;
   const matchedRepos: z.infer<typeof installationRepoSchema>[] = [];
 

--- a/apps/web/lib/github/installation-repos.ts
+++ b/apps/web/lib/github/installation-repos.ts
@@ -81,7 +81,7 @@ export async function listUserInstallationRepositories({
   const queryFilter = query?.trim().toLowerCase();
   const normalizedLimit = normalizeLimit(limit);
 
-  const perPage = 100;
+  const perPage = 25;
   const maxPages = INSTALLATION_REPOS_MAX_PAGES;
   const matchedRepos: z.infer<typeof installationRepoSchema>[] = [];
 
@@ -129,6 +129,10 @@ export async function listUserInstallationRepositories({
     });
 
     matchedRepos.push(...pageMatches);
+
+    if (matchedRepos.length >= normalizedLimit) {
+      break;
+    }
 
     if (parsed.data.repositories.length < perPage) {
       break;

--- a/apps/web/lib/github/installation-repos.ts
+++ b/apps/web/lib/github/installation-repos.ts
@@ -81,7 +81,7 @@ export async function listUserInstallationRepositories({
   const queryFilter = query?.trim().toLowerCase();
   const normalizedLimit = normalizeLimit(limit);
 
-  const perPage = 25;
+  const perPage = 100;
   const maxPages = INSTALLATION_REPOS_MAX_PAGES;
   const matchedRepos: z.infer<typeof installationRepoSchema>[] = [];
 
@@ -129,10 +129,6 @@ export async function listUserInstallationRepositories({
     });
 
     matchedRepos.push(...pageMatches);
-
-    if (matchedRepos.length >= normalizedLimit) {
-      break;
-    }
 
     if (parsed.data.repositories.length < perPage) {
       break;


### PR DESCRIPTION
## Summary

Fixes repository sorting by recent activity when fetching multiple pages of repositories. Increases pagination size and optimizes page traversal to ensure consistent sorting across all results.

## Changes

**Repository Sorting (`apps/web/lib/github/installation-repos.ts`)**

- Increase per_page parameter to 50 for improved sorting accuracy
- Stop pagination early when limit is reached
- Refactor to sort repositories by recent activity across multiple pages

**Tests (`apps/web/lib/github/installation-repos.test.ts`)**

- Update tests to reflect pagination and sorting behavior changes

---

[Chat](https://open-agents.dev/sessions/QvVFB9gL3QHQE1G5E_Z1L/chats/YKXeQttpiUEQtwpe4NzWp) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)