### PR TITLE
docs: enhance security guidance in code-review skill

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -33,6 +33,7 @@ Use best judgement when processing input.
 
 - Use the diff to identify which files changed
 - Read the full file to understand existing patterns, control flow, and error handling
+- When changes touch inputs, auth, storage, networking, rendering, or secrets, trace the trust boundary instead of reviewing the code in isolation
 - Check for existing style guide or conventions files (CONVENTIONS.md, AGENTS.md, .editorconfig, etc.)
 
 ---
@@ -43,8 +44,14 @@ Use best judgement when processing input.
 - Logic errors, off-by-one mistakes, incorrect conditionals
 - If-else guards: missing guards, incorrect branching, unreachable code paths
 - Edge cases: null/empty/undefined inputs, error conditions, race conditions
-- Security issues: injection, auth bypass, data exposure
 - Broken error handling that swallows failures, throws unexpectedly or returns error types that are not caught.
+
+**Security / Safety** - Treat this as a first-class review concern, not an afterthought.
+- Assume changed code may be reachable by untrusted users or hostile input unless you can verify otherwise
+- Look for injection, XSS, auth/authz bypass, CSRF, SSRF, open redirects, path traversal, unsafe file access, secret/token exposure, privilege escalation, insecure defaults, and tenant/data isolation leaks
+- Check that validation and authorization happen at the real boundary, not only in the UI or caller
+- Verify sensitive operations fail closed, do not log secrets, and do not expand access beyond the intended actor/resource scope
+- Prefer flagging realistic exploit paths over generic "security concern" comments; explain the attacker-controlled input, boundary, and impact
 
 **Structure** - Does the code fit the codebase?
 - Does it follow existing patterns and conventions?
@@ -63,6 +70,7 @@ Use best judgement when processing input.
 - Only review the changes - do not review pre-existing code that wasn't modified
 - Don't flag something as a bug if you're unsure - investigate first
 - Don't invent hypothetical problems - if an edge case matters, explain the realistic scenario where it breaks
+- For security findings, describe the concrete exploit path or trust-boundary failure instead of vague risk language
 - If you need more context to be sure, use the tools below to get it
 
 **Don't be a zealot about style.** When checking code against conventions:
@@ -89,6 +97,7 @@ If you're uncertain about something and can't verify it with these tools, say "I
 1. If there is a bug, be direct and clear about why it is a bug.
 2. Clearly communicate severity of issues. Do not overstate severity.
 3. Critiques should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
-4. Your tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
-5. Write so the reader can quickly understand the issue without reading too closely.
-6. AVOID flattery, do not give any comments that are not helpful to the reader. Avoid phrasing like "Great job ...", "Thanks for ...".
+4. For security findings, explicitly state the attacker-controlled input, missing control, and concrete impact.
+5. Your tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
+6. Write so the reader can quickly understand the issue without reading too closely.
+7. AVOID flattery, do not give any comments that are not helpful to the reader. Avoid phrasing like "Great job ...", "Thanks for ...".


### PR DESCRIPTION
## Summary

Enhances security guidance in the code-review skill documentation to improve code review quality and safety standards.

## Changes

**Documentation (`.agents/skills/code-review/SKILL.md`)**

- Added comprehensive security considerations for code reviews
- Updated guidance for identifying security vulnerabilities
- Improved documentation clarity and structure

---

[Chat](https://open-agents.dev/sessions/1-g5sDNNGp9_LHWQkYTDe/chats/tRPQiRvYyFHc0FwQKRgOL) - Built with guidance from [Nico Albanese](https://github.com/nicoalbanese)