### PR TITLE
fix: update breaking avatars

### DIFF
--- a/apps/web/lib/auth/config.ts
+++ b/apps/web/lib/auth/config.ts
@@ -88,7 +88,7 @@ export const auth = betterAuth({
   user: {
     modelName: "users",
     fields: {
-      image: "avatar_url",
+      image: "avatarUrl",
     },
     additionalFields: {
       username: { type: "string", required: true },


### PR DESCRIPTION
## Summary

Updated the avatar field name in the authentication configuration from snake_case to camelCase format to resolve avatar display issues on the Vercel domain.

## Changes

**Auth Configuration (`apps/web/lib/auth/config.ts`)**

- Changed avatar field name from snake_case to camelCase

---

[Chat](https://open-agents.dev/sessions/P1z9O62_35BOAOQ-BqA1n/chats/4GCNlC5Q43aKSA4iHAlWo) - Built with guidance from [Will Sather](https://github.com/willsather)