### PR TITLE
feat: Prioritize recent repos in the selector

### DIFF
--- a/apps/web/app/api/github/installations/repos/recent/route.ts
+++ b/apps/web/app/api/github/installations/repos/recent/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getInstallationByUserAndId } from "@/lib/db/installations";
+import { getRecentReposByUserId } from "@/lib/db/recent-repos";
+import { listAccessibleInstallationRepositoriesByNames } from "@/lib/github/installation-repos";
+import { getUserGitHubToken } from "@/lib/github/user-token";
+import { getServerSession } from "@/lib/session/get-server-session";
+
+function parseInstallationId(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function parseLimit(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const installationId = parseInstallationId(
+    searchParams.get("installation_id"),
+  );
+  const limit = parseLimit(searchParams.get("limit"));
+
+  if (!installationId) {
+    return NextResponse.json(
+      { error: "installation_id is required" },
+      { status: 400 },
+    );
+  }
+
+  const installation = await getInstallationByUserAndId(
+    session.user.id,
+    installationId,
+  );
+  if (!installation) {
+    return NextResponse.json(
+      { error: "Installation not found" },
+      { status: 403 },
+    );
+  }
+
+  const userToken = await getUserGitHubToken(session.user.id);
+  if (!userToken) {
+    return NextResponse.json(
+      { error: "GitHub not connected" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const recentRepos = await getRecentReposByUserId(session.user.id, {
+      owner: installation.accountLogin,
+      limit,
+    });
+
+    if (recentRepos.length === 0) {
+      return NextResponse.json([]);
+    }
+
+    const accessibleRepos = await listAccessibleInstallationRepositoriesByNames(
+      {
+        installationId,
+        userToken,
+        owner: installation.accountLogin,
+        names: recentRepos.map((repo) => repo.repo),
+      },
+    );
+    const recentByName = new Map(
+      recentRepos.map((repo) => [repo.repo.toLowerCase(), repo]),
+    );
+
+    return NextResponse.json(
+      accessibleRepos.flatMap((repo) => {
+        const recentRepo = recentByName.get(repo.name.toLowerCase());
+        if (!recentRepo) {
+          return [];
+        }
+
+        return [
+          {
+            ...repo,
+            last_used_at: recentRepo.lastUsedAt.toISOString(),
+          },
+        ];
+      }),
+    );
+  } catch (error) {
+    console.error("Failed to fetch recent installation repositories:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch recent repositories" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/sessions/route.test.ts
+++ b/apps/web/app/api/sessions/route.test.ts
@@ -19,7 +19,16 @@ let currentSession: {
 let existingSessionCount = 0;
 let savedLink: VercelProjectSelection | null = null;
 let currentVercelToken: string | null = "vercel-token";
+let currentGitHubToken: string | null = "github-token";
 let matchingProjects: VercelProjectSelection[] = [];
+let currentInstallation: {
+  installationId: number;
+  accountLogin: string;
+} | null = {
+  installationId: 123,
+  accountLogin: "vercel",
+};
+let hasInstallationRepoAccess = true;
 const createCalls: Array<Record<string, unknown>> = [];
 const upsertCalls: Array<Record<string, unknown>> = [];
 
@@ -55,8 +64,20 @@ mock.module("@/lib/db/vercel-project-links", () => ({
   },
 }));
 
+mock.module("@/lib/db/installations", () => ({
+  getInstallationByAccountLogin: async () => currentInstallation,
+}));
+
 mock.module("@/lib/vercel/token", () => ({
   getUserVercelToken: async () => currentVercelToken,
+}));
+
+mock.module("@/lib/github/user-token", () => ({
+  getUserGitHubToken: async () => currentGitHubToken,
+}));
+
+mock.module("@/lib/github/installation-repos", () => ({
+  isInstallationRepositoryAccessible: async () => hasInstallationRepoAccess,
 }));
 
 mock.module("@/lib/vercel/projects", () => ({
@@ -116,7 +137,13 @@ describe("/api/sessions POST vercel project linking", () => {
     existingSessionCount = 0;
     savedLink = null;
     currentVercelToken = "vercel-token";
+    currentGitHubToken = "github-token";
     matchingProjects = [];
+    currentInstallation = {
+      installationId: 123,
+      accountLogin: "vercel",
+    };
+    hasInstallationRepoAccess = true;
     createCalls.length = 0;
     upsertCalls.length = 0;
   });
@@ -326,6 +353,48 @@ describe("/api/sessions POST vercel project linking", () => {
     expect(createCalls[0]).toMatchObject({
       globalSkillRefs: [{ source: "vercel/ai", skillName: "ai-sdk" }],
     });
+  });
+
+  test("rejects repo-backed session creation when the repo is not accessible through the installation", async () => {
+    const { POST } = await routeModulePromise;
+
+    hasInstallationRepoAccess = false;
+
+    const response = await POST(
+      createJsonRequest({
+        repoOwner: "vercel",
+        repoName: "open-harness",
+        branch: "main",
+        cloneUrl: "https://github.com/vercel/open-harness",
+      }),
+    );
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe(
+      "Repository is not available through your GitHub App installation",
+    );
+    expect(createCalls).toHaveLength(0);
+  });
+
+  test("rejects repo-backed session creation when GitHub is not connected", async () => {
+    const { POST } = await routeModulePromise;
+
+    currentGitHubToken = null;
+
+    const response = await POST(
+      createJsonRequest({
+        repoOwner: "vercel",
+        repoName: "open-harness",
+        branch: "main",
+        cloneUrl: "https://github.com/vercel/open-harness",
+      }),
+    );
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("GitHub not connected");
+    expect(createCalls).toHaveLength(0);
   });
 
   test("rejects invalid repository owners", async () => {

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -6,6 +6,7 @@ import {
   getSessionsWithUnreadByUserId,
   getUsedSessionTitles,
 } from "@/lib/db/sessions";
+import { getInstallationByAccountLogin } from "@/lib/db/installations";
 import {
   getVercelProjectLinkByRepo,
   upsertVercelProjectLink,
@@ -16,6 +17,8 @@ import {
   isValidGitHubRepoName,
   isValidGitHubRepoOwner,
 } from "@/lib/github/repo-identifiers";
+import { isInstallationRepositoryAccessible } from "@/lib/github/installation-repos";
+import { getUserGitHubToken } from "@/lib/github/user-token";
 import { getRandomCityName } from "@/lib/random-city";
 import { getServerSession } from "@/lib/session/get-server-session";
 import {
@@ -42,6 +45,9 @@ interface CreateSessionRequest {
   autoCreatePr?: boolean;
   vercelProject?: VercelProjectSelection | null;
 }
+
+const REPO_INSTALLATION_ACCESS_ERROR =
+  "Repository is not available through your GitHub App installation";
 
 function generateBranchName(username: string, name?: string | null): string {
   let initials = "nb";
@@ -85,6 +91,43 @@ function parseNonNegativeInteger(value: string | null): number | null {
   }
 
   return Number(value);
+}
+
+async function validateSessionRepositoryAccess(params: {
+  userId: string;
+  repoOwner: string;
+  repoName: string;
+}): Promise<Response | null> {
+  const installation = await getInstallationByAccountLogin(
+    params.userId,
+    params.repoOwner,
+  );
+  if (!installation) {
+    return Response.json(
+      { error: REPO_INSTALLATION_ACCESS_ERROR },
+      { status: 403 },
+    );
+  }
+
+  const userGitHubToken = await getUserGitHubToken(params.userId);
+  if (!userGitHubToken) {
+    return Response.json({ error: "GitHub not connected" }, { status: 401 });
+  }
+
+  const hasRepoAccess = await isInstallationRepositoryAccessible({
+    installationId: installation.installationId,
+    userToken: userGitHubToken,
+    owner: installation.accountLogin,
+    name: params.repoName,
+  });
+  if (!hasRepoAccess) {
+    return Response.json(
+      { error: REPO_INSTALLATION_ACCESS_ERROR },
+      { status: 403 },
+    );
+  }
+
+  return null;
 }
 
 export async function GET(req: Request) {
@@ -270,6 +313,15 @@ export async function POST(req: Request) {
     let resolvedVercelProject: VercelProjectSelection | null = null;
     const hasRepo = Boolean(repoOwner && repoName);
     if (hasRepo && repoOwner && repoName) {
+      const repoAccessError = await validateSessionRepositoryAccess({
+        userId: session.user.id,
+        repoOwner,
+        repoName,
+      });
+      if (repoAccessError) {
+        return repoAccessError;
+      }
+
       if (explicitVercelProject) {
         const vercelToken = await getUserVercelToken(session.user.id);
         if (!vercelToken) {

--- a/apps/web/components/repo-selector-compact.tsx
+++ b/apps/web/components/repo-selector-compact.tsx
@@ -3,6 +3,7 @@
 import {
   CheckIcon,
   ChevronDown,
+  ChevronRight,
   ExternalLink,
   LockIcon,
   RefreshCw,
@@ -23,6 +24,10 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import {
+  type RecentInstallationRepo,
+  useInstallationRecentRepos,
+} from "@/hooks/use-installation-recent-repos";
 import {
   InstallationRepo,
   useInstallationRepos,
@@ -119,6 +124,39 @@ function SkeletonRow() {
   );
 }
 
+function RepositoryRow({
+  repo,
+  onSelect,
+  metaLabel,
+}: {
+  repo: InstallationRepo | RecentInstallationRepo;
+  onSelect: () => void;
+  metaLabel?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent/30 dark:hover:bg-white/[0.03]">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="truncate text-sm font-medium">{repo.name}</span>
+        {repo.private && (
+          <LockIcon className="size-3 shrink-0 text-muted-foreground" />
+        )}
+        <span className="shrink-0 text-xs text-muted-foreground">
+          ·{" "}
+          {metaLabel ??
+            (repo.updated_at ? formatRelativeDate(repo.updated_at) : "unknown")}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onSelect}
+        className="shrink-0 rounded-md border border-border/70 bg-background px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:border-white/20 dark:bg-white/[0.06] dark:hover:bg-white/10"
+      >
+        Select
+      </button>
+    </div>
+  );
+}
+
 function GitHubActionCard({
   title,
   description,
@@ -162,6 +200,8 @@ export function RepoSelectorCompact({
   const [repoSearch, setRepoSearch] = useState("");
   const [debouncedRepoSearch, setDebouncedRepoSearch] = useState("");
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [recentExpanded, setRecentExpanded] = useState(true);
+  const [allReposExpanded, setAllReposExpanded] = useState(true);
 
   const hasAutoSelectedRef = useRef(false);
 
@@ -196,6 +236,12 @@ export function RepoSelectorCompact({
     installationId: currentInstallation?.installationId ?? null,
     query: debouncedRepoSearch,
     limit: 25,
+  });
+  const showRecentRepos = repoSearch.trim().length === 0;
+  const { repos: recentRepos } = useInstallationRecentRepos({
+    installationId: currentInstallation?.installationId ?? null,
+    enabled: showRecentRepos,
+    limit: 5,
   });
 
   // Sort repos: by updated_at desc if available, otherwise alphabetical
@@ -256,7 +302,14 @@ export function RepoSelectorCompact({
     setRepoSearch("");
   }, [currentOwner]);
 
-  const handleRepoSelect = (repo: InstallationRepo) => {
+  useEffect(() => {
+    setRecentExpanded(true);
+    setAllReposExpanded(true);
+  }, [currentOwner]);
+
+  const handleRepoSelect = (
+    repo: InstallationRepo | RecentInstallationRepo,
+  ) => {
     onSelect(currentOwner, repo.name);
   };
 
@@ -506,44 +559,70 @@ export function RepoSelectorCompact({
           <div className="flex h-full items-center justify-center px-4 text-sm text-muted-foreground">
             {reposError}
           </div>
-        ) : sortedRepos.length === 0 ? (
+        ) : sortedRepos.length === 0 && recentRepos.length === 0 ? (
           <div className="flex h-full items-center justify-center px-4 text-sm text-muted-foreground">
             No repositories found.
           </div>
         ) : (
           <div className="divide-y divide-border/50 dark:divide-white/[0.06]">
-            {sortedRepos.slice(0, 25).map((repo) => (
-              <div
-                key={repo.full_name}
-                className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent/30 dark:hover:bg-white/[0.03]"
-              >
-                <div className="flex min-w-0 flex-1 items-center gap-2">
-                  <span className="truncate text-sm font-medium">
-                    {repo.name}
-                  </span>
-                  {repo.private && (
-                    <LockIcon className="size-3 shrink-0 text-muted-foreground" />
-                  )}
-                  {repo.updated_at && (
-                    <span className="shrink-0 text-xs text-muted-foreground">
-                      · {formatRelativeDate(repo.updated_at)}
-                    </span>
-                  )}
-                </div>
+            {showRecentRepos && recentRepos.length > 0 && (
+              <div className="divide-y divide-border/50 dark:divide-white/[0.06]">
                 <button
                   type="button"
-                  onClick={() => handleRepoSelect(repo)}
-                  className="shrink-0 rounded-md border border-border/70 bg-background px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:border-white/20 dark:bg-white/[0.06] dark:hover:bg-white/10"
+                  onClick={() => setRecentExpanded((expanded) => !expanded)}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground dark:hover:bg-white/[0.03]"
                 >
-                  Select
+                  {recentExpanded ? (
+                    <ChevronDown className="size-3" />
+                  ) : (
+                    <ChevronRight className="size-3" />
+                  )}
+                  <span>Recent repos</span>
                 </button>
-              </div>
-            ))}
-            {sortedRepos.length === 25 && !debouncedRepoSearch && (
-              <div className="px-4 py-2.5 text-center text-xs text-muted-foreground">
-                Showing first 25 results. Use search to narrow.
+                {recentExpanded &&
+                  recentRepos.map((repo) => (
+                    <RepositoryRow
+                      key={`recent-${repo.full_name}`}
+                      repo={repo}
+                      onSelect={() => handleRepoSelect(repo)}
+                      metaLabel={`used ${formatRelativeDate(repo.last_used_at)}`}
+                    />
+                  ))}
               </div>
             )}
+            {showRecentRepos &&
+              recentRepos.length > 0 &&
+              sortedRepos.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setAllReposExpanded((expanded) => !expanded)}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground dark:hover:bg-white/[0.03]"
+                >
+                  {allReposExpanded ? (
+                    <ChevronDown className="size-3" />
+                  ) : (
+                    <ChevronRight className="size-3" />
+                  )}
+                  <span>All repositories</span>
+                </button>
+              )}
+            {(recentRepos.length === 0 || allReposExpanded) &&
+              sortedRepos
+                .slice(0, 25)
+                .map((repo) => (
+                  <RepositoryRow
+                    key={repo.full_name}
+                    repo={repo}
+                    onSelect={() => handleRepoSelect(repo)}
+                  />
+                ))}
+            {(recentRepos.length === 0 || allReposExpanded) &&
+              sortedRepos.length === 25 &&
+              !debouncedRepoSearch && (
+                <div className="px-4 py-2.5 text-center text-xs text-muted-foreground">
+                  Showing first 25 results. Use search to narrow.
+                </div>
+              )}
           </div>
         )}
       </div>

--- a/apps/web/components/repo-selector.tsx
+++ b/apps/web/components/repo-selector.tsx
@@ -3,6 +3,8 @@
 import {
   BookIcon,
   CheckIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
   ChevronsUpDownIcon,
   LockIcon,
   RefreshCw,
@@ -24,6 +26,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { useInstallationRecentRepos } from "@/hooks/use-installation-recent-repos";
 import { useGitHubConnectionStatus } from "@/hooks/use-github-connection-status";
 import { useInstallationRepos } from "@/hooks/use-installation-repos";
 import { useSession } from "@/hooks/use-session";
@@ -70,6 +73,8 @@ export function RepoSelector({
   const [repoSearch, setRepoSearch] = useState("");
   const [debouncedRepoSearch, setDebouncedRepoSearch] = useState("");
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [recentExpanded, setRecentExpanded] = useState(true);
+  const [allReposExpanded, setAllReposExpanded] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const startGitHubInstall = useCallback(() => {
@@ -96,6 +101,12 @@ export function RepoSelector({
     installationId: selectedInstallation?.installationId ?? null,
     query: debouncedRepoSearch,
     limit: 25,
+  });
+  const showRecentRepos = repoSearch.trim().length === 0;
+  const { repos: recentRepos } = useInstallationRecentRepos({
+    installationId: selectedInstallation?.installationId ?? null,
+    enabled: showRecentRepos,
+    limit: 5,
   });
 
   useEffect(() => {
@@ -164,6 +175,11 @@ export function RepoSelector({
 
   useEffect(() => {
     setRepoSearch("");
+  }, [selectedOwner]);
+
+  useEffect(() => {
+    setRecentExpanded(true);
+    setAllReposExpanded(true);
   }, [selectedOwner]);
 
   const handleOwnerSelect = (ownerLogin: string) => {
@@ -321,33 +337,91 @@ export function RepoSelector({
                     ? "Loading..."
                     : "No repositories found."}
               </CommandEmpty>
-              <CommandGroup>
-                {repos.slice(0, 25).map((repo) => (
-                  <CommandItem
-                    key={repo.full_name}
-                    value={repo.name}
-                    onSelect={() => handleRepoSelect(repo.name)}
+              {showRecentRepos && recentRepos.length > 0 && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setRecentExpanded((expanded) => !expanded)}
+                    className="text-muted-foreground flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium uppercase tracking-[0.12em] transition-colors hover:bg-accent hover:text-foreground"
                   >
-                    <CheckIcon
-                      className={cn(
-                        "mr-2 size-4",
-                        selectedRepo === repo.name
-                          ? "opacity-100"
-                          : "opacity-0",
-                      )}
-                    />
-                    <span className="truncate">{repo.name}</span>
-                    {repo.private && (
-                      <LockIcon className="ml-auto size-3 text-muted-foreground" />
+                    {recentExpanded ? (
+                      <ChevronDownIcon className="size-3" />
+                    ) : (
+                      <ChevronRightIcon className="size-3" />
                     )}
-                  </CommandItem>
-                ))}
-                {repos.length === 25 && !debouncedRepoSearch && (
-                  <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                    Showing first 25 results. Use search to narrow.
-                  </div>
+                    <span>Recent repos</span>
+                  </button>
+                  {recentExpanded && (
+                    <CommandGroup>
+                      {recentRepos.map((repo) => (
+                        <CommandItem
+                          key={`recent-${repo.full_name}`}
+                          value={repo.name}
+                          onSelect={() => handleRepoSelect(repo.name)}
+                        >
+                          <CheckIcon
+                            className={cn(
+                              "mr-2 size-4",
+                              selectedRepo === repo.name
+                                ? "opacity-100"
+                                : "opacity-0",
+                            )}
+                          />
+                          <span className="truncate">{repo.name}</span>
+                          {repo.private && (
+                            <LockIcon className="ml-auto size-3 text-muted-foreground" />
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+                </>
+              )}
+              {showRecentRepos &&
+                recentRepos.length > 0 &&
+                repos.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setAllReposExpanded((expanded) => !expanded)}
+                    className="text-muted-foreground flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium uppercase tracking-[0.12em] transition-colors hover:bg-accent hover:text-foreground"
+                  >
+                    {allReposExpanded ? (
+                      <ChevronDownIcon className="size-3" />
+                    ) : (
+                      <ChevronRightIcon className="size-3" />
+                    )}
+                    <span>All repositories</span>
+                  </button>
                 )}
-              </CommandGroup>
+              {(recentRepos.length === 0 || allReposExpanded) && (
+                <CommandGroup>
+                  {repos.slice(0, 25).map((repo) => (
+                    <CommandItem
+                      key={repo.full_name}
+                      value={repo.name}
+                      onSelect={() => handleRepoSelect(repo.name)}
+                    >
+                      <CheckIcon
+                        className={cn(
+                          "mr-2 size-4",
+                          selectedRepo === repo.name
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                      <span className="truncate">{repo.name}</span>
+                      {repo.private && (
+                        <LockIcon className="ml-auto size-3 text-muted-foreground" />
+                      )}
+                    </CommandItem>
+                  ))}
+                  {repos.length === 25 && !debouncedRepoSearch && (
+                    <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                      Showing first 25 results. Use search to narrow.
+                    </div>
+                  )}
+                </CommandGroup>
+              )}
             </CommandList>
           </Command>
         </PopoverContent>

--- a/apps/web/hooks/use-installation-recent-repos.ts
+++ b/apps/web/hooks/use-installation-recent-repos.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useMemo } from "react";
+import useSWR from "swr";
+import { z } from "zod";
+import { fetcher } from "@/lib/swr";
+
+const recentInstallationRepoSchema = z.object({
+  name: z.string(),
+  full_name: z.string(),
+  description: z.string().nullable(),
+  private: z.boolean(),
+  updated_at: z.string(),
+  last_used_at: z.string(),
+});
+
+const recentInstallationReposSchema = z.array(recentInstallationRepoSchema);
+
+export type RecentInstallationRepo = z.infer<
+  typeof recentInstallationRepoSchema
+>;
+
+interface UseInstallationRecentReposOptions {
+  installationId: number | null;
+  limit?: number;
+  enabled?: boolean;
+}
+
+async function fetchRecentInstallationRepos(
+  url: string,
+): Promise<RecentInstallationRepo[]> {
+  const json = await fetcher<unknown>(url);
+  const parsed = recentInstallationReposSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error("Invalid recent repositories response");
+  }
+
+  return parsed.data;
+}
+
+export function useInstallationRecentRepos({
+  installationId,
+  limit = 5,
+  enabled = true,
+}: UseInstallationRecentReposOptions) {
+  const reposUrl = useMemo(() => {
+    if (!enabled || !installationId) {
+      return null;
+    }
+
+    const params = new URLSearchParams({
+      installation_id: `${installationId}`,
+      limit: `${limit}`,
+    });
+
+    return `/api/github/installations/repos/recent?${params.toString()}`;
+  }, [enabled, installationId, limit]);
+
+  const { data, error, isLoading } = useSWR<RecentInstallationRepo[]>(
+    reposUrl,
+    fetchRecentInstallationRepos,
+    {
+      dedupingInterval: 5_000,
+    },
+  );
+
+  return {
+    repos: data ?? [],
+    isLoading,
+    error: error?.message ?? null,
+  };
+}

--- a/apps/web/lib/db/recent-repos.ts
+++ b/apps/web/lib/db/recent-repos.ts
@@ -1,0 +1,83 @@
+import { and, asc, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { db } from "./client";
+import { sessions } from "./schema";
+
+export interface RecentRepoRecord {
+  owner: string;
+  repo: string;
+  lastUsedAt: Date;
+}
+
+interface GetRecentReposByUserIdOptions {
+  owner?: string;
+  limit?: number;
+}
+
+function normalizeRecentRepoDate(value: Date | string): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function normalizeLimit(limit?: number): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) {
+    return 5;
+  }
+
+  return Math.max(1, Math.min(limit, 20));
+}
+
+export async function getRecentReposByUserId(
+  userId: string,
+  options?: GetRecentReposByUserIdOptions,
+): Promise<RecentRepoRecord[]> {
+  const normalizedLimit = normalizeLimit(options?.limit);
+  const ownerFilter = options?.owner?.trim().toLowerCase();
+  const lastUsedAt =
+    sql<Date>`max(coalesce(${sessions.lastActivityAt}, ${sessions.createdAt}))`.as(
+      "last_used_at",
+    );
+
+  const rows = await db
+    .select({
+      owner: sessions.repoOwner,
+      repo: sessions.repoName,
+      lastUsedAt,
+    })
+    .from(sessions)
+    .where(
+      and(
+        eq(sessions.userId, userId),
+        isNotNull(sessions.repoOwner),
+        isNotNull(sessions.repoName),
+        ownerFilter
+          ? sql`lower(${sessions.repoOwner}) = ${ownerFilter}`
+          : undefined,
+      ),
+    )
+    .groupBy(sessions.repoOwner, sessions.repoName)
+    .orderBy(desc(lastUsedAt), asc(sessions.repoOwner), asc(sessions.repoName))
+    .limit(normalizedLimit);
+
+  return rows.flatMap((row) => {
+    if (!row.owner || !row.repo) {
+      return [];
+    }
+
+    const lastUsedAtDate = normalizeRecentRepoDate(row.lastUsedAt);
+    if (!lastUsedAtDate) {
+      return [];
+    }
+
+    return [
+      {
+        owner: row.owner,
+        repo: row.repo,
+        lastUsedAt: lastUsedAtDate,
+      },
+    ];
+  });
+}

--- a/apps/web/lib/github/installation-repos.test.ts
+++ b/apps/web/lib/github/installation-repos.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { listUserInstallationRepositories } from "./installation-repos";
+import {
+  isInstallationRepositoryAccessible,
+  listAccessibleInstallationRepositoriesByNames,
+  listUserInstallationRepositories,
+} from "./installation-repos";
 
 const originalFetch = globalThis.fetch;
 
@@ -129,5 +133,68 @@ describe("installation-repos", () => {
 
     expect(repos.map((repo) => repo.name)).toEqual(["docs-site", "docs"]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("matches recent repo names against installation-scoped access and preserves request order", async () => {
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = new URL(input.toString());
+      const page = url.searchParams.get("page");
+
+      if (page === "1") {
+        return Response.json({
+          repositories: createPage(
+            [
+              createRepository("alpha", "2024-01-01T00:00:00Z"),
+              createRepository("gamma", "2024-03-01T00:00:00Z"),
+            ],
+            1,
+          ),
+        });
+      }
+
+      return Response.json({
+        repositories: [createRepository("beta", "2024-02-01T00:00:00Z")],
+      });
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const repos = await listAccessibleInstallationRepositoriesByNames({
+      installationId: 123,
+      userToken: "token",
+      owner: "acme",
+      names: ["beta", "alpha", "beta", "missing"],
+    });
+
+    expect(repos.map((repo) => repo.name)).toEqual(["beta", "alpha"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("checks installation-scoped access for a single repository name", async () => {
+    const fetchMock = mock(async () =>
+      Response.json({
+        repositories: [createRepository("alpha", "2024-01-01T00:00:00Z")],
+      }),
+    );
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      isInstallationRepositoryAccessible({
+        installationId: 123,
+        userToken: "token",
+        owner: "acme",
+        name: "alpha",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      isInstallationRepositoryAccessible({
+        installationId: 123,
+        userToken: "token",
+        owner: "acme",
+        name: "beta",
+      }),
+    ).resolves.toBe(false);
   });
 });

--- a/apps/web/lib/github/installation-repos.ts
+++ b/apps/web/lib/github/installation-repos.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 const INSTALLATION_REPOS_MAX_PAGES = 20;
+const INSTALLATION_REPOS_PER_PAGE = 25;
 
 const installationRepoSchema = z.object({
   name: z.string(),
@@ -37,6 +38,13 @@ interface ListUserInstallationRepositoriesOptions {
   limit?: number;
 }
 
+interface ListAccessibleInstallationRepositoriesByNamesOptions {
+  installationId: number;
+  userToken: string;
+  owner?: string;
+  names: string[];
+}
+
 function normalizeLimit(limit?: number): number {
   if (typeof limit !== "number" || !Number.isFinite(limit)) {
     return 50;
@@ -65,6 +73,44 @@ function compareRepositoriesByRecentActivity(
   return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
 }
 
+async function fetchInstallationRepositoriesPage(params: {
+  installationId: number;
+  userToken: string;
+  page: number;
+  perPage?: number;
+}): Promise<z.infer<typeof installationReposResponseSchema>> {
+  const endpoint = new URL(
+    `https://api.github.com/user/installations/${params.installationId}/repositories`,
+  );
+  endpoint.searchParams.set(
+    "per_page",
+    `${params.perPage ?? INSTALLATION_REPOS_PER_PAGE}`,
+  );
+  endpoint.searchParams.set("page", `${params.page}`);
+
+  const response = await fetch(endpoint, {
+    headers: {
+      Authorization: `Bearer ${params.userToken}`,
+      Accept: "application/vnd.github.v3+json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to fetch user installation repositories: ${response.status} ${body}`,
+    );
+  }
+
+  const json = await response.json();
+  const parsed = installationReposResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error("Invalid GitHub user installation repositories response");
+  }
+
+  return parsed.data;
+}
+
 /**
  * List repositories accessible to the user through a specific GitHub App
  * installation. Uses the user's OAuth token so GitHub computes the
@@ -80,43 +126,20 @@ export async function listUserInstallationRepositories({
   const ownerFilter = owner?.trim().toLowerCase();
   const queryFilter = query?.trim().toLowerCase();
   const normalizedLimit = normalizeLimit(limit);
-
-  const perPage = 25;
-  const maxPages = INSTALLATION_REPOS_MAX_PAGES;
   const matchedRepos: z.infer<typeof installationRepoSchema>[] = [];
 
-  for (let page = 1; page <= maxPages; page++) {
-    const endpoint = new URL(
-      `https://api.github.com/user/installations/${installationId}/repositories`,
-    );
-    endpoint.searchParams.set("per_page", `${perPage}`);
-    endpoint.searchParams.set("page", `${page}`);
-
-    const response = await fetch(endpoint, {
-      headers: {
-        Authorization: `Bearer ${userToken}`,
-        Accept: "application/vnd.github.v3+json",
-      },
+  for (let page = 1; page <= INSTALLATION_REPOS_MAX_PAGES; page++) {
+    const data = await fetchInstallationRepositoriesPage({
+      installationId,
+      userToken,
+      page,
     });
 
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(
-        `Failed to fetch user installation repositories: ${response.status} ${body}`,
-      );
-    }
-
-    const json = await response.json();
-    const parsed = installationReposResponseSchema.safeParse(json);
-    if (!parsed.success) {
-      throw new Error("Invalid GitHub user installation repositories response");
-    }
-
-    if (parsed.data.repositories.length === 0) {
+    if (data.repositories.length === 0) {
       break;
     }
 
-    const pageMatches = parsed.data.repositories.filter((repo) => {
+    const pageMatches = data.repositories.filter((repo) => {
       const matchesOwner = ownerFilter
         ? repo.owner.login.toLowerCase() === ownerFilter
         : true;
@@ -134,7 +157,7 @@ export async function listUserInstallationRepositories({
       break;
     }
 
-    if (parsed.data.repositories.length < perPage) {
+    if (data.repositories.length < INSTALLATION_REPOS_PER_PAGE) {
       break;
     }
   }
@@ -150,4 +173,98 @@ export async function listUserInstallationRepositories({
     updated_at: repo.updated_at,
     language: repo.language,
   }));
+}
+
+export async function listAccessibleInstallationRepositoriesByNames({
+  installationId,
+  userToken,
+  owner,
+  names,
+}: ListAccessibleInstallationRepositoriesByNamesOptions): Promise<
+  InstallationRepository[]
+> {
+  const ownerFilter = owner?.trim().toLowerCase();
+  const orderedNames = names
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+  const requestedOrder = new Map<string, number>();
+
+  for (const name of orderedNames) {
+    const normalizedName = name.toLowerCase();
+    if (!requestedOrder.has(normalizedName)) {
+      requestedOrder.set(normalizedName, requestedOrder.size);
+    }
+  }
+
+  if (requestedOrder.size === 0) {
+    return [];
+  }
+
+  const foundRepos = new Map<string, InstallationRepository>();
+
+  for (let page = 1; page <= INSTALLATION_REPOS_MAX_PAGES; page++) {
+    const data = await fetchInstallationRepositoriesPage({
+      installationId,
+      userToken,
+      page,
+    });
+
+    if (data.repositories.length === 0) {
+      break;
+    }
+
+    for (const repo of data.repositories) {
+      if (ownerFilter && repo.owner.login.toLowerCase() !== ownerFilter) {
+        continue;
+      }
+
+      const normalizedName = repo.name.toLowerCase();
+      if (
+        requestedOrder.has(normalizedName) &&
+        !foundRepos.has(normalizedName)
+      ) {
+        foundRepos.set(normalizedName, {
+          name: repo.name,
+          full_name: repo.full_name,
+          description: repo.description,
+          private: repo.private,
+          clone_url: repo.clone_url,
+          updated_at: repo.updated_at,
+          language: repo.language,
+        });
+      }
+    }
+
+    if (foundRepos.size >= requestedOrder.size) {
+      break;
+    }
+
+    if (data.repositories.length < INSTALLATION_REPOS_PER_PAGE) {
+      break;
+    }
+  }
+
+  return [...foundRepos.entries()]
+    .toSorted(
+      ([nameA], [nameB]) =>
+        (requestedOrder.get(nameA) ?? Number.MAX_SAFE_INTEGER) -
+        (requestedOrder.get(nameB) ?? Number.MAX_SAFE_INTEGER),
+    )
+    .map(([, repo]) => repo);
+}
+
+export async function isInstallationRepositoryAccessible(params: {
+  installationId: number;
+  userToken: string;
+  owner?: string;
+  name: string;
+}): Promise<boolean> {
+  const repos = await listAccessibleInstallationRepositoriesByNames({
+    installationId: params.installationId,
+    userToken: params.userToken,
+    owner: params.owner,
+    names: [params.name],
+  });
+
+  return repos.length > 0;
 }


### PR DESCRIPTION
fixes #792

### Summary

This keeps GET /user/installations/{installation_id}/repositories as the source of truth for accessible repos, adds a small Recent repos section based on the current user’s own session history, and revalidates repo access on the server before creating a session.

---

### What changed
* Added recent-repo lookup based on the user’s existing session history
* Scoped recent repos to the selected installation owner/account
* Filtered recent repos against installation-accessible repositories before showing them
* Kept the full fallback list powered by installation-scoped GitHub App access
* Added final server-side repo access validation in session creation
* Updated the repo selector UI to show:
  * Recent repos
  * All repositories
* Made both sections collapsible


<img width="3024" height="1964" alt="Screenshot 2026-04-17 at 3 18 52 PM" src="https://github.com/user-attachments/assets/c0bf83c9-8999-4f1c-ac5c-977b8e314958" />

---

### Notes
* Recent repos are derived from the current user’s own session history, not GitHub push activity




