### PR TITLE
fix: suppress github reconnect gate on get-started page

### DIFF
--- a/apps/web/components/github-reconnect-gate.tsx
+++ b/apps/web/components/github-reconnect-gate.tsx
@@ -21,7 +21,13 @@ export function GitHubReconnectGate() {
     return buildGitHubReconnectUrl(next);
   }, [pathname, searchParams]);
 
-  if (loading || !isAuthenticated || isLoading || !reconnectRequired) {
+  if (
+    loading ||
+    !isAuthenticated ||
+    isLoading ||
+    !reconnectRequired ||
+    pathname === "/get-started"
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- The global `GitHubReconnectGate` was rendering on `/get-started`, overlaying a duplicate "Reconnect GitHub" modal on top of the onboarding flow that already handles reconnect in step 2.
- The modal's button built its `next` param from the current path, which nested `/get-started?step=github&next=/sessions` into itself and caused a redirect loop instead of triggering GitHub OAuth.
- Skip the gate when `pathname === "/get-started"` so the onboarding page is the sole surface for reconnect.

## Test plan
- [ ] Land on `/get-started?step=github` in a reconnect_required state and confirm no modal overlay appears
- [ ] Click the inline "Reconnect GitHub" button in step 2 and verify it routes to GitHub OAuth and back successfully
- [ ] Verify the reconnect dialog still appears on non-onboarding routes (e.g. `/sessions`) when reconnect is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)