### PR TITLE
fix: improve Vercel session revalidation with connection status tracking

### DIFF
--- a/apps/web/app/api/auth/info/route.test.ts
+++ b/apps/web/app/api/auth/info/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { NextRequest } from "next/server";
 import { SESSION_COOKIE_NAME } from "@/lib/session/constants";
 
@@ -18,9 +18,6 @@ let session: TestSession;
 let exists = true;
 let githubAccount: { id: string } | null = null;
 let installations: Array<{ installationId: number }> = [];
-let vercelToken: string | null = null;
-const fetchMock = mock(async () => new Response(null, { status: 200 }));
-const originalFetch = globalThis.fetch;
 
 mock.module("next/headers", () => ({
   cookies: async () => ({
@@ -46,10 +43,6 @@ mock.module("@/lib/db/installations", () => ({
   getInstallationsByUserId: async () => installations,
 }));
 
-mock.module("@/lib/vercel/token", () => ({
-  getUserVercelToken: async () => vercelToken,
-}));
-
 const routeModulePromise = import("./route");
 
 function createRequest(): NextRequest {
@@ -73,15 +66,7 @@ describe("GET /api/auth/info", () => {
     exists = true;
     githubAccount = null;
     installations = [];
-    vercelToken = "vercel-token";
     deletedCookies.length = 0;
-    fetchMock.mockClear();
-    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
   });
 
   test("returns unauthenticated when there is no session", async () => {
@@ -92,7 +77,6 @@ describe("GET /api/auth/info", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({});
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("clears the session cookie when the user record is gone", async () => {
@@ -106,58 +90,35 @@ describe("GET /api/auth/info", () => {
     expect(deletedCookies).toEqual([SESSION_COOKIE_NAME]);
   });
 
-  test("flags reconnect when the Vercel token is unavailable", async () => {
-    vercelToken = null;
+  test("reports GitHub account and installation state", async () => {
+    githubAccount = { id: "github-account-1" };
+    installations = [{ installationId: 1 }];
     const { GET } = await routeModulePromise;
 
     const response = await GET(createRequest());
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
+      user: session?.user,
       authProvider: "vercel",
-      vercelReconnectRequired: true,
-    });
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("flags reconnect when Vercel rejects the saved token", async () => {
-    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
-    const { GET } = await routeModulePromise;
-
-    const response = await GET(createRequest());
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      authProvider: "vercel",
-      vercelReconnectRequired: true,
+      hasGitHub: true,
+      hasGitHubAccount: true,
+      hasGitHubInstallations: true,
     });
   });
 
-  test("keeps Vercel sessions connected when validation aborts", async () => {
-    const abortError = new Error("The operation was aborted.");
-    abortError.name = "AbortError";
-    fetchMock.mockRejectedValueOnce(abortError);
+  test("reports missing GitHub connection state", async () => {
     const { GET } = await routeModulePromise;
 
     const response = await GET(createRequest());
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
+      user: session?.user,
       authProvider: "vercel",
-      vercelReconnectRequired: false,
+      hasGitHub: false,
+      hasGitHubAccount: false,
+      hasGitHubInstallations: false,
     });
-  });
-
-  test("keeps Vercel sessions connected when the token validates", async () => {
-    const { GET } = await routeModulePromise;
-
-    const response = await GET(createRequest());
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      authProvider: "vercel",
-      vercelReconnectRequired: false,
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/app/api/auth/info/route.ts
+++ b/apps/web/app/api/auth/info/route.ts
@@ -6,62 +6,8 @@ import { userExists } from "@/lib/db/users";
 import { SESSION_COOKIE_NAME } from "@/lib/session/constants";
 import { getSessionFromReq } from "@/lib/session/server";
 import type { SessionUserInfo } from "@/lib/session/types";
-import { getUserVercelToken } from "@/lib/vercel/token";
 
 const UNAUTHENTICATED: SessionUserInfo = { user: undefined };
-const VERCEL_USERINFO_URL = "https://api.vercel.com/login/oauth/userinfo";
-const VERCEL_USERINFO_TIMEOUT_MS = 3_000;
-
-async function requiresVercelReconnect(userId: string): Promise<boolean> {
-  const token = await getUserVercelToken(userId);
-  if (!token) {
-    return true;
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(
-    () => controller.abort(),
-    VERCEL_USERINFO_TIMEOUT_MS,
-  );
-
-  try {
-    const response = await fetch(VERCEL_USERINFO_URL, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-      },
-      cache: "no-store",
-      signal: controller.signal,
-    });
-
-    if (response.ok) {
-      return false;
-    }
-
-    if (
-      response.status === 400 ||
-      response.status === 401 ||
-      response.status === 403
-    ) {
-      return true;
-    }
-
-    console.error(
-      `Failed to validate Vercel connection status: ${response.status} ${response.statusText}`,
-    );
-    return false;
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      console.error("Timed out validating Vercel connection status");
-      return false;
-    }
-
-    console.error("Failed to validate Vercel connection status:", error);
-    return false;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
 
 export async function GET(req: NextRequest) {
   const session = await getSessionFromReq(req);
@@ -70,20 +16,13 @@ export async function GET(req: NextRequest) {
     return Response.json(UNAUTHENTICATED);
   }
 
-  const vercelReconnectPromise =
-    session.authProvider === "vercel"
-      ? requiresVercelReconnect(session.user.id)
-      : Promise.resolve(false);
-
-  // Run the user-existence check in parallel with the connection queries
+  // Run the user-existence check in parallel with the GitHub queries
   // so there is zero added latency on the happy path.
-  const [exists, ghAccount, installations, vercelReconnectRequired] =
-    await Promise.all([
-      userExists(session.user.id),
-      getGitHubAccount(session.user.id),
-      getInstallationsByUserId(session.user.id),
-      vercelReconnectPromise,
-    ]);
+  const [exists, ghAccount, installations] = await Promise.all([
+    userExists(session.user.id),
+    getGitHubAccount(session.user.id),
+    getInstallationsByUserId(session.user.id),
+  ]);
 
   // The session cookie (JWE) is self-contained and can outlive the user record.
   // If the user no longer exists, clear the stale cookie.
@@ -103,7 +42,6 @@ export async function GET(req: NextRequest) {
     hasGitHub,
     hasGitHubAccount,
     hasGitHubInstallations,
-    vercelReconnectRequired,
   };
 
   return Response.json(data);

--- a/apps/web/app/api/vercel/connection-status/route.test.ts
+++ b/apps/web/app/api/vercel/connection-status/route.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+type AuthSession = {
+  authProvider: "vercel" | "github";
+  user: {
+    id: string;
+  };
+} | null;
+
+let authSession: AuthSession;
+let vercelToken: string | null;
+const fetchMock = mock(async () => new Response(null, { status: 200 }));
+const originalFetch = globalThis.fetch;
+
+mock.module("@/lib/session/get-server-session", () => ({
+  getServerSession: async () => authSession,
+}));
+
+mock.module("@/lib/vercel/token", () => ({
+  getUserVercelToken: async () => vercelToken,
+}));
+
+const routeModulePromise = import("./route");
+
+describe("GET /api/vercel/connection-status", () => {
+  beforeEach(() => {
+    authSession = { authProvider: "vercel", user: { id: "user-1" } };
+    vercelToken = "vercel-token";
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns 401 when unauthenticated", async () => {
+    authSession = null;
+    const { GET } = await routeModulePromise;
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("stays connected for non-Vercel sessions", async () => {
+    authSession = { authProvider: "github", user: { id: "user-1" } };
+    const { GET } = await routeModulePromise;
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "connected",
+      reason: null,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("requires reconnect when no usable token is available", async () => {
+    vercelToken = null;
+    const { GET } = await routeModulePromise;
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "reconnect_required",
+      reason: "token_unavailable",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("requires reconnect when Vercel rejects the saved token", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    const { GET } = await routeModulePromise;
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "reconnect_required",
+      reason: "userinfo_auth_failed",
+    });
+  });
+
+  test("stays connected when validation aborts", async () => {
+    const abortError = new Error("The operation was aborted.");
+    abortError.name = "AbortError";
+    fetchMock.mockRejectedValueOnce(abortError);
+    const { GET } = await routeModulePromise;
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "connected",
+      reason: null,
+    });
+  });
+
+  test("stays connected when the token validates", async () => {
+    const { GET } = await routeModulePromise;
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "connected",
+      reason: null,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/api/vercel/connection-status/route.ts
+++ b/apps/web/app/api/vercel/connection-status/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "@/lib/session/get-server-session";
+import type { VercelConnectionStatusResponse } from "@/lib/vercel/connection-status";
+import { getUserVercelToken } from "@/lib/vercel/token";
+
+const VERCEL_USERINFO_URL = "https://api.vercel.com/login/oauth/userinfo";
+const VERCEL_USERINFO_TIMEOUT_MS = 3_000;
+
+export async function GET() {
+  const session = await getServerSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  if (session.authProvider !== "vercel") {
+    return NextResponse.json({
+      status: "connected",
+      reason: null,
+    } satisfies VercelConnectionStatusResponse);
+  }
+
+  const token = await getUserVercelToken(session.user.id);
+  if (!token) {
+    return NextResponse.json({
+      status: "reconnect_required",
+      reason: "token_unavailable",
+    } satisfies VercelConnectionStatusResponse);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    VERCEL_USERINFO_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(VERCEL_USERINFO_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    if (response.ok) {
+      return NextResponse.json({
+        status: "connected",
+        reason: null,
+      } satisfies VercelConnectionStatusResponse);
+    }
+
+    if (
+      response.status === 400 ||
+      response.status === 401 ||
+      response.status === 403
+    ) {
+      return NextResponse.json({
+        status: "reconnect_required",
+        reason: "userinfo_auth_failed",
+      } satisfies VercelConnectionStatusResponse);
+    }
+
+    console.error(
+      `Failed to validate Vercel connection status: ${response.status} ${response.statusText}`,
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      console.error("Timed out validating Vercel connection status");
+    } else {
+      console.error("Failed to validate Vercel connection status:", error);
+    }
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  return NextResponse.json({
+    status: "connected",
+    reason: null,
+  } satisfies VercelConnectionStatusResponse);
+}

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   Suspense,
   createContext,
@@ -11,9 +11,18 @@ import {
   useRef,
   useState,
 } from "react";
-import { Toaster, toast } from "sonner";
+import { Toaster } from "sonner";
 import { SWRConfig } from "swr";
 import { GitHubReconnectGate } from "@/components/github-reconnect-gate";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useSession } from "@/hooks/use-session";
 import { FetchError } from "@/lib/swr";
 
@@ -54,13 +63,27 @@ function applyTheme(resolvedTheme: ResolvedTheme) {
  * global error handler that detects 401 responses and signs the user out.
  */
 export function Providers({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
   const router = useRouter();
   const signingOut = useRef(false);
   const vercelReconnectRedirecting = useRef(false);
-  const vercelReconnectFailureNotifiedFor = useRef<string | null>(null);
-  const { session, loading: sessionLoading } = useSession();
+  const lastRevalidatedRouteRef = useRef<string | null>(null);
+  const {
+    session,
+    loading: sessionLoading,
+    refresh: refreshSession,
+  } = useSession();
   const [theme, setThemeState] = useState<ThemePreference>("system");
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("dark");
+  const [showVercelReconnectDialog, setShowVercelReconnectDialog] =
+    useState(false);
+
+  const currentRoute = pathname;
+
+  const getCurrentVercelReconnectUrl = useCallback(() => {
+    const next = `${window.location.pathname}${window.location.search}`;
+    return `/api/auth/signin/vercel?next=${encodeURIComponent(next)}`;
+  }, []);
 
   const applyThemePreference = useCallback((nextTheme: ThemePreference) => {
     const nextResolvedTheme =
@@ -106,6 +129,20 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   useEffect(() => {
+    if (lastRevalidatedRouteRef.current === null) {
+      lastRevalidatedRouteRef.current = currentRoute;
+      return;
+    }
+
+    if (lastRevalidatedRouteRef.current === currentRoute) {
+      return;
+    }
+
+    lastRevalidatedRouteRef.current = currentRoute;
+    void refreshSession();
+  }, [currentRoute, refreshSession]);
+
+  useEffect(() => {
     if (sessionLoading) {
       return;
     }
@@ -121,7 +158,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     ) {
       window.sessionStorage.removeItem(VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY);
       vercelReconnectRedirecting.current = false;
-      vercelReconnectFailureNotifiedFor.current = null;
+      setShowVercelReconnectDialog(false);
       return;
     }
 
@@ -130,27 +167,32 @@ export function Providers({ children }: { children: React.ReactNode }) {
     }
 
     if (reconnectAttemptedUserId === session.user.id) {
-      if (vercelReconnectFailureNotifiedFor.current !== session.user.id) {
-        vercelReconnectFailureNotifiedFor.current = session.user.id;
-        toast.error(
-          "Couldn't refresh your Vercel session. Sign out and sign back in to retry.",
-        );
-      }
+      setShowVercelReconnectDialog(true);
       return;
     }
 
+    setShowVercelReconnectDialog(false);
     window.sessionStorage.setItem(
       VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY,
       session.user.id,
     );
-    vercelReconnectFailureNotifiedFor.current = null;
     vercelReconnectRedirecting.current = true;
+    window.location.assign(getCurrentVercelReconnectUrl());
+  }, [getCurrentVercelReconnectUrl, session, sessionLoading]);
 
-    const next = `${window.location.pathname}${window.location.search}`;
-    window.location.assign(
-      `/api/auth/signin/vercel?next=${encodeURIComponent(next)}`,
-    );
-  }, [session, sessionLoading]);
+  const handleReconnectVercel = useCallback(() => {
+    window.location.assign(getCurrentVercelReconnectUrl());
+  }, [getCurrentVercelReconnectUrl]);
+
+  const handleManualSignOut = useCallback(() => {
+    window.sessionStorage.removeItem(VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY);
+
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = "/api/auth/signout";
+    document.body.appendChild(form);
+    form.submit();
+  }, []);
 
   const handleError = useCallback(
     (error: Error) => {
@@ -189,6 +231,29 @@ export function Providers({ children }: { children: React.ReactNode }) {
         <Suspense fallback={null}>
           <GitHubReconnectGate />
         </Suspense>
+        <Dialog open={showVercelReconnectDialog}>
+          <DialogContent showCloseButton={false}>
+            <DialogHeader>
+              <DialogTitle>Reconnect Vercel</DialogTitle>
+              <DialogDescription>
+                Your saved Vercel session is no longer valid. Reconnect now to
+                keep using the app.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleManualSignOut}
+              >
+                Sign out
+              </Button>
+              <Button type="button" onClick={handleReconnectVercel}>
+                Reconnect Vercel
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </SWRConfig>
       <Toaster theme={resolvedTheme} />
     </ThemeContext.Provider>

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import {
   Suspense,
   createContext,
@@ -14,21 +14,10 @@ import {
 import { Toaster } from "sonner";
 import { SWRConfig } from "swr";
 import { GitHubReconnectGate } from "@/components/github-reconnect-gate";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { useSession } from "@/hooks/use-session";
+import { VercelReconnectGate } from "@/components/vercel-reconnect-gate";
 import { FetchError } from "@/lib/swr";
 
 const THEME_STORAGE_KEY = "open-agents-theme";
-const VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY =
-  "open-agents-vercel-reconnect-attempt";
 const DARK_MODE_MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
 export type ThemePreference = "light" | "dark" | "system";
@@ -63,27 +52,10 @@ function applyTheme(resolvedTheme: ResolvedTheme) {
  * global error handler that detects 401 responses and signs the user out.
  */
 export function Providers({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
   const router = useRouter();
   const signingOut = useRef(false);
-  const vercelReconnectRedirecting = useRef(false);
-  const lastRevalidatedRouteRef = useRef<string | null>(null);
-  const {
-    session,
-    loading: sessionLoading,
-    refresh: refreshSession,
-  } = useSession();
   const [theme, setThemeState] = useState<ThemePreference>("system");
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("dark");
-  const [showVercelReconnectDialog, setShowVercelReconnectDialog] =
-    useState(false);
-
-  const currentRoute = pathname;
-
-  const getCurrentVercelReconnectUrl = useCallback(() => {
-    const next = `${window.location.pathname}${window.location.search}`;
-    return `/api/auth/signin/vercel?next=${encodeURIComponent(next)}`;
-  }, []);
 
   const applyThemePreference = useCallback((nextTheme: ThemePreference) => {
     const nextResolvedTheme =
@@ -128,72 +100,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
     [applyThemePreference],
   );
 
-  useEffect(() => {
-    if (lastRevalidatedRouteRef.current === null) {
-      lastRevalidatedRouteRef.current = currentRoute;
-      return;
-    }
-
-    if (lastRevalidatedRouteRef.current === currentRoute) {
-      return;
-    }
-
-    lastRevalidatedRouteRef.current = currentRoute;
-    void refreshSession();
-  }, [currentRoute, refreshSession]);
-
-  useEffect(() => {
-    if (sessionLoading) {
-      return;
-    }
-
-    const reconnectAttemptedUserId = window.sessionStorage.getItem(
-      VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY,
-    );
-
-    if (
-      session?.authProvider !== "vercel" ||
-      !session?.user?.id ||
-      !session.vercelReconnectRequired
-    ) {
-      window.sessionStorage.removeItem(VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY);
-      vercelReconnectRedirecting.current = false;
-      setShowVercelReconnectDialog(false);
-      return;
-    }
-
-    if (vercelReconnectRedirecting.current) {
-      return;
-    }
-
-    if (reconnectAttemptedUserId === session.user.id) {
-      setShowVercelReconnectDialog(true);
-      return;
-    }
-
-    setShowVercelReconnectDialog(false);
-    window.sessionStorage.setItem(
-      VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY,
-      session.user.id,
-    );
-    vercelReconnectRedirecting.current = true;
-    window.location.assign(getCurrentVercelReconnectUrl());
-  }, [getCurrentVercelReconnectUrl, session, sessionLoading]);
-
-  const handleReconnectVercel = useCallback(() => {
-    window.location.assign(getCurrentVercelReconnectUrl());
-  }, [getCurrentVercelReconnectUrl]);
-
-  const handleManualSignOut = useCallback(() => {
-    window.sessionStorage.removeItem(VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY);
-
-    const form = document.createElement("form");
-    form.method = "POST";
-    form.action = "/api/auth/signout";
-    document.body.appendChild(form);
-    form.submit();
-  }, []);
-
   const handleError = useCallback(
     (error: Error) => {
       const isSessionAuthError =
@@ -230,30 +136,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
         {children}
         <Suspense fallback={null}>
           <GitHubReconnectGate />
+          <VercelReconnectGate />
         </Suspense>
-        <Dialog open={showVercelReconnectDialog}>
-          <DialogContent showCloseButton={false}>
-            <DialogHeader>
-              <DialogTitle>Reconnect Vercel</DialogTitle>
-              <DialogDescription>
-                Your saved Vercel session is no longer valid. Reconnect now to
-                keep using the app.
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleManualSignOut}
-              >
-                Sign out
-              </Button>
-              <Button type="button" onClick={handleReconnectVercel}>
-                Reconnect Vercel
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
       </SWRConfig>
       <Toaster theme={resolvedTheme} />
     </ThemeContext.Provider>

--- a/apps/web/components/vercel-reconnect-dialog.tsx
+++ b/apps/web/components/vercel-reconnect-dialog.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import type { VercelConnectionReason } from "@/lib/vercel/connection-status";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+function getReconnectDescription(
+  reason: VercelConnectionReason | null,
+): string {
+  switch (reason) {
+    case "token_unavailable":
+      return "Your saved Vercel token is no longer usable.";
+    case "userinfo_auth_failed":
+      return "Vercel rejected the saved session while we validated your connection.";
+    default:
+      return "Your Vercel connection needs to be refreshed before you continue.";
+  }
+}
+
+export function VercelReconnectDialog({
+  open,
+  reconnectUrl,
+  reason,
+  onSignOut,
+}: {
+  open: boolean;
+  reconnectUrl: string;
+  reason: VercelConnectionReason | null;
+  onSignOut: () => void;
+}) {
+  return (
+    <Dialog open={open}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Reconnect Vercel</DialogTitle>
+          <DialogDescription>
+            {getReconnectDescription(reason)} Reconnect now to keep using the
+            app.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onSignOut}>
+            Sign out
+          </Button>
+          <Button asChild>
+            <Link href={reconnectUrl}>Reconnect Vercel</Link>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/vercel-reconnect-gate.tsx
+++ b/apps/web/components/vercel-reconnect-gate.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSession } from "@/hooks/use-session";
+import { useVercelConnectionStatus } from "@/hooks/use-vercel-connection-status";
+import {
+  buildVercelReconnectUrl,
+  VERCEL_CONNECTION_STATUS_DEDUPING_INTERVAL_MS,
+} from "@/lib/vercel/connection-status";
+import { VercelReconnectDialog } from "./vercel-reconnect-dialog";
+
+const VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY =
+  "open-agents-vercel-reconnect-attempt";
+
+export function VercelReconnectGate() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { session, isAuthenticated, loading } = useSession();
+  const { reconnectRequired, reason, isLoading, refresh } =
+    useVercelConnectionStatus({ enabled: isAuthenticated });
+  const redirectingRef = useRef(false);
+  const lastRouteRefreshAtRef = useRef<number | null>(null);
+  const [showReconnectDialog, setShowReconnectDialog] = useState(false);
+
+  const currentRoute = useMemo(() => {
+    const search = searchParams.toString();
+    return search ? `${pathname}?${search}` : pathname;
+  }, [pathname, searchParams]);
+
+  const reconnectUrl = useMemo(
+    () => buildVercelReconnectUrl(currentRoute),
+    [currentRoute],
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated || session?.authProvider !== "vercel") {
+      lastRouteRefreshAtRef.current = null;
+      return;
+    }
+
+    const now = Date.now();
+
+    if (lastRouteRefreshAtRef.current === null) {
+      lastRouteRefreshAtRef.current = now;
+      return;
+    }
+
+    if (
+      now - lastRouteRefreshAtRef.current <
+      VERCEL_CONNECTION_STATUS_DEDUPING_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    lastRouteRefreshAtRef.current = now;
+    void refresh();
+  }, [currentRoute, isAuthenticated, refresh, session?.authProvider]);
+
+  useEffect(() => {
+    if (loading || isLoading) {
+      return;
+    }
+
+    const reconnectAttemptedUserId = window.sessionStorage.getItem(
+      VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY,
+    );
+
+    if (
+      session?.authProvider !== "vercel" ||
+      !session?.user?.id ||
+      !reconnectRequired
+    ) {
+      window.sessionStorage.removeItem(VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY);
+      redirectingRef.current = false;
+      setShowReconnectDialog(false);
+      return;
+    }
+
+    if (redirectingRef.current) {
+      return;
+    }
+
+    if (reconnectAttemptedUserId === session.user.id) {
+      setShowReconnectDialog(true);
+      return;
+    }
+
+    setShowReconnectDialog(false);
+    window.sessionStorage.setItem(
+      VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY,
+      session.user.id,
+    );
+    redirectingRef.current = true;
+    window.location.assign(reconnectUrl);
+  }, [isLoading, loading, reconnectRequired, reconnectUrl, session]);
+
+  const handleSignOut = useCallback(() => {
+    window.sessionStorage.removeItem(VERCEL_RECONNECT_ATTEMPT_STORAGE_KEY);
+
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = "/api/auth/signout";
+    document.body.appendChild(form);
+    form.submit();
+  }, []);
+
+  if (loading || !isAuthenticated || isLoading || !reconnectRequired) {
+    return null;
+  }
+
+  return (
+    <VercelReconnectDialog
+      open={showReconnectDialog}
+      reason={reason}
+      reconnectUrl={reconnectUrl}
+      onSignOut={handleSignOut}
+    />
+  );
+}

--- a/apps/web/hooks/use-session.ts
+++ b/apps/web/hooks/use-session.ts
@@ -2,12 +2,12 @@
 
 import useSWR from "swr";
 import type { SessionUserInfo } from "@/lib/session/types";
-import { fetcher } from "@/lib/swr";
+import { fetcherNoStore } from "@/lib/swr";
 
 export function useSession() {
-  const { data, isLoading } = useSWR<SessionUserInfo>(
+  const { data, isLoading, mutate } = useSWR<SessionUserInfo>(
     "/api/auth/info",
-    fetcher,
+    fetcherNoStore,
     {
       revalidateOnFocus: true,
     },
@@ -20,5 +20,6 @@ export function useSession() {
     hasGitHub: data?.hasGitHub ?? false,
     hasGitHubAccount: data?.hasGitHubAccount ?? false,
     hasGitHubInstallations: data?.hasGitHubInstallations ?? false,
+    refresh: mutate,
   };
 }

--- a/apps/web/hooks/use-session.ts
+++ b/apps/web/hooks/use-session.ts
@@ -2,12 +2,12 @@
 
 import useSWR from "swr";
 import type { SessionUserInfo } from "@/lib/session/types";
-import { fetcherNoStore } from "@/lib/swr";
+import { fetcher } from "@/lib/swr";
 
 export function useSession() {
-  const { data, isLoading, mutate } = useSWR<SessionUserInfo>(
+  const { data, isLoading } = useSWR<SessionUserInfo>(
     "/api/auth/info",
-    fetcherNoStore,
+    fetcher,
     {
       revalidateOnFocus: true,
     },
@@ -20,6 +20,5 @@ export function useSession() {
     hasGitHub: data?.hasGitHub ?? false,
     hasGitHubAccount: data?.hasGitHubAccount ?? false,
     hasGitHubInstallations: data?.hasGitHubInstallations ?? false,
-    refresh: mutate,
   };
 }

--- a/apps/web/hooks/use-vercel-connection-status.ts
+++ b/apps/web/hooks/use-vercel-connection-status.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcherNoStore } from "@/lib/swr";
+import {
+  VERCEL_CONNECTION_STATUS_DEDUPING_INTERVAL_MS,
+  type VercelConnectionStatusResponse,
+} from "@/lib/vercel/connection-status";
+import { useSession } from "./use-session";
+
+interface UseVercelConnectionStatusOptions {
+  enabled?: boolean;
+}
+
+export function useVercelConnectionStatus(
+  options?: UseVercelConnectionStatusOptions,
+) {
+  const { session, isAuthenticated } = useSession();
+  const enabled = options?.enabled ?? true;
+  const shouldFetch =
+    enabled && isAuthenticated && session?.authProvider === "vercel";
+
+  const { data, error, isLoading, mutate } =
+    useSWR<VercelConnectionStatusResponse>(
+      shouldFetch ? "/api/vercel/connection-status" : null,
+      fetcherNoStore,
+      {
+        dedupingInterval: VERCEL_CONNECTION_STATUS_DEDUPING_INTERVAL_MS,
+        revalidateOnFocus: true,
+      },
+    );
+
+  return {
+    data: data ?? null,
+    status: data?.status ?? (shouldFetch ? null : "connected"),
+    reason: data?.reason ?? null,
+    reconnectRequired: data?.status === "reconnect_required",
+    isLoading: shouldFetch && isLoading,
+    error: error instanceof Error ? error.message : null,
+    refresh: mutate,
+  };
+}

--- a/apps/web/lib/session/types.ts
+++ b/apps/web/lib/session/types.ts
@@ -16,5 +16,4 @@ export interface SessionUserInfo {
   hasGitHub?: boolean;
   hasGitHubAccount?: boolean;
   hasGitHubInstallations?: boolean;
-  vercelReconnectRequired?: boolean;
 }

--- a/apps/web/lib/vercel/connection-status.ts
+++ b/apps/web/lib/vercel/connection-status.ts
@@ -1,0 +1,17 @@
+export const VERCEL_CONNECTION_STATUS_DEDUPING_INTERVAL_MS = 30_000;
+
+export type VercelConnectionStatus = "connected" | "reconnect_required";
+
+export type VercelConnectionReason =
+  | "token_unavailable"
+  | "userinfo_auth_failed";
+
+export interface VercelConnectionStatusResponse {
+  status: VercelConnectionStatus;
+  reason: VercelConnectionReason | null;
+}
+
+export function buildVercelReconnectUrl(next: string): string {
+  const params = new URLSearchParams({ next });
+  return `/api/auth/signin/vercel?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary

Improves Vercel session revalidation by introducing a dedicated connection status route and adding UI components to handle reconnection scenarios gracefully.

## Changes

**API Routes (`apps/web/app/api/`)**

- Refactored auth/info route to remove Vercel validation logic
- Created new vercel/connection-status route with implementation and comprehensive tests

**Components (`apps/web/components/`)**

- Added vercel-reconnect-dialog.tsx for reconnection UI
- Added vercel-reconnect-gate.tsx to wrap Vercel-dependent features

**Hooks (`apps/web/hooks/`)**

- Added use-vercel-connection-status.ts hook for tracking connection status

**Infrastructure (`apps/web/`)**

- Simplified providers.tsx by removing Vercel validation logic
- Added vercel/connection-status.ts utility library for connection status management
- Updated session/types.ts to remove deprecated type definition

---

[Chat](https://open-agents.dev/sessions/jB-PF75DrWGfrhPo-Zy1R/chats/06f1059e-cbf3-44c0-90a9-8a612438084b) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)