### PR TITLE
feat: update deps and add Opus 4.7 adaptive thinking support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,18 +136,18 @@
     "zod": "^4.3.6",
   },
   "catalog": {
-    "@ai-sdk/anthropic": "^3.0.69",
+    "@ai-sdk/anthropic": "^3.0.70",
     "@ai-sdk/openai": "^3.0.53",
-    "@ai-sdk/react": "^3.0.163",
-    "ai": "^6.0.161",
+    "@ai-sdk/react": "^3.0.167",
+    "ai": "^6.0.165",
     "zod": "^4.3.6",
   },
   "packages": {
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.69", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.70", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hubTFcfnG3NbrlcDW0tU2fsZhRy/7dF5GCymu4DzBQUYliy2lb7tCeeMhDtFBaYa01qSBHRjkwGnsAdUtDPCwA=="],
 
     "@ai-sdk/elevenlabs": ["@ai-sdk/elevenlabs@2.0.29", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-l4t+kgOtDav2P2BJ50gZfhOYbKcGblnD0U8jXOF3WH3dczYmYfTC7JGH1/MTheurSy6UnhLw7ee4wL6StCTQ+w=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.98", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ol+nP8PIlj8FjN8qKlxhE89N0woqAaGi9CUBGp1boe3RafpphJ7WMuq/RErSvxtwTqje03TP+zIdzP113krxRg=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.102", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-GrwDpaYJiVafrsA1MTbZtXPcQUI67g5AXiJo7Y1F8b+w+SiYHLk3ZIn1YmpQVoVAh2bjvxjj+Vo0AvfskuGH4g=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ=="],
 
@@ -155,7 +155,7 @@
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.163", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.23", "ai": "6.0.161", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-UM8BwNx4YFcG1XIBSTepIGx48RXk974qVSplVZc2JPiY86tC4Qpb8trquh5MdtSKzlS6yrUX46n8gS2WZaUIXQ=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.167", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.23", "ai": "6.0.165", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-9kqVr/FNipduUw60dlhOTJQ3GeQaGp2ZBoJ9qk1zplxY44Csgch6oEpQn06NtumK7L4Ttk26Epshws8Wsa8kUw=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -1003,7 +1003,7 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
-    "ai": ["ai@6.0.161", "", { "dependencies": { "@ai-sdk/gateway": "3.0.98", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ufhmijmx2YyWTPAicGgtpLOB/xD7mG8zKs1pT1Trj+JL/3r1rS8fkMi/cHZoChSAQSGB4pgmcWVxDrVTUvK2IQ=="],
+    "ai": ["ai@6.0.165", "", { "dependencies": { "@ai-sdk/gateway": "3.0.102", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2Qqd0TZudA6p66W3BcK5eh5S5CrbyPPfmnrX50KhgNFVWFCPJcZdm4lQaYDSFRFz6sK8SawsE6xGsuLVhNSIpw=="],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
       "packages/*"
     ],
     "catalog": {
-      "ai": "^6.0.161",
-      "@ai-sdk/anthropic": "^3.0.69",
+      "ai": "^6.0.165",
+      "@ai-sdk/anthropic": "^3.0.70",
       "@ai-sdk/openai": "^3.0.53",
-      "@ai-sdk/react": "^3.0.163",
+      "@ai-sdk/react": "^3.0.167",
       "zod": "^4.3.6"
     }
   },

--- a/packages/agent/models.test.ts
+++ b/packages/agent/models.test.ts
@@ -40,6 +40,41 @@ describe("shouldApplyOpenAIReasoningDefaults", () => {
 });
 
 describe("getProviderOptionsForModel", () => {
+  test("applies adaptive thinking defaults to Anthropic 4.6 models", () => {
+    const result = getProviderOptionsForModel("anthropic/claude-sonnet-4.6");
+
+    expect(result).toEqual({
+      anthropic: {
+        effort: "medium",
+        thinking: { type: "adaptive" },
+      },
+    });
+  });
+
+  test("applies adaptive thinking defaults to Anthropic 4.7 models", () => {
+    const result = getProviderOptionsForModel("anthropic/claude-opus-4.7");
+
+    expect(result).toEqual({
+      anthropic: {
+        effort: "medium",
+        thinking: { type: "adaptive" },
+      },
+    });
+  });
+
+  test("preserves legacy thinking defaults for older Anthropic models", () => {
+    const result = getProviderOptionsForModel("anthropic/claude-opus-4.5");
+
+    expect(result).toEqual({
+      anthropic: {
+        thinking: {
+          type: "enabled",
+          budgetTokens: 8000,
+        },
+      },
+    });
+  });
+
   test("merges OpenAI defaults with custom variant options", () => {
     const result = getProviderOptionsForModel("openai/gpt-5", {
       openai: {

--- a/packages/agent/models.ts
+++ b/packages/agent/models.ts
@@ -10,10 +10,14 @@ import {
 import type { AnthropicLanguageModelOptions } from "@ai-sdk/anthropic";
 import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
 
-// Models with 4.5+ support adaptive thinking with effort control.
+function supportsAdaptiveAnthropicThinking(modelId: string): boolean {
+  return modelId.includes("4.6") || modelId.includes("4.7");
+}
+
+// Models with adaptive thinking support use effort control.
 // Older models use the legacy extended thinking API with a budget.
 function getAnthropicSettings(modelId: string): AnthropicLanguageModelOptions {
-  if (modelId.includes("4.6")) {
+  if (supportsAdaptiveAnthropicThinking(modelId)) {
     return {
       effort: "medium",
       thinking: { type: "adaptive" },


### PR DESCRIPTION
## Summary

Adds support for Claude Opus 4.7 with adaptive thinking capabilities, enabling enhanced reasoning and problem-solving in agent workflows.

## Changes

**Model Configuration (`packages/agent/models.ts`)**

- Add Opus 4.7 model configuration
- Enable adaptive thinking support for new model variant

**Tests (`packages/agent/models.test.ts`)**

- Add comprehensive test coverage for Opus 4.7 adaptive thinking support

---

[Chat](https://open-agents.dev/sessions/hrNerNbB-jvaoVCt6VjRA/chats/1OeKgbZ1hEKZ3TEvZbYhn) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)