### PR TITLE
feat: add Vercel token staleness validation to auth info endpoint

### DIFF
--- a/apps/web/app/api/auth/info/route.test.ts
+++ b/apps/web/app/api/auth/info/route.test.ts
@@ -133,6 +133,21 @@ describe("GET /api/auth/info", () => {
     });
   });
 
+  test("keeps Vercel sessions connected when validation aborts", async () => {
+    const abortError = new Error("The operation was aborted.");
+    abortError.name = "AbortError";
+    fetchMock.mockRejectedValueOnce(abortError);
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      authProvider: "vercel",
+      vercelReconnectRequired: false,
+    });
+  });
+
   test("keeps Vercel sessions connected when the token validates", async () => {
     const { GET } = await routeModulePromise;
 

--- a/apps/web/app/api/auth/info/route.test.ts
+++ b/apps/web/app/api/auth/info/route.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NextRequest } from "next/server";
+import { SESSION_COOKIE_NAME } from "@/lib/session/constants";
+
+const deletedCookies: string[] = [];
+
+type TestSession = {
+  authProvider: "vercel" | "github";
+  user: {
+    id: string;
+    username: string;
+    email?: string;
+    avatar: string;
+  };
+} | null;
+
+let session: TestSession;
+let exists = true;
+let githubAccount: { id: string } | null = null;
+let installations: Array<{ installationId: number }> = [];
+let vercelToken: string | null = null;
+const fetchMock = mock(async () => new Response(null, { status: 200 }));
+const originalFetch = globalThis.fetch;
+
+mock.module("next/headers", () => ({
+  cookies: async () => ({
+    delete: (name: string) => {
+      deletedCookies.push(name);
+    },
+  }),
+}));
+
+mock.module("@/lib/session/server", () => ({
+  getSessionFromReq: async () => session,
+}));
+
+mock.module("@/lib/db/users", () => ({
+  userExists: async () => exists,
+}));
+
+mock.module("@/lib/db/accounts", () => ({
+  getGitHubAccount: async () => githubAccount,
+}));
+
+mock.module("@/lib/db/installations", () => ({
+  getInstallationsByUserId: async () => installations,
+}));
+
+mock.module("@/lib/vercel/token", () => ({
+  getUserVercelToken: async () => vercelToken,
+}));
+
+const routeModulePromise = import("./route");
+
+function createRequest(): NextRequest {
+  return {
+    nextUrl: new URL("http://localhost/api/auth/info"),
+    url: "http://localhost/api/auth/info",
+  } as NextRequest;
+}
+
+describe("GET /api/auth/info", () => {
+  beforeEach(() => {
+    session = {
+      authProvider: "vercel",
+      user: {
+        id: "user-1",
+        username: "vercel-user",
+        email: "person@example.com",
+        avatar: "https://example.com/avatar.png",
+      },
+    };
+    exists = true;
+    githubAccount = null;
+    installations = [];
+    vercelToken = "vercel-token";
+    deletedCookies.length = 0;
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns unauthenticated when there is no session", async () => {
+    session = null;
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("clears the session cookie when the user record is gone", async () => {
+    exists = false;
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+    expect(deletedCookies).toEqual([SESSION_COOKIE_NAME]);
+  });
+
+  test("flags reconnect when the Vercel token is unavailable", async () => {
+    vercelToken = null;
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      authProvider: "vercel",
+      vercelReconnectRequired: true,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("flags reconnect when Vercel rejects the saved token", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      authProvider: "vercel",
+      vercelReconnectRequired: true,
+    });
+  });
+
+  test("keeps Vercel sessions connected when the token validates", async () => {
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      authProvider: "vercel",
+      vercelReconnectRequired: false,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/api/auth/info/route.ts
+++ b/apps/web/app/api/auth/info/route.ts
@@ -10,12 +10,19 @@ import { getUserVercelToken } from "@/lib/vercel/token";
 
 const UNAUTHENTICATED: SessionUserInfo = { user: undefined };
 const VERCEL_USERINFO_URL = "https://api.vercel.com/login/oauth/userinfo";
+const VERCEL_USERINFO_TIMEOUT_MS = 3_000;
 
 async function requiresVercelReconnect(userId: string): Promise<boolean> {
   const token = await getUserVercelToken(userId);
   if (!token) {
     return true;
   }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    VERCEL_USERINFO_TIMEOUT_MS,
+  );
 
   try {
     const response = await fetch(VERCEL_USERINFO_URL, {
@@ -24,6 +31,7 @@ async function requiresVercelReconnect(userId: string): Promise<boolean> {
         Accept: "application/json",
       },
       cache: "no-store",
+      signal: controller.signal,
     });
 
     if (response.ok) {
@@ -43,8 +51,15 @@ async function requiresVercelReconnect(userId: string): Promise<boolean> {
     );
     return false;
   } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      console.error("Timed out validating Vercel connection status");
+      return false;
+    }
+
     console.error("Failed to validate Vercel connection status:", error);
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/apps/web/app/api/auth/info/route.ts
+++ b/apps/web/app/api/auth/info/route.ts
@@ -6,8 +6,47 @@ import { userExists } from "@/lib/db/users";
 import { SESSION_COOKIE_NAME } from "@/lib/session/constants";
 import { getSessionFromReq } from "@/lib/session/server";
 import type { SessionUserInfo } from "@/lib/session/types";
+import { getUserVercelToken } from "@/lib/vercel/token";
 
 const UNAUTHENTICATED: SessionUserInfo = { user: undefined };
+const VERCEL_USERINFO_URL = "https://api.vercel.com/login/oauth/userinfo";
+
+async function requiresVercelReconnect(userId: string): Promise<boolean> {
+  const token = await getUserVercelToken(userId);
+  if (!token) {
+    return true;
+  }
+
+  try {
+    const response = await fetch(VERCEL_USERINFO_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+      cache: "no-store",
+    });
+
+    if (response.ok) {
+      return false;
+    }
+
+    if (
+      response.status === 400 ||
+      response.status === 401 ||
+      response.status === 403
+    ) {
+      return true;
+    }
+
+    console.error(
+      `Failed to validate Vercel connection status: ${response.status} ${response.statusText}`,
+    );
+    return false;
+  } catch (error) {
+    console.error("Failed to validate Vercel connection status:", error);
+    return false;
+  }
+}
 
 export async function GET(req: NextRequest) {
   const session = await getSessionFromReq(req);
@@ -16,13 +55,20 @@ export async function GET(req: NextRequest) {
     return Response.json(UNAUTHENTICATED);
   }
 
-  // Run the user-existence check in parallel with the GitHub queries
+  const vercelReconnectPromise =
+    session.authProvider === "vercel"
+      ? requiresVercelReconnect(session.user.id)
+      : Promise.resolve(false);
+
+  // Run the user-existence check in parallel with the connection queries
   // so there is zero added latency on the happy path.
-  const [exists, ghAccount, installations] = await Promise.all([
-    userExists(session.user.id),
-    getGitHubAccount(session.user.id),
-    getInstallationsByUserId(session.user.id),
-  ]);
+  const [exists, ghAccount, installations, vercelReconnectRequired] =
+    await Promise.all([
+      userExists(session.user.id),
+      getGitHubAccount(session.user.id),
+      getInstallationsByUserId(session.user.id),
+      vercelReconnectPromise,
+    ]);
 
   // The session cookie (JWE) is self-contained and can outlive the user record.
   // If the user no longer exists, clear the stale cookie.
@@ -42,6 +88,7 @@ export async function GET(req: NextRequest) {
     hasGitHub,
     hasGitHubAccount,
     hasGitHubInstallations,
+    vercelReconnectRequired,
   };
 
   return Response.json(data);

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -11,13 +11,15 @@ import {
   useRef,
   useState,
 } from "react";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
 import { SWRConfig } from "swr";
 import { GitHubReconnectGate } from "@/components/github-reconnect-gate";
 import { useSession } from "@/hooks/use-session";
 import { FetchError } from "@/lib/swr";
 
 const THEME_STORAGE_KEY = "open-agents-theme";
+const VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY =
+  "open-agents-vercel-reconnect-attempt";
 const DARK_MODE_MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
 export type ThemePreference = "light" | "dark" | "system";
@@ -55,6 +57,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const signingOut = useRef(false);
   const vercelReconnectRedirecting = useRef(false);
+  const vercelReconnectFailureNotifiedFor = useRef<string | null>(null);
   const { session, loading: sessionLoading } = useSession();
   const [theme, setThemeState] = useState<ThemePreference>("system");
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("dark");
@@ -103,16 +106,46 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   useEffect(() => {
-    if (
-      sessionLoading ||
-      vercelReconnectRedirecting.current ||
-      session?.authProvider !== "vercel" ||
-      !session.vercelReconnectRequired
-    ) {
+    if (sessionLoading) {
       return;
     }
 
+    const reconnectAttemptedUserId = window.sessionStorage.getItem(
+      VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY,
+    );
+
+    if (
+      session?.authProvider !== "vercel" ||
+      !session?.user?.id ||
+      !session.vercelReconnectRequired
+    ) {
+      window.sessionStorage.removeItem(VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY);
+      vercelReconnectRedirecting.current = false;
+      vercelReconnectFailureNotifiedFor.current = null;
+      return;
+    }
+
+    if (vercelReconnectRedirecting.current) {
+      return;
+    }
+
+    if (reconnectAttemptedUserId === session.user.id) {
+      if (vercelReconnectFailureNotifiedFor.current !== session.user.id) {
+        vercelReconnectFailureNotifiedFor.current = session.user.id;
+        toast.error(
+          "Couldn't refresh your Vercel session. Sign out and sign back in to retry.",
+        );
+      }
+      return;
+    }
+
+    window.sessionStorage.setItem(
+      VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY,
+      session.user.id,
+    );
+    vercelReconnectFailureNotifiedFor.current = null;
     vercelReconnectRedirecting.current = true;
+
     const next = `${window.location.pathname}${window.location.search}`;
     window.location.assign(
       `/api/auth/signin/vercel?next=${encodeURIComponent(next)}`,

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -14,6 +14,7 @@ import {
 import { Toaster } from "sonner";
 import { SWRConfig } from "swr";
 import { GitHubReconnectGate } from "@/components/github-reconnect-gate";
+import { useSession } from "@/hooks/use-session";
 import { FetchError } from "@/lib/swr";
 
 const THEME_STORAGE_KEY = "open-agents-theme";
@@ -53,6 +54,8 @@ function applyTheme(resolvedTheme: ResolvedTheme) {
 export function Providers({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const signingOut = useRef(false);
+  const vercelReconnectRedirecting = useRef(false);
+  const { session, loading: sessionLoading } = useSession();
   const [theme, setThemeState] = useState<ThemePreference>("system");
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("dark");
 
@@ -98,6 +101,23 @@ export function Providers({ children }: { children: React.ReactNode }) {
     },
     [applyThemePreference],
   );
+
+  useEffect(() => {
+    if (
+      sessionLoading ||
+      vercelReconnectRedirecting.current ||
+      session?.authProvider !== "vercel" ||
+      !session.vercelReconnectRequired
+    ) {
+      return;
+    }
+
+    vercelReconnectRedirecting.current = true;
+    const next = `${window.location.pathname}${window.location.search}`;
+    window.location.assign(
+      `/api/auth/signin/vercel?next=${encodeURIComponent(next)}`,
+    );
+  }, [session, sessionLoading]);
 
   const handleError = useCallback(
     (error: Error) => {

--- a/apps/web/lib/session/types.ts
+++ b/apps/web/lib/session/types.ts
@@ -16,4 +16,5 @@ export interface SessionUserInfo {
   hasGitHub?: boolean;
   hasGitHubAccount?: boolean;
   hasGitHubInstallations?: boolean;
+  vercelReconnectRequired?: boolean;
 }


### PR DESCRIPTION
## Summary

Add Vercel token staleness validation to the auth info endpoint and check token freshness as part of the authentication flow.

## Changes

**API (`apps/web/app/api/auth/info/route.ts`)**

- Add Vercel token validation logic to auth info endpoint
- Return token staleness information in response
- Implement token refresh mechanism when needed

**Tests (`apps/web/app/api/auth/info/route.test.ts`)**

- Add comprehensive test suite for Vercel token validation (148 lines)
- Test token staleness detection scenarios
- Test various token states and error handling

**Providers (`apps/web/app/providers.tsx`)**

- Update provider configuration to support token validation checks

**Types (`apps/web/lib/session/types.ts`)**

- Add type definitions for token staleness information

---

[Chat](https://open-agents.dev/sessions/uNa0eMWpkWwwGOtgQDcu7/chats/lcilQpwAbuYdFCKHhB3Tk) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)