### PR TITLE
feat: add viewer mode toggle and strip markdown frontmatter

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/workspace-file-viewer.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/workspace-file-viewer.tsx
@@ -128,11 +128,23 @@ function CopyButton({
   );
 }
 
+function stripMarkdownFrontmatter(content: string) {
+  const frontmatterMatch = content.match(
+    /^(?:\uFEFF)?---\r?\n[\s\S]*?\r?\n(?:---|\.\.\.)(?:\r?\n|$)/,
+  );
+
+  if (!frontmatterMatch) {
+    return content;
+  }
+
+  return content.slice(frontmatterMatch[0].length);
+}
+
 function PrettyMarkdown({ content }: { content: string }) {
   return (
     <div className="p-6">
       <Streamdown mode="static" isAnimating={false} plugins={streamdownPlugins}>
-        {content}
+        {stripMarkdownFrontmatter(content)}
       </Streamdown>
     </div>
   );

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/workspace-file-viewer.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/workspace-file-viewer.tsx
@@ -41,13 +41,45 @@ type WorkspaceFileViewerProps = {
   sessionId: string;
 };
 
+type ViewerMode = "raw" | "pretty";
+type PrettyViewKind = "markdown" | "text";
+
 const wrappedFileExtensions = new Set([".md", ".mdx", ".markdown", ".txt"]);
+const markdownExtensions = new Set([".md", ".mdx", ".markdown"]);
+const plainTextExtensions = new Set([".txt"]);
+
+function getFileExtension(filePath: string) {
+  const normalizedPath = filePath.toLowerCase();
+  const lastDotIndex = normalizedPath.lastIndexOf(".");
+
+  if (lastDotIndex === -1) {
+    return "";
+  }
+
+  return normalizedPath.slice(lastDotIndex);
+}
 
 function shouldWrapFileContent(filePath: string) {
-  const normalizedPath = filePath.toLowerCase();
-  return [...wrappedFileExtensions].some((extension) =>
-    normalizedPath.endsWith(extension),
-  );
+  return wrappedFileExtensions.has(getFileExtension(filePath));
+}
+
+function getPrettyViewKind(filePath: string): PrettyViewKind | null {
+  const extension = getFileExtension(filePath);
+
+  if (markdownExtensions.has(extension)) {
+    return "markdown";
+  }
+
+  if (plainTextExtensions.has(extension)) {
+    return "text";
+  }
+
+  return null;
+}
+
+function getDefaultViewerMode(filePath: string): ViewerMode {
+  const fileName = filePath.split("/").pop()?.toLowerCase();
+  return fileName === "plan.md" ? "pretty" : "raw";
 }
 
 function useCopyAction() {
@@ -96,12 +128,73 @@ function CopyButton({
   );
 }
 
-function PlanMarkdown({ content }: { content: string }) {
+function PrettyMarkdown({ content }: { content: string }) {
   return (
     <div className="p-6">
       <Streamdown mode="static" isAnimating={false} plugins={streamdownPlugins}>
         {content}
       </Streamdown>
+    </div>
+  );
+}
+
+function PrettyText({ content }: { content: string }) {
+  return (
+    <pre className="overflow-x-auto whitespace-pre-wrap break-words p-6 text-sm leading-6 text-foreground">
+      {content}
+    </pre>
+  );
+}
+
+function PrettyFileContent({
+  content,
+  kind,
+}: {
+  content: string;
+  kind: PrettyViewKind;
+}) {
+  if (kind === "markdown") {
+    return <PrettyMarkdown content={content} />;
+  }
+
+  return <PrettyText content={content} />;
+}
+
+function ViewModeToggle({
+  mode,
+  onModeChange,
+}: {
+  mode: ViewerMode;
+  onModeChange: (mode: ViewerMode) => void;
+}) {
+  return (
+    <div className="flex items-center rounded-md border border-border bg-muted p-0.5">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-pressed={mode === "raw"}
+        onClick={() => onModeChange("raw")}
+        className={cn(
+          "h-6 px-2 text-xs",
+          mode === "raw" && "bg-background shadow-xs hover:bg-background",
+        )}
+      >
+        Raw
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-pressed={mode === "pretty"}
+        onClick={() => onModeChange("pretty")}
+        className={cn(
+          "h-6 px-2 text-xs",
+          mode === "pretty" && "bg-background shadow-xs hover:bg-background",
+        )}
+      >
+        Pretty
+      </Button>
     </div>
   );
 }
@@ -129,9 +222,12 @@ function ViewerBody({
   onAddToPrompt?: (selectedText: string, comment: string) => void;
   response: WorkspaceFileContentResponse | undefined;
 }) {
+  const [viewerMode, setViewerMode] = useState<ViewerMode>(() =>
+    getDefaultViewerMode(filePath),
+  );
   const hasContent = response != null && response.content.length > 0;
-  const fileName = filePath.split("/").pop() ?? filePath;
-  const isPlanFile = fileName.toLowerCase() === "plan.md";
+  const prettyViewKind = getPrettyViewKind(filePath);
+  const supportsPrettyView = prettyViewKind != null;
   const fileOptions = shouldWrapFileContent(filePath)
     ? { ...defaultFileOptions, overflow: "wrap" as const }
     : defaultFileOptions;
@@ -150,6 +246,9 @@ function ViewerBody({
           <CopyButton text={filePath} title="Copy file path" />
         </div>
         <div className="flex items-center gap-1">
+          {supportsPrettyView && (
+            <ViewModeToggle mode={viewerMode} onModeChange={setViewerMode} />
+          )}
           {onOpenInEditor && (
             <Button
               type="button"
@@ -191,7 +290,7 @@ function ViewerBody({
           <CopyButton
             text={response.content}
             title="Copy file contents"
-            className="absolute top-2 right-4 z-10 bg-background/80 backdrop-blur-sm border border-border/60 shadow-sm hover:bg-muted"
+            className="absolute top-2 right-4 z-10 border border-border/60 bg-background/80 shadow-sm backdrop-blur-sm hover:bg-muted"
           />
         )}
         {isLoading ? (
@@ -208,8 +307,11 @@ function ViewerBody({
             <div className="px-4 py-6 text-sm text-muted-foreground">
               This file is empty.
             </div>
-          ) : isPlanFile ? (
-            <PlanMarkdown content={response.content} />
+          ) : viewerMode === "pretty" && prettyViewKind ? (
+            <PrettyFileContent
+              content={response.content}
+              kind={prettyViewKind}
+            />
           ) : (
             <DiffsFile
               file={{ name: filePath, contents: response.content }}
@@ -273,6 +375,7 @@ export function WorkspaceFileViewer({
 
   const body = (
     <ViewerBody
+      key={filePath}
       editorBusy={editorBusy}
       editorDisabledReason={editorDisabledReason}
       errorMessage={errorMessage}


### PR DESCRIPTION
## Summary

Enhances the workspace file viewer with markdown frontmatter stripping and viewer mode toggle functionality. This improves the rendering of markdown files by removing metadata before display and provides users with control over how file content is presented.

## Changes

**File Viewer Features (`chats/[chatId]/workspace-file-viewer.tsx`)**

- Add viewer mode toggle to switch between different file content display modes
- Strip markdown frontmatter before rendering to prevent metadata from appearing in the output
- Expand component logic with 126 new lines to support these features
- Maintain backward compatibility with existing file viewer functionality

---

[Chat](https://open-agents.dev/sessions/ONEmS1ibP71a9RnVr2ibO/chats/cnA33r6eMd22Ay76CpNDz) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)