### PR TITLE
feat: require approval for reading dotenv files

### DIFF
--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -33,10 +33,11 @@ const DANGEROUS_COMMAND_PATTERNS = [/\brm\s+-rf\b/];
 
 /**
  * Check if a command should require approval.
- * Returns true only for dangerous patterns.
+ * Returns true for dangerous patterns or commands that reference dotenv files.
  */
 export function commandNeedsApproval(command: string): boolean {
   const trimmedCommand = command.trim();
+  const lowerCommand = trimmedCommand.toLowerCase();
 
   for (const pattern of DANGEROUS_COMMAND_PATTERNS) {
     if (pattern.test(trimmedCommand)) {
@@ -44,7 +45,7 @@ export function commandNeedsApproval(command: string): boolean {
     }
   }
 
-  return false;
+  return lowerCommand.includes(".env");
 }
 
 export const bashTool = (options?: ToolOptions) =>

--- a/packages/agent/tools/read.ts
+++ b/packages/agent/tools/read.ts
@@ -4,6 +4,11 @@ import * as path from "path";
 import * as fs from "fs";
 import { getSandbox, toDisplayPath } from "./utils";
 
+function isDotEnvFilePath(filePath: string): boolean {
+  const basename = path.basename(filePath.replaceAll("\\", "/")).toLowerCase();
+  return basename.startsWith(".env");
+}
+
 const readInputSchema = z.object({
   filePath: z
     .string()
@@ -54,6 +59,7 @@ function resolveFilePath(filePath: string, workingDirectory: string): string {
 
 export const readFileTool = () =>
   tool({
+    needsApproval: ({ filePath }) => isDotEnvFilePath(filePath),
     description: `Read a file from the filesystem.
 
 USAGE:
@@ -80,7 +86,6 @@ EXAMPLES:
       const workingDirectory = sandbox.workingDirectory;
 
       try {
-        // Use the same path resolution logic as needsApproval
         const absolutePath = resolveFilePath(filePath, workingDirectory);
 
         const stats = await sandbox.stat(absolutePath);

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -399,7 +399,7 @@ describe("tools execute behavior", () => {
     });
   });
 
-  test("commandNeedsApproval flags only rm -rf commands", () => {
+  test("commandNeedsApproval flags rm -rf and dotenv commands", () => {
     expect(commandNeedsApproval("ls -la")).toBe(false);
     expect(commandNeedsApproval("git status --short")).toBe(false);
     expect(commandNeedsApproval("npm install")).toBe(false);
@@ -408,9 +408,13 @@ describe("tools execute behavior", () => {
     expect(commandNeedsApproval("git reset --hard HEAD~1")).toBe(false);
     expect(commandNeedsApproval("rm -fr tmp")).toBe(false);
     expect(commandNeedsApproval("rm -rf tmp")).toBe(true);
+    expect(commandNeedsApproval("cat .env.local")).toBe(true);
+    expect(commandNeedsApproval("grep API_KEY apps/web/.env.example")).toBe(
+      true,
+    );
   });
 
-  test("bashTool needsApproval blocks dangerous commands by default", async () => {
+  test("bashTool needsApproval blocks dangerous and dotenv commands by default", async () => {
     const baseContext = {
       sandbox: { workingDirectory: "/repo" },
       model: "test-model",
@@ -433,6 +437,15 @@ describe("tools execute behavior", () => {
       },
     );
     expect(dangerousCommand).toBe(true);
+
+    const dotenvCommand = await getNeedsApprovalResult(
+      bashTool().needsApproval,
+      { command: "cat .env.local" },
+      {
+        ...baseContext,
+      },
+    );
+    expect(dotenvCommand).toBe(true);
 
     const allowedBuildCommand = await getNeedsApprovalResult(
       bashTool().needsApproval,

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -166,6 +166,34 @@ describe("tools execute behavior", () => {
     });
   });
 
+  test("readFileTool requires approval for dotenv files", async () => {
+    const baseContext = {
+      sandbox: { workingDirectory: "/repo" },
+      model: "test-model",
+    };
+
+    const dotenvApproval = await getNeedsApprovalResult(
+      readFileTool().needsApproval,
+      { filePath: ".env.local" },
+      baseContext,
+    );
+    expect(dotenvApproval).toBe(true);
+
+    const nestedDotenvApproval = await getNeedsApprovalResult(
+      readFileTool().needsApproval,
+      { filePath: "apps/web/.env.example" },
+      baseContext,
+    );
+    expect(nestedDotenvApproval).toBe(true);
+
+    const regularFileApproval = await getNeedsApprovalResult(
+      readFileTool().needsApproval,
+      { filePath: "README.md" },
+      baseContext,
+    );
+    expect(regularFileApproval).toBe(false);
+  });
+
   test("writeFileTool creates parent directories and writes content", async () => {
     const { sandbox, workingDirectory } = await createFsSandbox();
     const relativePath = "nested/output.txt";


### PR DESCRIPTION
## Summary

This PR adds an approval requirement for reading dotenv environment files in the agent tools. Users must now explicitly approve access to .env files before they can be read.

## Changes

**Tools (`packages/agent/tools/read.ts`)**

- Add approval requirement validation before reading dotenv files
- Implement approval check logic for environment file access

**Tests (`packages/agent/tools/tools.test.ts`)**

- Add test cases for dotenv file approval requirement
- Verify approval workflow for reading environment files

---

[Chat](https://open-agents.dev/sessions/E8_pjityIMUkggDV9iPko/chats/z2XwbTDYNrGahrcaCFRjb) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)