### PR TITLE
fix: drop legacy github_accounts table

### DIFF
--- a/apps/web/lib/db/migrations/0033_drop_legacy_github_accounts.sql
+++ b/apps/web/lib/db/migrations/0033_drop_legacy_github_accounts.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "github_accounts" CASCADE;

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1776696625627,
       "tag": "0032_funny_tag",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1776848655619,
+      "tag": "0033_drop_legacy_github_accounts",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a `0033` migration that drops the legacy `github_accounts` table left behind by the Better Auth migration
- update the Drizzle migration journal so existing and fresh environments both apply the cleanup
- remove stale pre-Better Auth GitHub token storage from migrated databases instead of relying on manual one-off cleanup

## Verification
- `bun run --cwd apps/web db:check`
- `bun run ci` *(fails in existing unrelated `packages/shared` typecheck errors)*