### PR TITLE
Improve chat workflow startup and diff refresh behavior

### DIFF
--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { assistantFileLinkPrompt } from "@/lib/assistant-file-links";
 
 mock.module("server-only", () => ({}));
 
@@ -346,14 +345,13 @@ describe("/api/chat route", () => {
     expect(startCalls[0]?.[1]).toEqual([
       expect.objectContaining({
         maxSteps: 500,
-        agentOptions: expect.objectContaining({
-          customInstructions: assistantFileLinkPrompt,
-        }),
+        requestUrl: "http://localhost/api/chat",
+        authSession: currentAuthSession,
       }),
     ]);
   });
 
-  test("passes selected and resolved model ids to the workflow", async () => {
+  test("defers selected model resolution to the workflow", async () => {
     const { POST } = await routeModulePromise;
     if (!chatRecord) {
       throw new Error("chatRecord must be set");
@@ -374,9 +372,9 @@ describe("/api/chat route", () => {
     expect(response.ok).toBe(true);
     expect(startCalls).toHaveLength(1);
     expect(startCalls[0]?.[1]).toEqual([
-      expect.objectContaining({
-        selectedModelId: "variant:test-model",
-        modelId: "openai/gpt-5",
+      expect.not.objectContaining({
+        selectedModelId: expect.anything(),
+        modelId: expect.anything(),
       }),
     ]);
   });
@@ -389,11 +387,8 @@ describe("/api/chat route", () => {
     expect(response.ok).toBe(true);
     expect(discoverSkillDirsCalls).toEqual([]);
     expect(startCalls[0]?.[1]).toEqual([
-      expect.objectContaining({
-        agentOptions: expect.not.objectContaining({
-          sandbox: expect.anything(),
-          skills: expect.anything(),
-        }),
+      expect.not.objectContaining({
+        agentOptions: expect.anything(),
       }),
     ]);
   });
@@ -407,7 +402,7 @@ describe("/api/chat route", () => {
     expect(response.ok).toBe(true);
     expect(startCalls).toHaveLength(1);
     expect(startCalls[0]?.[1]).toEqual([
-      expect.objectContaining({
+      expect.not.objectContaining({
         autoCommitEnabled: true,
         autoCreatePrEnabled: true,
       }),
@@ -427,7 +422,7 @@ describe("/api/chat route", () => {
     expect(response.ok).toBe(true);
     expect(startCalls).toHaveLength(1);
     expect(startCalls[0]?.[1]).toEqual([
-      expect.objectContaining({
+      expect.not.objectContaining({
         autoCommitEnabled: true,
         autoCreatePrEnabled: true,
       }),

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -9,6 +9,7 @@ interface TestSessionRecord {
   cloneUrl: string;
   repoOwner: string;
   repoName: string;
+  status: "running" | "archived";
   prNumber?: number | null;
   autoCommitPushOverride?: boolean | null;
   autoCreatePrOverride?: boolean | null;
@@ -41,6 +42,7 @@ let claimActiveStreamDefaultResult = true;
 let compareAndSetDefaultResult = true;
 let compareAndSetResults: boolean[] = [];
 let startCalls: unknown[][] = [];
+let routeEvents: string[] = [];
 let preferencesState: {
   autoCommitPush: boolean;
   autoCreatePr: boolean;
@@ -65,6 +67,18 @@ const claimChatActiveStreamIdSpy = mock(
 const compareAndSetChatActiveStreamIdSpy = mock(async () => {
   const nextResult = compareAndSetResults.shift();
   return nextResult ?? compareAndSetDefaultResult;
+});
+
+const createChatMessageIfNotExistsSpy = mock(async ({ id }: { id: string }) => {
+  routeEvents.push("persist-user");
+  return { id };
+});
+const touchChatSpy = mock(async () => {
+  routeEvents.push("touch-chat");
+});
+const isFirstChatMessageSpy = mock(async () => true);
+const updateChatSpy = mock(async () => {
+  routeEvents.push("update-chat");
 });
 
 const originalFetch = globalThis.fetch;
@@ -92,10 +106,13 @@ mock.module("ai", () => ({
     stream: ReadableStream;
     headers?: Record<string, string>;
   }) => new Response(stream, { status: 200, headers }),
+  isToolUIPart: (part: { type: string }) =>
+    part.type === "tool-invocation" || part.type.startsWith("tool-"),
 }));
 
 mock.module("workflow/api", () => ({
   start: async (...args: unknown[]) => {
+    routeEvents.push("start-workflow");
     startCalls.push(args);
     return {
       runId: "wrun_test-123",
@@ -157,9 +174,13 @@ mock.module("@/lib/db/sessions", () => ({
   claimChatActiveStreamId: claimChatActiveStreamIdSpy,
   compareAndSetChatActiveStreamId: compareAndSetChatActiveStreamIdSpy,
   countUserMessagesByUserId: async () => existingUserMessageCount,
+  createChatMessageIfNotExists: createChatMessageIfNotExistsSpy,
   getChatById: async () => chatRecord,
   getChatMessageById: async () => existingChatMessage,
   getSessionById: async () => sessionRecord,
+  isFirstChatMessage: isFirstChatMessageSpy,
+  touchChat: touchChatSpy,
+  updateChat: updateChatSpy,
   updateChatActiveStreamId: async () => {},
   updateChatAssistantActivity: async () => {},
   updateSession: async (_sessionId: string, patch: Record<string, unknown>) =>
@@ -238,6 +259,7 @@ describe("/api/chat route", () => {
     compareAndSetDefaultResult = true;
     compareAndSetResults = [];
     startCalls = [];
+    routeEvents = [];
     cachedSkillsState = null;
     discoverSkillDirsCalls = [];
     existingUserMessageCount = 0;
@@ -249,6 +271,10 @@ describe("/api/chat route", () => {
     };
     claimChatActiveStreamIdSpy.mockClear();
     compareAndSetChatActiveStreamIdSpy.mockClear();
+    createChatMessageIfNotExistsSpy.mockClear();
+    touchChatSpy.mockClear();
+    isFirstChatMessageSpy.mockClear();
+    updateChatSpy.mockClear();
     currentAuthSession = {
       user: {
         id: "user-1",
@@ -259,6 +285,7 @@ describe("/api/chat route", () => {
       id: "session-1",
       userId: "user-1",
       title: "Session title",
+      status: "running",
       cloneUrl: "https://github.com/acme/repo.git",
       repoOwner: "acme",
       repoName: "repo",
@@ -283,6 +310,41 @@ describe("/api/chat route", () => {
     const response = await POST(createValidRequest());
 
     expect(response.ok).toBe(true);
+  });
+
+  test("returns 400 for archived sessions without starting a workflow", async () => {
+    if (!sessionRecord) {
+      throw new Error("sessionRecord must be set");
+    }
+    sessionRecord.status = "archived";
+    const { POST } = await routeModulePromise;
+
+    const response = await POST(createValidRequest());
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Session is archived",
+    });
+    expect(startCalls).toHaveLength(0);
+    expect(createChatMessageIfNotExistsSpy).not.toHaveBeenCalled();
+  });
+
+  test("persists the latest user message before starting the workflow", async () => {
+    const { POST } = await routeModulePromise;
+
+    const response = await POST(createValidRequest());
+
+    expect(response.ok).toBe(true);
+    expect(createChatMessageIfNotExistsSpy).toHaveBeenCalledWith({
+      id: "user-1",
+      chatId: "chat-1",
+      role: "user",
+      parts: expect.objectContaining({ id: "user-1", role: "user" }),
+    });
+    expect(routeEvents.indexOf("persist-user")).toBeGreaterThanOrEqual(0);
+    expect(routeEvents.indexOf("start-workflow")).toBeGreaterThan(
+      routeEvents.indexOf("persist-user"),
+    );
   });
 
   test("blocks a sixth message for non-Vercel trial users on the managed deployment", async () => {
@@ -527,6 +589,7 @@ describe("/api/chat route", () => {
     expect(response.ok).toBe(true);
     expect(response.headers.get("x-workflow-run-id")).toBe("wrun_existing-456");
     expect(startCalls).toHaveLength(0);
+    expect(createChatMessageIfNotExistsSpy).not.toHaveBeenCalled();
     expect(compareAndSetChatActiveStreamIdSpy).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -381,18 +381,20 @@ describe("/api/chat route", () => {
     ]);
   });
 
-  test("discovers global sandbox skills after repo-local skill directories", async () => {
+  test("does not connect to the sandbox before starting the workflow", async () => {
     const { POST } = await routeModulePromise;
 
     const response = await POST(createValidRequest());
 
     expect(response.ok).toBe(true);
-    expect(discoverSkillDirsCalls).toEqual([
-      [
-        "/vercel/sandbox/.claude/skills",
-        "/vercel/sandbox/.agents/skills",
-        "/root/.agents/skills",
-      ],
+    expect(discoverSkillDirsCalls).toEqual([]);
+    expect(startCalls[0]?.[1]).toEqual([
+      expect.objectContaining({
+        agentOptions: expect.not.objectContaining({
+          sandbox: expect.anything(),
+          skills: expect.anything(),
+        }),
+      }),
     ]);
   });
 
@@ -522,16 +524,14 @@ describe("/api/chat route", () => {
     });
   });
 
-  test("returns 400 when sandbox is not active", async () => {
+  test("starts a workflow when sandbox is not active", async () => {
     isSandboxActive = false;
     const { POST } = await routeModulePromise;
 
     const response = await POST(createValidRequest());
 
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      error: "Sandbox not initialized",
-    });
+    expect(response.ok).toBe(true);
+    expect(startCalls).toHaveLength(1);
   });
 
   test("reconnects to existing running workflow instead of starting new one", async () => {

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -153,26 +153,13 @@ mock.module("@open-agents/sandbox", () => ({
   }),
 }));
 
-const persistAssistantMessagesWithToolResultsSpy = mock(() =>
-  Promise.resolve(),
-);
-
-mock.module("./_lib/persist-tool-results", () => ({
-  persistAssistantMessagesWithToolResults:
-    persistAssistantMessagesWithToolResultsSpy,
-}));
-
 mock.module("@/lib/db/sessions", () => ({
   claimChatActiveStreamId: claimChatActiveStreamIdSpy,
   compareAndSetChatActiveStreamId: compareAndSetChatActiveStreamIdSpy,
   countUserMessagesByUserId: async () => existingUserMessageCount,
-  createChatMessageIfNotExists: async () => undefined,
   getChatById: async () => chatRecord,
   getChatMessageById: async () => existingChatMessage,
   getSessionById: async () => sessionRecord,
-  isFirstChatMessage: async () => false,
-  touchChat: async () => {},
-  updateChat: async () => {},
   updateChatActiveStreamId: async () => {},
   updateChatAssistantActivity: async () => {},
   updateSession: async (_sessionId: string, patch: Record<string, unknown>) =>
@@ -262,7 +249,6 @@ describe("/api/chat route", () => {
     };
     claimChatActiveStreamIdSpy.mockClear();
     compareAndSetChatActiveStreamIdSpy.mockClear();
-    persistAssistantMessagesWithToolResultsSpy.mockClear();
     currentAuthSession = {
       user: {
         id: "user-1",
@@ -618,21 +604,5 @@ describe("/api/chat route", () => {
 
     expect(response.ok).toBe(true);
     expect(response.headers.get("x-workflow-run-id")).toBe("wrun_test-123");
-  });
-
-  test("calls persistAssistantMessagesWithToolResults on submit", async () => {
-    const { POST } = await routeModulePromise;
-
-    const response = await POST(createValidRequest());
-    expect(response.ok).toBe(true);
-
-    // Wait for the fire-and-forget call to settle
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(persistAssistantMessagesWithToolResultsSpy).toHaveBeenCalledTimes(1);
-    expect(persistAssistantMessagesWithToolResultsSpy).toHaveBeenCalledWith(
-      "chat-1",
-      expect.any(Array),
-    );
   });
 });

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -13,7 +13,6 @@ import {
   isFirstChatMessage,
   touchChat,
   updateChat,
-  updateSession,
 } from "@/lib/db/sessions";
 import { getUserPreferences } from "@/lib/db/user-preferences";
 import {
@@ -30,14 +29,12 @@ import {
   MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT,
   MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT_ERROR,
 } from "@/lib/managed-template-trial";
-import { buildActiveLifecycleUpdate } from "@/lib/sandbox/lifecycle";
 import {
   requireAuthenticatedUser,
   requireOwnedSessionChat,
 } from "./_lib/chat-context";
 import { resolveChatModelSelection } from "./_lib/model-selection";
 import { parseChatRequestBody, requireChatIdentifiers } from "./_lib/request";
-import { createChatRuntime } from "./_lib/runtime";
 import { runAgentWorkflow } from "@/app/workflows/chat";
 import { persistAssistantMessagesWithToolResults } from "./_lib/persist-tool-results";
 
@@ -90,18 +87,12 @@ export async function POST(req: Request) {
     sessionId,
     chatId,
     forbiddenMessage: "Unauthorized",
-    requireActiveSandbox: true,
-    sandboxInactiveMessage: "Sandbox not initialized",
   });
   if (!chatContext.ok) {
     return chatContext.response;
   }
 
   const { sessionRecord, chat } = chatContext;
-  const activeSandboxState = sessionRecord.sandboxState;
-  if (!activeSandboxState) {
-    throw new Error("Sandbox not initialized");
-  }
 
   if (isManagedTemplateTrialUser(session, req.url)) {
     const latestUserMessage = getLatestUserMessage(messages);
@@ -143,15 +134,6 @@ export async function POST(req: Request) {
     }
   }
 
-  const requestStartedAt = new Date();
-
-  // Refresh lifecycle activity so long-running responses don't look idle.
-  await updateSession(sessionId, {
-    ...buildActiveLifecycleUpdate(sessionRecord.sandboxState, {
-      activityAt: requestStartedAt,
-    }),
-  });
-
   // Persist the latest user message immediately (fire-and-forget) so it's
   // in the DB before the workflow starts. This ensures a page refresh
   // during workflow queue time still shows the message.
@@ -163,20 +145,12 @@ export async function POST(req: Request) {
   // would lose the tool result.
   void persistAssistantMessagesWithToolResults(chatId, messages);
 
-  const runtimePromise = createChatRuntime({
-    userId,
-    sessionId,
-    sessionRecord,
-  });
   const preferencesPromise = getUserPreferences(userId).catch((error) => {
     console.error("Failed to load user preferences:", error);
     return null;
   });
 
-  const [{ sandbox, skills }, rawPreferences] = await Promise.all([
-    runtimePromise,
-    preferencesPromise,
-  ]);
+  const rawPreferences = await preferencesPromise;
 
   const preferences = rawPreferences
     ? sanitizeUserPreferencesForSession(rawPreferences, session, req.url)
@@ -233,17 +207,10 @@ export async function POST(req: Request) {
       modelId: mainModelSelection.id,
       maxSteps: 500,
       agentOptions: {
-        sandbox: {
-          state: activeSandboxState,
-          workingDirectory: sandbox.workingDirectory,
-          currentBranch: sandbox.currentBranch,
-          environmentDetails: sandbox.environmentDetails,
-        },
         model: mainModelSelection,
         ...(subagentModelSelection
           ? { subagentModel: subagentModelSelection }
           : {}),
-        ...(skills.length > 0 && { skills }),
         customInstructions: assistantFileLinkPrompt,
       },
       ...(shouldAutoCommitPush &&
@@ -251,9 +218,6 @@ export async function POST(req: Request) {
         sessionRecord.repoName && {
           autoCommitEnabled: true,
           autoCreatePrEnabled: shouldAutoCreatePr,
-          sessionTitle: sessionRecord.title,
-          repoOwner: sessionRecord.repoOwner,
-          repoName: sessionRecord.repoName,
         }),
     },
   ]);

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -14,15 +14,7 @@ import {
   touchChat,
   updateChat,
 } from "@/lib/db/sessions";
-import { getUserPreferences } from "@/lib/db/user-preferences";
-import {
-  filterModelVariantsForSession,
-  sanitizeSelectedModelIdForSession,
-  sanitizeUserPreferencesForSession,
-} from "@/lib/model-access";
-import { getAllVariants } from "@/lib/model-variants";
 import { createCancelableReadableStream } from "@/lib/chat/create-cancelable-readable-stream";
-import { assistantFileLinkPrompt } from "@/lib/assistant-file-links";
 import { getServerSession } from "@/lib/session/get-server-session";
 import {
   isManagedTemplateTrialUser,
@@ -33,7 +25,6 @@ import {
   requireAuthenticatedUser,
   requireOwnedSessionChat,
 } from "./_lib/chat-context";
-import { resolveChatModelSelection } from "./_lib/model-selection";
 import { parseChatRequestBody, requireChatIdentifiers } from "./_lib/request";
 import { runAgentWorkflow } from "@/app/workflows/chat";
 import { persistAssistantMessagesWithToolResults } from "./_lib/persist-tool-results";
@@ -92,7 +83,7 @@ export async function POST(req: Request) {
     return chatContext.response;
   }
 
-  const { sessionRecord, chat } = chatContext;
+  const { chat } = chatContext;
 
   if (isManagedTemplateTrialUser(session, req.url)) {
     const latestUserMessage = getLatestUserMessage(messages);
@@ -145,57 +136,6 @@ export async function POST(req: Request) {
   // would lose the tool result.
   void persistAssistantMessagesWithToolResults(chatId, messages);
 
-  const preferencesPromise = getUserPreferences(userId).catch((error) => {
-    console.error("Failed to load user preferences:", error);
-    return null;
-  });
-
-  const rawPreferences = await preferencesPromise;
-
-  const preferences = rawPreferences
-    ? sanitizeUserPreferencesForSession(rawPreferences, session, req.url)
-    : null;
-  const modelVariants = filterModelVariantsForSession(
-    getAllVariants(preferences?.modelVariants ?? []),
-    session,
-    req.url,
-  );
-  const selectedModelId =
-    sanitizeSelectedModelIdForSession(
-      chat.modelId,
-      modelVariants,
-      session,
-      req.url,
-    ) ??
-    chat.modelId ??
-    null;
-  const mainModelSelection = resolveChatModelSelection({
-    selectedModelId,
-    modelVariants,
-    missingVariantLabel: "Selected model variant",
-  });
-  const subagentModelSelection = preferences?.defaultSubagentModelId
-    ? resolveChatModelSelection({
-        selectedModelId: sanitizeSelectedModelIdForSession(
-          preferences.defaultSubagentModelId,
-          modelVariants,
-          session,
-          req.url,
-        ),
-        modelVariants,
-        missingVariantLabel: "Subagent model variant",
-      })
-    : undefined;
-
-  // Determine if auto-commit and auto-PR should run after a natural finish.
-  const shouldAutoCommitPush =
-    sessionRecord.autoCommitPushOverride ??
-    preferences?.autoCommitPush ??
-    false;
-  const shouldAutoCreatePr =
-    shouldAutoCommitPush &&
-    (sessionRecord.autoCreatePrOverride ?? preferences?.autoCreatePr ?? false);
-
   // Start the durable workflow
   const run = await start(runAgentWorkflow, [
     {
@@ -203,22 +143,9 @@ export async function POST(req: Request) {
       chatId,
       sessionId,
       userId,
-      selectedModelId: selectedModelId ?? mainModelSelection.id,
-      modelId: mainModelSelection.id,
+      requestUrl: req.url,
+      authSession: session ?? null,
       maxSteps: 500,
-      agentOptions: {
-        model: mainModelSelection,
-        ...(subagentModelSelection
-          ? { subagentModel: subagentModelSelection }
-          : {}),
-        customInstructions: assistantFileLinkPrompt,
-      },
-      ...(shouldAutoCommitPush &&
-        sessionRecord.repoOwner &&
-        sessionRecord.repoName && {
-          autoCommitEnabled: true,
-          autoCreatePrEnabled: shouldAutoCreatePr,
-        }),
     },
   ]);
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -7,12 +7,8 @@ import {
   claimChatActiveStreamId,
   compareAndSetChatActiveStreamId,
   countUserMessagesByUserId,
-  createChatMessageIfNotExists,
   getChatById,
   getChatMessageById,
-  isFirstChatMessage,
-  touchChat,
-  updateChat,
 } from "@/lib/db/sessions";
 import { createCancelableReadableStream } from "@/lib/chat/create-cancelable-readable-stream";
 import { getServerSession } from "@/lib/session/get-server-session";
@@ -27,7 +23,6 @@ import {
 } from "./_lib/chat-context";
 import { parseChatRequestBody, requireChatIdentifiers } from "./_lib/request";
 import { runAgentWorkflow } from "@/app/workflows/chat";
-import { persistAssistantMessagesWithToolResults } from "./_lib/persist-tool-results";
 
 export const maxDuration = 800;
 
@@ -124,17 +119,6 @@ export async function POST(req: Request) {
       );
     }
   }
-
-  // Persist the latest user message immediately (fire-and-forget) so it's
-  // in the DB before the workflow starts. This ensures a page refresh
-  // during workflow queue time still shows the message.
-  void persistLatestUserMessage(chatId, messages);
-
-  // Also persist any assistant messages that contain client-side tool results
-  // (e.g. ask_user_question responses). Without this, tool results are only
-  // persisted when the workflow finishes, so switching devices mid-stream
-  // would lose the tool result.
-  void persistAssistantMessagesWithToolResults(chatId, messages);
 
   // Start the durable workflow
   const run = await start(runAgentWorkflow, [
@@ -237,52 +221,4 @@ async function reconcileExistingActiveStream(
   }
 
   return currentStreamId ? { action: "conflict" } : { action: "ready" };
-}
-
-async function persistLatestUserMessage(
-  chatId: string,
-  messages: WebAgentUIMessage[],
-): Promise<void> {
-  const latestMessage = messages[messages.length - 1];
-  if (!latestMessage || latestMessage.role !== "user") {
-    return;
-  }
-
-  try {
-    const created = await createChatMessageIfNotExists({
-      id: latestMessage.id,
-      chatId,
-      role: "user",
-      parts: latestMessage,
-    });
-
-    if (!created) {
-      return;
-    }
-
-    await touchChat(chatId);
-
-    const shouldSetTitle = await isFirstChatMessage(chatId, created.id);
-    if (!shouldSetTitle) {
-      return;
-    }
-
-    const textContent = latestMessage.parts
-      .filter(
-        (part): part is { type: "text"; text: string } => part.type === "text",
-      )
-      .map((part) => part.text)
-      .join(" ")
-      .trim();
-
-    if (textContent.length > 0) {
-      const title =
-        textContent.length > 80
-          ? `${textContent.slice(0, 80)}...`
-          : textContent;
-      await updateChat(chatId, { title });
-    }
-  } catch (error) {
-    console.error("Failed to persist user message:", error);
-  }
 }

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -7,8 +7,12 @@ import {
   claimChatActiveStreamId,
   compareAndSetChatActiveStreamId,
   countUserMessagesByUserId,
+  createChatMessageIfNotExists,
   getChatById,
   getChatMessageById,
+  isFirstChatMessage,
+  touchChat,
+  updateChat,
 } from "@/lib/db/sessions";
 import { createCancelableReadableStream } from "@/lib/chat/create-cancelable-readable-stream";
 import { getServerSession } from "@/lib/session/get-server-session";
@@ -23,6 +27,7 @@ import {
 } from "./_lib/chat-context";
 import { parseChatRequestBody, requireChatIdentifiers } from "./_lib/request";
 import { runAgentWorkflow } from "@/app/workflows/chat";
+import { persistAssistantMessagesWithToolResults } from "./_lib/persist-tool-results";
 
 export const maxDuration = 800;
 
@@ -78,7 +83,11 @@ export async function POST(req: Request) {
     return chatContext.response;
   }
 
-  const { chat } = chatContext;
+  const { sessionRecord, chat } = chatContext;
+
+  if (sessionRecord.status === "archived") {
+    return Response.json({ error: "Session is archived" }, { status: 400 });
+  }
 
   if (isManagedTemplateTrialUser(session, req.url)) {
     const latestUserMessage = getLatestUserMessage(messages);
@@ -119,6 +128,11 @@ export async function POST(req: Request) {
       );
     }
   }
+
+  await Promise.all([
+    persistLatestUserMessage(chatId, messages),
+    persistAssistantMessagesWithToolResults(chatId, messages),
+  ]);
 
   // Start the durable workflow
   const run = await start(runAgentWorkflow, [
@@ -221,4 +235,52 @@ async function reconcileExistingActiveStream(
   }
 
   return currentStreamId ? { action: "conflict" } : { action: "ready" };
+}
+
+async function persistLatestUserMessage(
+  chatId: string,
+  messages: WebAgentUIMessage[],
+): Promise<void> {
+  const latestMessage = messages[messages.length - 1];
+  if (!latestMessage || latestMessage.role !== "user") {
+    return;
+  }
+
+  try {
+    const created = await createChatMessageIfNotExists({
+      id: latestMessage.id,
+      chatId,
+      role: "user",
+      parts: latestMessage,
+    });
+
+    if (!created) {
+      return;
+    }
+
+    await touchChat(chatId);
+
+    const shouldSetTitle = await isFirstChatMessage(chatId, created.id);
+    if (!shouldSetTitle) {
+      return;
+    }
+
+    const textContent = latestMessage.parts
+      .filter(
+        (part): part is { type: "text"; text: string } => part.type === "text",
+      )
+      .map((part) => part.text)
+      .join(" ")
+      .trim();
+
+    if (textContent.length === 0) {
+      return;
+    }
+
+    const title =
+      textContent.length > 80 ? `${textContent.slice(0, 80)}...` : textContent;
+    await updateChat(chatId, { title });
+  } catch (error) {
+    console.error("Failed to persist user message:", error);
+  }
 }

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/hooks/use-session-chat-runtime.ts
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/hooks/use-session-chat-runtime.ts
@@ -2,7 +2,13 @@
 
 import { type UseChatHelpers, useChat } from "@ai-sdk/react";
 import { isToolUIPart } from "ai";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import type {
   WebAgentUIMessage,
   WebAgentWorkspaceStatusData,
@@ -13,6 +19,12 @@ import {
   getOrCreateChatInstance,
 } from "@/lib/chat-instance-manager";
 import { cleanupChatRouteOnUnmount } from "@/lib/chat-route-cleanup";
+import {
+  clearChatWorkspaceStatus,
+  getChatWorkspaceStatusSnapshot,
+  setChatWorkspaceStatus,
+  subscribeChatWorkspaceStatus,
+} from "@/lib/workspace-status-store";
 
 const CHAT_UI_UPDATE_THROTTLE_MS = 75;
 
@@ -85,8 +97,14 @@ export function useSessionChatRuntime({
   contextLimit,
 }: UseSessionChatRuntimeParams): UseSessionChatRuntimeReturn {
   const contextLimitRef = useRef<number | null>(contextLimit);
-  const [workspaceStatus, setWorkspaceStatus] =
-    useState<WebAgentWorkspaceStatusData | null>(null);
+  const workspaceStatus = useSyncExternalStore(
+    useCallback(
+      (listener) => subscribeChatWorkspaceStatus(chatId, listener),
+      [chatId],
+    ),
+    useCallback(() => getChatWorkspaceStatusSnapshot(chatId), [chatId]),
+    () => null,
+  );
 
   useEffect(() => {
     contextLimitRef.current = contextLimit;
@@ -125,7 +143,7 @@ export function useSessionChatRuntime({
         messages: initialMessages,
         onData: (dataPart) => {
           if (dataPart.type === "data-workspace-status") {
-            setWorkspaceStatus(dataPart.data);
+            setChatWorkspaceStatus(chatId, dataPart.data);
           }
         },
         sendAutomaticallyWhen: shouldAutoSubmit,
@@ -235,14 +253,14 @@ export function useSessionChatRuntime({
   useEffect(() => {
     if (chat.status === "submitted") {
       userStoppedRef.current = false;
-      setWorkspaceStatus(null);
+      clearChatWorkspaceStatus(chatId);
       return;
     }
 
     if (chat.status === "ready" || chat.status === "error") {
-      setWorkspaceStatus(null);
+      clearChatWorkspaceStatus(chatId);
     }
-  }, [chat.status]);
+  }, [chat.status, chatId]);
 
   useEffect(() => {
     if (!workspaceStatus) {
@@ -251,13 +269,13 @@ export function useSessionChatRuntime({
 
     const lastMessage = chat.messages[chat.messages.length - 1];
     if (lastMessage?.role === "assistant" && lastMessage.parts.length > 0) {
-      setWorkspaceStatus(null);
+      clearChatWorkspaceStatus(chatId);
     }
-  }, [chat.messages, workspaceStatus]);
+  }, [chat.messages, chatId, workspaceStatus]);
 
   const clearWorkspaceStatus = useCallback(() => {
-    setWorkspaceStatus(null);
-  }, []);
+    clearChatWorkspaceStatus(chatId);
+  }, [chatId]);
 
   // Reactive resume fallback.
   //

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/hooks/use-session-chat-runtime.ts
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/hooks/use-session-chat-runtime.ts
@@ -2,8 +2,11 @@
 
 import { type UseChatHelpers, useChat } from "@ai-sdk/react";
 import { isToolUIPart } from "ai";
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import type { WebAgentUIMessage } from "@/app/types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  WebAgentUIMessage,
+  WebAgentWorkspaceStatusData,
+} from "@/app/types";
 import { AbortableChatTransport } from "@/lib/abortable-chat-transport";
 import {
   abortChatInstanceTransport,
@@ -30,6 +33,8 @@ type UseSessionChatRuntimeReturn = {
   chat: UseChatHelpers<WebAgentUIMessage>;
   stopChatStream: () => void;
   retryChatStream: (opts?: RetryChatStreamOptions) => void;
+  workspaceStatus: WebAgentWorkspaceStatusData | null;
+  clearWorkspaceStatus: () => void;
 };
 
 /**
@@ -80,6 +85,8 @@ export function useSessionChatRuntime({
   contextLimit,
 }: UseSessionChatRuntimeParams): UseSessionChatRuntimeReturn {
   const contextLimitRef = useRef<number | null>(contextLimit);
+  const [workspaceStatus, setWorkspaceStatus] =
+    useState<WebAgentWorkspaceStatusData | null>(null);
 
   useEffect(() => {
     contextLimitRef.current = contextLimit;
@@ -116,6 +123,11 @@ export function useSessionChatRuntime({
         id: chatId,
         transport,
         messages: initialMessages,
+        onData: (dataPart) => {
+          if (dataPart.type === "data-workspace-status") {
+            setWorkspaceStatus(dataPart.data);
+          }
+        },
         sendAutomaticallyWhen: shouldAutoSubmit,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only create once per chatId; init values are only used at creation time
@@ -223,8 +235,29 @@ export function useSessionChatRuntime({
   useEffect(() => {
     if (chat.status === "submitted") {
       userStoppedRef.current = false;
+      setWorkspaceStatus(null);
+      return;
+    }
+
+    if (chat.status === "ready" || chat.status === "error") {
+      setWorkspaceStatus(null);
     }
   }, [chat.status]);
+
+  useEffect(() => {
+    if (!workspaceStatus) {
+      return;
+    }
+
+    const lastMessage = chat.messages[chat.messages.length - 1];
+    if (lastMessage?.role === "assistant" && lastMessage.parts.length > 0) {
+      setWorkspaceStatus(null);
+    }
+  }, [chat.messages, workspaceStatus]);
+
+  const clearWorkspaceStatus = useCallback(() => {
+    setWorkspaceStatus(null);
+  }, []);
 
   // Reactive resume fallback.
   //
@@ -319,5 +352,7 @@ export function useSessionChatRuntime({
     chat,
     stopChatStream,
     retryChatStream,
+    workspaceStatus,
+    clearWorkspaceStatus,
   };
 }

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -767,29 +767,11 @@ function _SandboxHeaderBadge({
 }
 
 function SandboxInputOverlay({
-  isSandboxActive,
-  isCreating,
-  isRestoring,
-  isReconnecting,
-  isHibernating,
   isArchived,
-  isInitializing,
   snapshotPending,
-  hasSnapshot,
-  onRestore,
-  onCreateNew,
 }: {
-  isSandboxActive: boolean;
-  isCreating: boolean;
-  isRestoring: boolean;
-  isReconnecting: boolean;
-  isHibernating: boolean;
   isArchived: boolean;
-  isInitializing: boolean;
   snapshotPending: boolean;
-  hasSnapshot: boolean;
-  onRestore: () => void;
-  onCreateNew: () => void;
 }) {
   if (isArchived) {
     return (
@@ -806,40 +788,7 @@ function SandboxInputOverlay({
     );
   }
 
-  // During sandbox creation/restoration/reconnection/initialization, don't block the input.
-  // The submit button is disabled separately, and the header badge shows status.
-  if (
-    isSandboxActive ||
-    isCreating ||
-    isRestoring ||
-    isReconnecting ||
-    isHibernating ||
-    isInitializing
-  ) {
-    return null;
-  }
-
-  // Sandbox is fully inactive and not transitioning -- show resume/create buttons
-  return (
-    <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/60 backdrop-blur-[2px]">
-      <div className="flex items-center gap-2">
-        {hasSnapshot ? (
-          <Button onClick={onRestore} size="sm" className="shadow-sm">
-            Resume sandbox
-          </Button>
-        ) : (
-          <Button
-            onClick={onCreateNew}
-            size="sm"
-            variant="outline"
-            className="shadow-sm"
-          >
-            Create sandbox
-          </Button>
-        )}
-      </div>
-    </div>
-  );
+  return null;
 }
 
 function ShareDialog({
@@ -1249,6 +1198,7 @@ export function SessionChatContent({
     contextLimit,
     stopChatStream,
     retryChatStream,
+    workspaceStatus,
     hadInitialMessages,
     initialMessages,
   } = useSessionChatRuntimeContext();
@@ -2214,7 +2164,7 @@ export function SessionChatContent({
     checkBranchAndPr,
   ]);
 
-  const handleRestoreSnapshot = useCallback(async () => {
+  const _handleRestoreSnapshot = useCallback(async () => {
     setIsRestoringSnapshot(true);
     setRestoreError(null);
 
@@ -2292,7 +2242,7 @@ export function SessionChatContent({
     waitForSandboxReady,
   ]);
 
-  const handleCreateNewSandbox = useCallback(async () => {
+  const _handleCreateNewSandbox = useCallback(async () => {
     setIsCreatingSandbox(true);
     setSandboxCreateError(null);
 
@@ -2430,20 +2380,9 @@ export function SessionChatContent({
     userStopped,
   ]);
 
-  // Track whether we've auto-attempted sandbox startup for this page load.
-  const hasAutoStartedSandboxRef = useRef(false);
-  const hasHandledInitialSandboxEntryRef = useRef(false);
   const shouldRefreshRestoredWorkspaceRef = useRef(false);
 
   const isArchived = session.status === "archived";
-  const isAutoRestoringOnEntry =
-    !hasHandledInitialSandboxEntryRef.current &&
-    !isArchived &&
-    hasSnapshot &&
-    !sandboxInfo &&
-    !isCreatingSandbox &&
-    !isRestoringSnapshot &&
-    reconnectionStatus === "no_sandbox";
 
   // After a snapshot restore, wait for the live workspace hooks to be active
   // again before forcing refreshes. Calling the pre-restore callbacks inside
@@ -2483,29 +2422,6 @@ export function SessionChatContent({
     attemptReconnection,
   ]);
 
-  useEffect(() => {
-    if (isArchived) {
-      return;
-    }
-    if (hasHandledInitialSandboxEntryRef.current) {
-      return;
-    }
-    if (reconnectionStatus === "idle" || reconnectionStatus === "checking") {
-      return;
-    }
-
-    hasHandledInitialSandboxEntryRef.current = true;
-
-    if (isAutoRestoringOnEntry) {
-      void handleRestoreSnapshot();
-    }
-  }, [
-    handleRestoreSnapshot,
-    isArchived,
-    isAutoRestoringOnEntry,
-    reconnectionStatus,
-  ]);
-
   // Server-authoritative lifecycle state: lightweight status poll every 15s.
   useEffect(() => {
     if (isCreatingSandbox || isRestoringSnapshot) return;
@@ -2529,89 +2445,6 @@ export function SessionChatContent({
     isRestoringSnapshot,
     reconnectionStatus,
     requestStatusSync,
-  ]);
-
-  const ensureSandboxReady = useCallback(async () => {
-    if (isSandboxValid(sandboxInfo)) {
-      return true;
-    }
-    if (isCreatingSandbox) {
-      return false;
-    }
-
-    try {
-      setIsCreatingSandbox(true);
-      setSandboxCreateError(null);
-
-      const branchExistsOnOrigin = session.prNumber != null;
-      const shouldCreateNewBranch =
-        session.isNewBranch && !branchExistsOnOrigin;
-      const newSandbox = await createSandbox(
-        session.cloneUrl ?? undefined,
-        session.branch ?? undefined,
-        shouldCreateNewBranch,
-        session.id,
-        preferredSandboxType,
-      );
-      setSandboxInfo(newSandbox);
-      setSandboxTypeFromUnknown(newSandbox.type);
-      setSandboxCreateError(null);
-      void requestStatusSync("force");
-      return true;
-    } catch (err) {
-      const details = getSandboxCreateErrorDetails(err);
-      setSandboxCreateError(details);
-      console.error("Failed to create sandbox:", err);
-      return false;
-    } finally {
-      setIsCreatingSandbox(false);
-    }
-  }, [
-    sandboxInfo,
-    isCreatingSandbox,
-    session.prNumber,
-    session.isNewBranch,
-    session.cloneUrl,
-    session.branch,
-    session.id,
-    preferredSandboxType,
-    setSandboxInfo,
-    setSandboxTypeFromUnknown,
-    requestStatusSync,
-  ]);
-
-  // Auto-create sandbox right away for new sessions/chats.
-  // Skip for archived sessions.
-  useEffect(() => {
-    if (isArchived) return;
-    if (sandboxInfo || isCreatingSandbox || isRestoringSnapshot) return;
-
-    // If we have stored sandbox state, wait for reconnect attempt first.
-    if (session.sandboxState && reconnectionStatus === "idle") return;
-    if (session.sandboxState && reconnectionStatus === "checking") return;
-    if (session.sandboxState && reconnectionStatus === "connected") {
-      hasAutoStartedSandboxRef.current = true;
-      return;
-    }
-
-    // Paused sessions require an explicit Resume action.
-    if (hasSnapshot) {
-      return;
-    }
-
-    if (hasAutoStartedSandboxRef.current) return;
-    hasAutoStartedSandboxRef.current = true;
-
-    void ensureSandboxReady();
-  }, [
-    isArchived,
-    session.sandboxState,
-    hasSnapshot,
-    reconnectionStatus,
-    sandboxInfo,
-    isCreatingSandbox,
-    isRestoringSnapshot,
-    ensureSandboxReady,
   ]);
 
   // Track tool completions to trigger diff refresh
@@ -3370,22 +3203,9 @@ export function SessionChatContent({
                         {groupedRenderMessages.length === 0 &&
                           !hasPendingResponse && (
                             <div className="flex h-full min-h-[40vh] items-center justify-center">
-                              {!isArchived &&
-                              (isCreatingSandbox ||
-                                isRestoringSnapshot ||
-                                isReconnectingSandbox ||
-                                isHibernatingUi ||
-                                isServerRestoring ||
-                                !isSandboxActive) ? (
-                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                  <Loader2 className="h-4 w-4 animate-spin" />
-                                  <p>Sandbox is initializing…</p>
-                                </div>
-                              ) : (
-                                <p className="text-sm text-muted-foreground">
-                                  Send a message to get started
-                                </p>
-                              )}
+                              <p className="text-sm text-muted-foreground">
+                                Send a message to get started
+                              </p>
                             </div>
                           )}
                         {groupedRenderMessages.map(
@@ -3834,7 +3654,9 @@ export function SessionChatContent({
                               <span className="flex size-3.5 shrink-0 items-center justify-center">
                                 <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-muted-foreground" />
                               </span>
-                              <span className="leading-none">Thinking…</span>
+                              <span className="leading-none">
+                                {workspaceStatus?.message ?? "Thinking…"}
+                              </span>
                             </div>
                           </div>
                         )}
@@ -3948,7 +3770,6 @@ export function SessionChatContent({
                           if (showInlineQuestion) return;
                           if (
                             isArchived ||
-                            !isSandboxActive ||
                             isChatInFlight ||
                             hasPendingResponse
                           ) {
@@ -4113,22 +3934,8 @@ export function SessionChatContent({
                       >
                         {/* Sandbox overlay when inactive */}
                         <SandboxInputOverlay
-                          isSandboxActive={isSandboxActive}
-                          isCreating={isCreatingSandbox}
-                          isRestoring={isRestoringSnapshot}
-                          isReconnecting={
-                            isReconnectingSandbox && !isHibernatingUi
-                          }
-                          isHibernating={isHibernatingUi}
                           isArchived={isArchived}
-                          isInitializing={
-                            reconnectionStatus === "idle" ||
-                            isAutoRestoringOnEntry
-                          }
                           snapshotPending={isArchiveSnapshotPending}
-                          hasSnapshot={hasSnapshot}
-                          onRestore={handleRestoreSnapshot}
-                          onCreateNew={handleCreateNewSandbox}
                         />
 
                         {/* Attachments preview */}
@@ -4199,7 +4006,7 @@ export function SessionChatContent({
                                 !hasPendingResponse
                               ) {
                                 e.preventDefault();
-                                if (!isArchived && isSandboxActive) {
+                                if (!isArchived) {
                                   e.currentTarget.form?.requestSubmit();
                                 }
                               }
@@ -4396,8 +4203,7 @@ export function SessionChatContent({
                                         (!input.trim() &&
                                           images.length === 0 &&
                                           textAttachments.length === 0) ||
-                                        isUpdatingModel ||
-                                        !isSandboxActive
+                                        isUpdatingModel
                                       }
                                       className="h-8 w-8 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-30"
                                     >
@@ -4405,11 +4211,6 @@ export function SessionChatContent({
                                     </Button>
                                   </span>
                                 </TooltipTrigger>
-                                {!isSandboxActive && !isArchived && (
-                                  <TooltipContent side="top" sideOffset={8}>
-                                    Waiting for sandbox...
-                                  </TooltipContent>
-                                )}
                               </Tooltip>
                             )}
                           </div>

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -18,7 +18,10 @@ import type { SandboxStatusResponse } from "@/app/api/sandbox/status/route";
 import type { DiffResponse } from "@/app/api/sessions/[sessionId]/diff/route";
 import type { FileSuggestion } from "@/app/api/sessions/[sessionId]/files/route";
 import type { SkillSuggestion } from "@/app/api/sessions/[sessionId]/skills/route";
-import type { WebAgentUIMessage } from "@/app/types";
+import type {
+  WebAgentUIMessage,
+  WebAgentWorkspaceStatusData,
+} from "@/app/types";
 import { useModelOptions } from "@/hooks/use-model-options";
 import { useUserPreferences } from "@/hooks/use-user-preferences";
 import { useSessionDiff } from "@/hooks/use-session-diff";
@@ -107,6 +110,8 @@ type SessionChatContextValue = {
   contextLimit: number | null;
   stopChatStream: () => void;
   sandboxInfo: SandboxInfo | null;
+  workspaceStatus: WebAgentWorkspaceStatusData | null;
+  clearWorkspaceStatus: () => void;
   setSandboxInfo: (info: SandboxInfo) => void;
   clearSandboxInfo: () => void;
   archiveSession: () => Promise<void>;
@@ -204,6 +209,8 @@ type SessionChatRuntimeContextValue = Pick<
   | "chat"
   | "contextLimit"
   | "stopChatStream"
+  | "workspaceStatus"
+  | "clearWorkspaceStatus"
   | "retryChatStream"
   | "hadInitialMessages"
   | "initialMessages"
@@ -331,7 +338,13 @@ export function SessionChatProvider({
     [modelOptions, chatInfo.modelId],
   );
   const hadInitialMessages = initialMessages.length > 0;
-  const { chat, stopChatStream, retryChatStream } = useSessionChatRuntime({
+  const {
+    chat,
+    stopChatStream,
+    retryChatStream,
+    workspaceStatus,
+    clearWorkspaceStatus,
+  } = useSessionChatRuntime({
     sessionId: sessionRecord.id,
     chatId: chatInfo.id,
     initialMessages,
@@ -1017,6 +1030,8 @@ export function SessionChatProvider({
       contextLimit,
       stopChatStream,
       retryChatStream,
+      workspaceStatus,
+      clearWorkspaceStatus,
       hadInitialMessages,
       initialMessages,
     }),
@@ -1025,6 +1040,8 @@ export function SessionChatProvider({
       contextLimit,
       stopChatStream,
       retryChatStream,
+      workspaceStatus,
+      clearWorkspaceStatus,
       hadInitialMessages,
       initialMessages,
     ],

--- a/apps/web/app/types.ts
+++ b/apps/web/app/types.ts
@@ -60,10 +60,16 @@ export type WebAgentSnippetData = {
   filename: string;
 };
 
+export type WebAgentWorkspaceStatusData = {
+  status: "setting-up";
+  message: string;
+};
+
 export type WebAgentDataParts = {
   commit: WebAgentCommitData;
   pr: WebAgentPrData;
   snippet: WebAgentSnippetData;
+  "workspace-status": WebAgentWorkspaceStatusData;
 };
 
 // All types derived from the agent

--- a/apps/web/app/workflows/chat-post-finish.ts
+++ b/apps/web/app/workflows/chat-post-finish.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelUsage } from "ai";
+import { isToolUIPart, type LanguageModelUsage } from "ai";
 import type { SandboxState, Sandbox } from "@open-agents/sandbox";
 import type { WebAgentUIMessage } from "@/app/types";
 import type { AutoCommitResult } from "@/lib/chat/auto-commit-direct";
@@ -129,6 +129,50 @@ export async function persistUserMessage(
     await updateChat(chatId, { title });
   } catch (error) {
     console.error("[workflow] Failed to persist user message:", error);
+  }
+}
+
+export async function persistAssistantMessageWithToolResults(
+  chatId: string,
+  message: WebAgentUIMessage,
+): Promise<void> {
+  "use step";
+
+  if (message.role !== "assistant") {
+    return;
+  }
+
+  const hasToolResults = message.parts.some(
+    (part) =>
+      isToolUIPart(part) &&
+      (part.state === "output-available" ||
+        part.state === "output-error" ||
+        part.state === "approval-responded"),
+  );
+
+  if (!hasToolResults) {
+    return;
+  }
+
+  try {
+    const dedupedMessage = dedupeMessageReasoning(message);
+    const result = await upsertChatMessageScoped({
+      id: dedupedMessage.id,
+      chatId,
+      role: "assistant",
+      parts: dedupedMessage,
+    });
+
+    if (result.status === "conflict") {
+      console.warn(
+        `[workflow] Skipped assistant tool-result upsert due to ID scope conflict: ${message.id}`,
+      );
+    }
+  } catch (error) {
+    console.error(
+      "[workflow] Failed to persist assistant message with tool results:",
+      error,
+    );
   }
 }
 

--- a/apps/web/app/workflows/chat-sandbox-runtime.ts
+++ b/apps/web/app/workflows/chat-sandbox-runtime.ts
@@ -4,6 +4,9 @@ import {
   type Sandbox,
   type SandboxState,
 } from "@open-agents/sandbox";
+import type { UIMessageChunk } from "ai";
+import { getWritable } from "workflow";
+import type { WebAgentWorkspaceStatusData } from "@/app/types";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { getGitHubUserProfile, getUserGitHubToken } from "@/lib/github/token";
 import {
@@ -142,13 +145,18 @@ async function loadSessionSkills(params: {
   return discoveredSkills;
 }
 
-export async function shouldEmitWorkspaceSetupStatus(
-  sessionId: string,
-): Promise<boolean> {
-  "use step";
-
-  const session = await getSessionById(sessionId);
-  return !isSandboxActive(session?.sandboxState);
+async function sendWorkspaceStatus(data: WebAgentWorkspaceStatusData) {
+  const writer = getWritable<UIMessageChunk>().getWriter();
+  try {
+    await writer.write({
+      type: "data-workspace-status",
+      id: "workspace-status",
+      data,
+      transient: true,
+    });
+  } finally {
+    writer.releaseLock();
+  }
 }
 
 export async function resolveChatSandboxRuntime(params: {
@@ -165,13 +173,22 @@ export async function resolveChatSandboxRuntime(params: {
     throw new Error("Unauthorized");
   }
 
-  const githubToken = await getUserGitHubToken(params.userId);
+  const didSetupWorkspace = !isSandboxActive(session.sandboxState);
+  if (didSetupWorkspace) {
+    await sendWorkspaceStatus({
+      status: "setting-up",
+      message: "Setting up the workspace...",
+    });
+  }
+
+  const [githubToken, gitUser] = await Promise.all([
+    getUserGitHubToken(params.userId),
+    getGitUser(params.userId),
+  ]);
   if (session.cloneUrl && !githubToken) {
     throw new Error("Connect GitHub to access repositories");
   }
 
-  const didSetupWorkspace = !isSandboxActive(session.sandboxState);
-  const gitUser = await getGitUser(params.userId);
   const sandbox = await connectSandbox({
     state: buildSandboxState(session),
     options: {
@@ -186,24 +203,25 @@ export async function resolveChatSandboxRuntime(params: {
     },
   });
 
-  await installSessionGlobalSkills({
-    session,
-    sandbox,
-    didSetupWorkspace,
-  });
-
   const rawSandboxState = sandbox.getState?.();
   const sandboxState = isSandboxState(rawSandboxState)
     ? rawSandboxState
     : buildSandboxState(session);
 
-  await updateSession(params.sessionId, {
-    sandboxState,
-    snapshotUrl: null,
-    snapshotCreatedAt: null,
-    lifecycleVersion: getNextLifecycleVersion(session.lifecycleVersion),
-    ...buildActiveLifecycleUpdate(sandboxState),
-  });
+  await Promise.all([
+    updateSession(params.sessionId, {
+      sandboxState,
+      snapshotUrl: null,
+      snapshotCreatedAt: null,
+      lifecycleVersion: getNextLifecycleVersion(session.lifecycleVersion),
+      ...buildActiveLifecycleUpdate(sandboxState),
+    }),
+    installSessionGlobalSkills({
+      session,
+      sandbox,
+      didSetupWorkspace,
+    }),
+  ]);
 
   kickSandboxLifecycleWorkflow({
     sessionId: params.sessionId,

--- a/apps/web/app/workflows/chat-sandbox-runtime.ts
+++ b/apps/web/app/workflows/chat-sandbox-runtime.ts
@@ -184,6 +184,9 @@ export async function resolveChatSandboxRuntime(params: {
   if (session.userId !== params.userId) {
     throw new Error("Unauthorized");
   }
+  if (session.status === "archived") {
+    throw new Error("Session is archived");
+  }
 
   const didSetupWorkspace = !isSandboxActive(session.sandboxState);
   if (didSetupWorkspace) {

--- a/apps/web/app/workflows/chat-sandbox-runtime.ts
+++ b/apps/web/app/workflows/chat-sandbox-runtime.ts
@@ -159,11 +159,23 @@ async function sendWorkspaceStatus(data: WebAgentWorkspaceStatusData) {
   }
 }
 
+async function sendStart(messageId: string) {
+  const writer = getWritable<UIMessageChunk>().getWriter();
+  try {
+    await writer.write({ type: "start", messageId });
+  } finally {
+    writer.releaseLock();
+  }
+}
+
 export async function resolveChatSandboxRuntime(params: {
   userId: string;
   sessionId: string;
+  assistantId: string;
 }): Promise<ResolvedChatSandboxRuntime> {
   "use step";
+
+  await sendStart(params.assistantId);
 
   const session = await getSessionById(params.sessionId);
   if (!session) {

--- a/apps/web/app/workflows/chat-sandbox-runtime.ts
+++ b/apps/web/app/workflows/chat-sandbox-runtime.ts
@@ -1,0 +1,230 @@
+import { discoverSkills } from "@open-agents/agent";
+import {
+  connectSandbox,
+  type Sandbox,
+  type SandboxState,
+} from "@open-agents/sandbox";
+import { getSessionById, updateSession } from "@/lib/db/sessions";
+import { getGitHubUserProfile, getUserGitHubToken } from "@/lib/github/token";
+import {
+  buildActiveLifecycleUpdate,
+  getNextLifecycleVersion,
+} from "@/lib/sandbox/lifecycle";
+import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
+import {
+  DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
+  DEFAULT_SANDBOX_PORTS,
+  DEFAULT_SANDBOX_TIMEOUT_MS,
+} from "@/lib/sandbox/config";
+import {
+  getResumableSandboxName,
+  getSessionSandboxName,
+  isSandboxActive,
+} from "@/lib/sandbox/utils";
+import { getSandboxSkillDirectories } from "@/lib/skills/directories";
+import { installGlobalSkills } from "@/lib/skills/global-skill-installer";
+import { getCachedSkills, setCachedSkills } from "@/lib/skills-cache";
+
+type SessionRecord = NonNullable<Awaited<ReturnType<typeof getSessionById>>>;
+type DiscoveredSkills = Awaited<ReturnType<typeof discoverSkills>>;
+
+export type ResolvedChatSandboxRuntime = {
+  sandboxState: SandboxState;
+  workingDirectory: string;
+  currentBranch?: string;
+  environmentDetails?: string;
+  skills: DiscoveredSkills;
+  didSetupWorkspace: boolean;
+  sessionTitle: string;
+  repoOwner?: string;
+  repoName?: string;
+};
+
+function isSandboxState(value: unknown): value is SandboxState {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "vercel"
+  );
+}
+
+function buildSandboxSource(session: SessionRecord): SandboxState["source"] {
+  if (!session.cloneUrl) {
+    return undefined;
+  }
+
+  const branchExistsOnOrigin = session.prNumber != null;
+  const shouldCreateNewBranch = session.isNewBranch && !branchExistsOnOrigin;
+
+  return {
+    repo: session.cloneUrl,
+    ...(shouldCreateNewBranch
+      ? { newBranch: session.branch ?? undefined }
+      : { branch: session.branch ?? "main" }),
+  };
+}
+
+function buildSandboxState(session: SessionRecord): SandboxState {
+  const existingState = session.sandboxState;
+  const sandboxName =
+    getResumableSandboxName(existingState) ?? getSessionSandboxName(session.id);
+  const source = buildSandboxSource(session);
+
+  return {
+    type: "vercel",
+    ...(isSandboxState(existingState) ? existingState : {}),
+    sandboxName,
+    ...(source ? { source } : {}),
+  };
+}
+
+async function getGitUser(userId: string) {
+  const profile = await getGitHubUserProfile(userId);
+  const githubNoreplyEmail =
+    profile?.externalUserId && profile.username
+      ? `${profile.externalUserId}+${profile.username}@users.noreply.github.com`
+      : undefined;
+
+  return {
+    name: profile?.username ?? "Open Harness",
+    email: githubNoreplyEmail ?? `${userId}@users.noreply.github.com`,
+  };
+}
+
+async function installSessionGlobalSkills(params: {
+  session: SessionRecord;
+  sandbox: Sandbox;
+  didSetupWorkspace: boolean;
+}): Promise<void> {
+  if (!params.didSetupWorkspace) {
+    return;
+  }
+
+  const globalSkillRefs = params.session.globalSkillRefs ?? [];
+  if (globalSkillRefs.length === 0) {
+    return;
+  }
+
+  try {
+    await installGlobalSkills({
+      sandbox: params.sandbox,
+      globalSkillRefs,
+    });
+  } catch (error) {
+    console.error(
+      `Failed to install global skills for session ${params.session.id}:`,
+      error,
+    );
+  }
+}
+
+async function loadSessionSkills(params: {
+  sessionId: string;
+  sandboxState: SandboxState;
+  sandbox: Sandbox;
+}): Promise<DiscoveredSkills> {
+  const cachedSkills = await getCachedSkills(
+    params.sessionId,
+    params.sandboxState,
+  );
+  if (cachedSkills !== null) {
+    return cachedSkills;
+  }
+
+  const skillDirs = await getSandboxSkillDirectories(params.sandbox);
+  const discoveredSkills = await discoverSkills(params.sandbox, skillDirs);
+  await setCachedSkills(
+    params.sessionId,
+    params.sandboxState,
+    discoveredSkills,
+  );
+  return discoveredSkills;
+}
+
+export async function shouldEmitWorkspaceSetupStatus(
+  sessionId: string,
+): Promise<boolean> {
+  "use step";
+
+  const session = await getSessionById(sessionId);
+  return !isSandboxActive(session?.sandboxState);
+}
+
+export async function resolveChatSandboxRuntime(params: {
+  userId: string;
+  sessionId: string;
+}): Promise<ResolvedChatSandboxRuntime> {
+  "use step";
+
+  const session = await getSessionById(params.sessionId);
+  if (!session) {
+    throw new Error("Session not found");
+  }
+  if (session.userId !== params.userId) {
+    throw new Error("Unauthorized");
+  }
+
+  const githubToken = await getUserGitHubToken(params.userId);
+  if (session.cloneUrl && !githubToken) {
+    throw new Error("Connect GitHub to access repositories");
+  }
+
+  const didSetupWorkspace = !isSandboxActive(session.sandboxState);
+  const gitUser = await getGitUser(params.userId);
+  const sandbox = await connectSandbox({
+    state: buildSandboxState(session),
+    options: {
+      githubToken: githubToken ?? undefined,
+      gitUser,
+      timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+      ports: DEFAULT_SANDBOX_PORTS,
+      baseSnapshotId: DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
+      persistent: true,
+      resume: true,
+      createIfMissing: true,
+    },
+  });
+
+  await installSessionGlobalSkills({
+    session,
+    sandbox,
+    didSetupWorkspace,
+  });
+
+  const rawSandboxState = sandbox.getState?.();
+  const sandboxState = isSandboxState(rawSandboxState)
+    ? rawSandboxState
+    : buildSandboxState(session);
+
+  await updateSession(params.sessionId, {
+    sandboxState,
+    snapshotUrl: null,
+    snapshotCreatedAt: null,
+    lifecycleVersion: getNextLifecycleVersion(session.lifecycleVersion),
+    ...buildActiveLifecycleUpdate(sandboxState),
+  });
+
+  kickSandboxLifecycleWorkflow({
+    sessionId: params.sessionId,
+    reason: "sandbox-created",
+  });
+
+  const skills = await loadSessionSkills({
+    sessionId: params.sessionId,
+    sandboxState,
+    sandbox,
+  });
+
+  return {
+    sandboxState,
+    workingDirectory: sandbox.workingDirectory,
+    currentBranch: sandbox.currentBranch,
+    environmentDetails: sandbox.environmentDetails,
+    skills,
+    didSetupWorkspace,
+    sessionTitle: session.title,
+    repoOwner: session.repoOwner ?? undefined,
+    repoName: session.repoName ?? undefined,
+  };
+}

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -6,9 +6,50 @@ import type { UIMessageChunk } from "ai";
 const writtenChunks: UIMessageChunk[] = [];
 let runStatus: string = "running";
 
+type TestResolvedChatSandboxRuntime = {
+  sandboxState: {
+    type: "vercel";
+    sandboxName: string;
+    expiresAt: number;
+  };
+  workingDirectory: string;
+  currentBranch: string;
+  environmentDetails: string;
+  skills: never[];
+  didSetupWorkspace: boolean;
+  sessionTitle: string;
+  repoOwner?: string;
+  repoName?: string;
+};
+
+function createResolvedChatSandboxRuntime(
+  overrides: Partial<TestResolvedChatSandboxRuntime> = {},
+): TestResolvedChatSandboxRuntime {
+  return {
+    sandboxState: {
+      type: "vercel",
+      sandboxName: "session_session-1",
+      expiresAt: Date.now() + 60_000,
+    },
+    workingDirectory: "/vercel/sandbox",
+    currentBranch: "main",
+    environmentDetails: "test sandbox",
+    skills: [],
+    didSetupWorkspace: false,
+    sessionTitle: "Session title",
+    repoOwner: "acme",
+    repoName: "repo",
+    ...overrides,
+  };
+}
+
 const spies = {
   persistAssistantMessage: mock(() => Promise.resolve()),
   persistSandboxState: mock(() => Promise.resolve()),
+  shouldEmitWorkspaceSetupStatus: mock(() => Promise.resolve(false)),
+  resolveChatSandboxRuntime: mock(() =>
+    Promise.resolve(createResolvedChatSandboxRuntime()),
+  ),
   claimActiveStream: mock(() => Promise.resolve("claimed")),
   clearActiveStream: mock(() => Promise.resolve()),
   recordWorkflowUsage: mock(() => Promise.resolve()),
@@ -228,6 +269,11 @@ mock.module("ai", () => ({
 
 mock.module("@open-agents/agent", () => ({}));
 
+mock.module("./chat-sandbox-runtime", () => ({
+  shouldEmitWorkspaceSetupStatus: spies.shouldEmitWorkspaceSetupStatus,
+  resolveChatSandboxRuntime: spies.resolveChatSandboxRuntime,
+}));
+
 const { runAgentWorkflow } = await import("./chat");
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -246,9 +292,7 @@ function makeOptions(overrides?: Record<string, unknown>) {
     userId: "user-1",
     selectedModelId: "gpt-4",
     modelId: "gpt-4",
-    agentOptions: {
-      sandbox: { state: { type: "vercel" } },
-    },
+    agentOptions: {},
     maxSteps: 1,
     ...overrides,
   } as Parameters<typeof runAgentWorkflow>[0];
@@ -318,6 +362,25 @@ describe("runAgentWorkflow", () => {
     const types = writtenChunks.map((c) => c.type);
     expect(types[0]).toBe("start");
     expect(types[types.length - 1]).toBe("finish");
+  });
+
+  test("streams transient workspace setup status before assistant start", async () => {
+    spies.shouldEmitWorkspaceSetupStatus.mockImplementationOnce(() =>
+      Promise.resolve(true),
+    );
+
+    await runAgentWorkflow(makeOptions());
+
+    expect(writtenChunks[0]).toEqual({
+      type: "data-workspace-status",
+      id: "workspace-status",
+      data: {
+        status: "setting-up",
+        message: "Setting up the workspace...",
+      },
+      transient: true,
+    });
+    expect(writtenChunks[1]?.type).toBe("start");
   });
 
   test("persists assistant message after run", async () => {
@@ -903,16 +966,6 @@ describe("runAgentWorkflow", () => {
     expect(spies.persistSandboxState).toHaveBeenCalledTimes(1);
   });
 
-  test("skips sandbox state when no sandbox", async () => {
-    await runAgentWorkflow(
-      makeOptions({
-        agentOptions: {},
-      }),
-    );
-
-    expect(spies.persistSandboxState).not.toHaveBeenCalled();
-  });
-
   test("clears active stream in finally block", async () => {
     await runAgentWorkflow(makeOptions());
 
@@ -1212,8 +1265,6 @@ describe("runAgentWorkflow", () => {
     await runAgentWorkflow(
       makeOptions({
         autoCommitEnabled: false,
-        repoOwner: "acme",
-        repoName: "repo",
       }),
     );
 
@@ -1221,11 +1272,18 @@ describe("runAgentWorkflow", () => {
   });
 
   test("skips auto-commit when repoOwner is missing", async () => {
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(() =>
+      Promise.resolve(
+        createResolvedChatSandboxRuntime({
+          repoOwner: undefined,
+          repoName: "repo",
+        }),
+      ),
+    );
+
     await runAgentWorkflow(
       makeOptions({
         autoCommitEnabled: true,
-        repoOwner: undefined,
-        repoName: "repo",
       }),
     );
 
@@ -1233,11 +1291,18 @@ describe("runAgentWorkflow", () => {
   });
 
   test("skips auto-commit when repoName is missing", async () => {
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(() =>
+      Promise.resolve(
+        createResolvedChatSandboxRuntime({
+          repoOwner: "acme",
+          repoName: undefined,
+        }),
+      ),
+    );
+
     await runAgentWorkflow(
       makeOptions({
         autoCommitEnabled: true,
-        repoOwner: "acme",
-        repoName: undefined,
       }),
     );
 

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -46,9 +46,10 @@ function createResolvedChatSandboxRuntime(
 const spies = {
   persistAssistantMessage: mock(() => Promise.resolve()),
   persistSandboxState: mock(() => Promise.resolve()),
-  resolveChatSandboxRuntime: mock(() =>
-    Promise.resolve(createResolvedChatSandboxRuntime()),
-  ),
+  resolveChatSandboxRuntime: mock((params: { assistantId: string }) => {
+    writtenChunks.push({ type: "start", messageId: params.assistantId });
+    return Promise.resolve(createResolvedChatSandboxRuntime());
+  }),
   claimActiveStream: mock(() => Promise.resolve("claimed")),
   clearActiveStream: mock(() => Promise.resolve()),
   recordWorkflowUsage: mock(() => Promise.resolve()),
@@ -362,8 +363,9 @@ describe("runAgentWorkflow", () => {
     expect(types[types.length - 1]).toBe("finish");
   });
 
-  test("streams transient workspace setup status before assistant start", async () => {
-    spies.resolveChatSandboxRuntime.mockImplementationOnce(async () => {
+  test("streams transient workspace setup status from runtime prep", async () => {
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(async (params) => {
+      writtenChunks.push({ type: "start", messageId: params.assistantId });
       writtenChunks.push({
         type: "data-workspace-status",
         id: "workspace-status",
@@ -380,7 +382,8 @@ describe("runAgentWorkflow", () => {
 
     await runAgentWorkflow(makeOptions());
 
-    expect(writtenChunks[0]).toEqual({
+    expect(writtenChunks[0]).toEqual({ type: "start", messageId: "gen-id-1" });
+    expect(writtenChunks[1]).toEqual({
       type: "data-workspace-status",
       id: "workspace-status",
       data: {
@@ -389,7 +392,6 @@ describe("runAgentWorkflow", () => {
       },
       transient: true,
     });
-    expect(writtenChunks[1]?.type).toBe("start");
   });
 
   test("persists assistant message after run", async () => {

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -70,6 +70,34 @@ const spies = {
   ),
 };
 
+let testSessionRecord: {
+  id: string;
+  userId: string;
+  autoCommitPushOverride: boolean | null;
+  autoCreatePrOverride: boolean | null;
+  repoOwner: string | null;
+  repoName: string | null;
+};
+let testChatRecord: {
+  id: string;
+  sessionId: string;
+  modelId: string | null;
+};
+let testPreferences: {
+  defaultModelId: string;
+  defaultSubagentModelId: string | null;
+  defaultSandboxType: "vercel";
+  defaultDiffMode: "unified";
+  autoCommitPush: boolean;
+  autoCreatePr: boolean;
+  alertsEnabled: boolean;
+  alertSoundEnabled: boolean;
+  publicUsageEnabled: boolean;
+  globalSkillRefs: never[];
+  modelVariants: never[];
+  enabledModelIds: string[];
+};
+
 // Track what the agent stream yields
 let agentStreamParts: Array<Record<string, unknown>> = [];
 let agentFinishReason = "stop";
@@ -269,6 +297,15 @@ mock.module("ai", () => ({
 
 mock.module("@open-agents/agent", () => ({}));
 
+mock.module("@/lib/db/sessions", () => ({
+  getChatById: async () => testChatRecord,
+  getSessionById: async () => testSessionRecord,
+}));
+
+mock.module("@/lib/db/user-preferences", () => ({
+  getUserPreferences: async () => testPreferences,
+}));
+
 mock.module("./chat-sandbox-runtime", () => ({
   resolveChatSandboxRuntime: spies.resolveChatSandboxRuntime,
 }));
@@ -289,6 +326,16 @@ function makeOptions(overrides?: Record<string, unknown>) {
     chatId: "chat-1",
     sessionId: "session-1",
     userId: "user-1",
+    requestUrl: "http://localhost/api/chat",
+    authSession: {
+      authProvider: "vercel" as const,
+      user: {
+        id: "user-1",
+        username: "user",
+        email: "user@example.com",
+        avatar: "",
+      },
+    },
     selectedModelId: "gpt-4",
     modelId: "gpt-4",
     agentOptions: {},
@@ -315,6 +362,33 @@ beforeEach(() => {
   agentProviderMetadata = undefined;
   agentInputMessages = undefined;
   streamOnFinishCallback = undefined;
+  testSessionRecord = {
+    id: "session-1",
+    userId: "user-1",
+    autoCommitPushOverride: null,
+    autoCreatePrOverride: null,
+    repoOwner: "acme",
+    repoName: "repo",
+  };
+  testChatRecord = {
+    id: "chat-1",
+    sessionId: "session-1",
+    modelId: null,
+  };
+  testPreferences = {
+    defaultModelId: "anthropic/claude-haiku-4.5",
+    defaultSubagentModelId: null,
+    defaultSandboxType: "vercel",
+    defaultDiffMode: "unified",
+    autoCommitPush: false,
+    autoCreatePr: false,
+    alertsEnabled: true,
+    alertSoundEnabled: true,
+    publicUsageEnabled: false,
+    globalSkillRefs: [],
+    modelVariants: [],
+    enabledModelIds: [],
+  };
   Object.values(spies).forEach((s) => s.mockClear());
 });
 

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -44,6 +44,8 @@ function createResolvedChatSandboxRuntime(
 }
 
 const spies = {
+  persistUserMessage: mock(() => Promise.resolve()),
+  persistAssistantMessageWithToolResults: mock(() => Promise.resolve()),
   persistAssistantMessage: mock(() => Promise.resolve()),
   persistSandboxState: mock(() => Promise.resolve()),
   resolveChatSandboxRuntime: mock((params: { assistantId: string }) => {
@@ -474,6 +476,19 @@ describe("runAgentWorkflow", () => {
     expect(spies.persistAssistantMessage).toHaveBeenCalledTimes(1);
     const paCalls = spies.persistAssistantMessage.mock.calls as unknown[][];
     expect(paCalls[0][0]).toBe("chat-1");
+  });
+
+  test("persists incoming messages during workflow startup", async () => {
+    await runAgentWorkflow(makeOptions());
+
+    expect(spies.persistUserMessage).toHaveBeenCalledWith(
+      "chat-1",
+      expect.objectContaining({ id: "user-1", role: "user" }),
+    );
+    expect(spies.persistAssistantMessageWithToolResults).toHaveBeenCalledWith(
+      "chat-1",
+      expect.objectContaining({ id: "user-1", role: "user" }),
+    );
   });
 
   test("records usage after run", async () => {

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -475,6 +475,64 @@ describe("runAgentWorkflow", () => {
     });
   });
 
+  test("streams a user-visible message when workspace setup fails", async () => {
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(async (params) => {
+      writtenChunks.push({ type: "start", messageId: params.assistantId });
+      throw new Error("Connect GitHub to access repositories");
+    });
+
+    await expect(runAgentWorkflow(makeOptions())).rejects.toThrow(
+      "Connect GitHub to access repositories",
+    );
+
+    expect(writtenChunks).toEqual(
+      expect.arrayContaining([
+        { type: "start", messageId: "gen-id-1" },
+        { type: "text-start", id: "setup-error" },
+        {
+          type: "text-delta",
+          id: "setup-error",
+          delta: "Connect GitHub to access this repository, then try again.",
+        },
+        { type: "text-end", id: "setup-error" },
+      ]),
+    );
+    expect(spies.persistAssistantMessage).toHaveBeenCalledWith(
+      "chat-1",
+      expect.objectContaining({
+        id: "gen-id-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "Connect GitHub to access this repository, then try again.",
+          },
+        ],
+      }),
+    );
+  });
+
+  test("streams an archived-session setup message when runtime rejects", async () => {
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(async (params) => {
+      writtenChunks.push({ type: "start", messageId: params.assistantId });
+      throw new Error("Session is archived");
+    });
+
+    await expect(runAgentWorkflow(makeOptions())).rejects.toThrow(
+      "Session is archived",
+    );
+
+    expect(writtenChunks).toEqual(
+      expect.arrayContaining([
+        {
+          type: "text-delta",
+          id: "setup-error",
+          delta: "This session is archived. Unarchive it to continue.",
+        },
+      ]),
+    );
+  });
+
   test("persists assistant message after run", async () => {
     await runAgentWorkflow(makeOptions());
 

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -46,7 +46,6 @@ function createResolvedChatSandboxRuntime(
 const spies = {
   persistAssistantMessage: mock(() => Promise.resolve()),
   persistSandboxState: mock(() => Promise.resolve()),
-  shouldEmitWorkspaceSetupStatus: mock(() => Promise.resolve(false)),
   resolveChatSandboxRuntime: mock(() =>
     Promise.resolve(createResolvedChatSandboxRuntime()),
   ),
@@ -270,7 +269,6 @@ mock.module("ai", () => ({
 mock.module("@open-agents/agent", () => ({}));
 
 mock.module("./chat-sandbox-runtime", () => ({
-  shouldEmitWorkspaceSetupStatus: spies.shouldEmitWorkspaceSetupStatus,
   resolveChatSandboxRuntime: spies.resolveChatSandboxRuntime,
 }));
 
@@ -365,9 +363,20 @@ describe("runAgentWorkflow", () => {
   });
 
   test("streams transient workspace setup status before assistant start", async () => {
-    spies.shouldEmitWorkspaceSetupStatus.mockImplementationOnce(() =>
-      Promise.resolve(true),
-    );
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(async () => {
+      writtenChunks.push({
+        type: "data-workspace-status",
+        id: "workspace-status",
+        data: {
+          status: "setting-up",
+          message: "Setting up the workspace...",
+        },
+        transient: true,
+      });
+      return createResolvedChatSandboxRuntime({
+        didSetupWorkspace: true,
+      });
+    });
 
     await runAgentWorkflow(makeOptions());
 

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -102,6 +102,7 @@ let testPreferences: {
 
 // Track what the agent stream yields
 let agentStreamParts: Array<Record<string, unknown>> = [];
+let agentAssistantParts: Array<Record<string, unknown>> | undefined;
 let agentFinishReason = "stop";
 let agentRawFinishReason: string | undefined = "provider_stop";
 let agentTotalUsage = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
@@ -203,7 +204,9 @@ mock.module("@/app/config", () => ({
               : {
                   id: "assistant-1",
                   role: "assistant",
-                  parts: [{ type: "text", text: "Hello!" }],
+                  parts: agentAssistantParts ?? [
+                    { type: "text", text: "Hello!" },
+                  ],
                   metadata: {},
                 }
           ) as {
@@ -289,7 +292,8 @@ mock.module("ai", () => ({
       };
     }),
   generateId: () => "gen-id-1",
-  isToolUIPart: (part: { type: string }) => part.type === "tool-invocation",
+  isToolUIPart: (part: { type: string }) =>
+    part.type === "tool-invocation" || part.type.startsWith("tool-"),
   pruneMessages: ({ messages }: { messages: Array<Record<string, unknown>> }) =>
     messages.filter((message) => {
       const content = message.content;
@@ -352,6 +356,7 @@ beforeEach(() => {
   writtenChunks.length = 0;
   runStatus = "running";
   agentStreamParts = [{ type: "text-delta", textDelta: "Hi" }];
+  agentAssistantParts = undefined;
   agentFinishReason = "stop";
   agentRawFinishReason = "provider_stop";
   agentTotalUsage = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
@@ -1075,7 +1080,26 @@ describe("runAgentWorkflow", () => {
     );
   });
 
-  test("refreshes diff cache after run", async () => {
+  test("skips diff cache refresh when no file-changing tools ran", async () => {
+    await runAgentWorkflow(makeOptions());
+
+    expect(spies.refreshDiffCache).not.toHaveBeenCalled();
+  });
+
+  test("refreshes diff cache after a write tool runs", async () => {
+    agentStreamParts = [];
+    agentResponseMessages = [];
+    agentResponse = { messages: agentResponseMessages };
+    streamOnFinishCallback = undefined;
+    const writeToolPart = {
+      type: "tool-write",
+      toolCallId: "write-1",
+      state: "output-available",
+      input: { filePath: "app/page.tsx" },
+      output: { success: true },
+    };
+    agentAssistantParts = [writeToolPart];
+
     await runAgentWorkflow(makeOptions());
 
     expect(spies.refreshDiffCache).toHaveBeenCalledTimes(1);

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -11,6 +11,7 @@ import {
 import type { OpenAgentCallOptions } from "@open-agents/agent";
 import { getWorkflowMetadata, getWritable } from "workflow";
 import { getRun } from "workflow/api";
+import { assistantFileLinkPrompt } from "@/lib/assistant-file-links";
 import { addLanguageModelUsage } from "./usage-utils";
 import { extractGatewayCost } from "./gateway-metadata";
 import type {
@@ -33,25 +34,46 @@ import {
   runAutoCreatePrStep,
 } from "./chat-post-finish";
 import { dedupeMessageReasoning } from "@/lib/chat/dedupe-message-reasoning";
+import { getChatById, getSessionById } from "@/lib/db/sessions";
+import { getUserPreferences } from "@/lib/db/user-preferences";
+import {
+  filterModelVariantsForSession,
+  sanitizeSelectedModelIdForSession,
+  sanitizeUserPreferencesForSession,
+} from "@/lib/model-access";
+import { getAllVariants } from "@/lib/model-variants";
+import { APP_DEFAULT_MODEL_ID } from "@/lib/models";
+import type { Session as AuthSession } from "@/lib/session/types";
 import type {
   WorkflowRunStatus,
   WorkflowRunStepTiming,
 } from "@/lib/db/workflow-runs";
+import { resolveChatModelSelection } from "../api/chat/_lib/model-selection";
 import { resolveChatSandboxRuntime } from "./chat-sandbox-runtime";
+
+type AuthSessionContext = Pick<AuthSession, "authProvider" | "user"> | null;
 
 type Options = {
   messages: WebAgentUIMessage[];
   chatId: string;
   sessionId: string;
   userId: string;
+  requestUrl: string;
+  authSession: AuthSessionContext;
+  selectedModelId?: string;
+  modelId?: string;
+  agentOptions?: Omit<OpenAgentCallOptions, "sandbox" | "skills">;
+  maxSteps?: number;
+  autoCommitEnabled?: boolean;
+  autoCreatePrEnabled?: boolean;
+};
+
+type ChatModelRuntime = {
   selectedModelId: string;
   modelId: string;
   agentOptions: Omit<OpenAgentCallOptions, "sandbox" | "skills">;
-  maxSteps?: number;
-  /** Whether auto-commit+push should run after a natural finish. */
-  autoCommitEnabled?: boolean;
-  /** Whether auto PR creation should run after auto-commit on a natural finish. */
-  autoCreatePrEnabled?: boolean;
+  autoCommitEnabled: boolean;
+  autoCreatePrEnabled: boolean;
 };
 
 type Writable = WritableStream<UIMessageChunk>;
@@ -92,6 +114,96 @@ const convertMessages = async (
     emptyMessages: "remove",
   });
 };
+
+async function resolveChatModelRuntime(params: {
+  userId: string;
+  sessionId: string;
+  chatId: string;
+  requestUrl: string;
+  authSession: AuthSessionContext;
+}): Promise<ChatModelRuntime> {
+  "use step";
+
+  const [sessionRecord, chat, rawPreferences] = await Promise.all([
+    getSessionById(params.sessionId),
+    getChatById(params.chatId),
+    getUserPreferences(params.userId).catch((error) => {
+      console.error("Failed to load user preferences:", error);
+      return null;
+    }),
+  ]);
+
+  if (!sessionRecord) {
+    throw new Error("Session not found");
+  }
+  if (sessionRecord.userId !== params.userId) {
+    throw new Error("Unauthorized");
+  }
+  if (!chat || chat.sessionId !== params.sessionId) {
+    throw new Error("Chat not found");
+  }
+
+  const preferences = rawPreferences
+    ? sanitizeUserPreferencesForSession(
+        rawPreferences,
+        params.authSession,
+        params.requestUrl,
+      )
+    : null;
+  const modelVariants = filterModelVariantsForSession(
+    getAllVariants(preferences?.modelVariants ?? []),
+    params.authSession,
+    params.requestUrl,
+  );
+  const selectedModelId =
+    sanitizeSelectedModelIdForSession(
+      chat.modelId,
+      modelVariants,
+      params.authSession,
+      params.requestUrl,
+    ) ??
+    chat.modelId ??
+    null;
+  const mainModelSelection = resolveChatModelSelection({
+    selectedModelId,
+    modelVariants,
+    missingVariantLabel: "Selected model variant",
+  });
+  const subagentModelSelection = preferences?.defaultSubagentModelId
+    ? resolveChatModelSelection({
+        selectedModelId: sanitizeSelectedModelIdForSession(
+          preferences.defaultSubagentModelId,
+          modelVariants,
+          params.authSession,
+          params.requestUrl,
+        ),
+        modelVariants,
+        missingVariantLabel: "Subagent model variant",
+      })
+    : undefined;
+  const autoCommitEnabled =
+    (sessionRecord.autoCommitPushOverride ??
+      preferences?.autoCommitPush ??
+      false) &&
+    Boolean(sessionRecord.repoOwner && sessionRecord.repoName);
+  const autoCreatePrEnabled =
+    autoCommitEnabled &&
+    (sessionRecord.autoCreatePrOverride ?? preferences?.autoCreatePr ?? false);
+
+  return {
+    selectedModelId: selectedModelId ?? mainModelSelection.id,
+    modelId: mainModelSelection.id,
+    agentOptions: {
+      model: mainModelSelection,
+      ...(subagentModelSelection
+        ? { subagentModel: subagentModelSelection }
+        : {}),
+      customInstructions: assistantFileLinkPrompt,
+    },
+    autoCommitEnabled,
+    autoCreatePrEnabled,
+  };
+}
 
 const generateId = async () => {
   "use step";
@@ -479,6 +591,8 @@ export async function runAgentWorkflow(options: Options) {
   const modelMessagesPromise = convertMessages(options.messages);
   const assistantId =
     latestMessage.role === "assistant" ? latestMessage.id : await generateId();
+  let selectedModelId = APP_DEFAULT_MODEL_ID;
+  let modelId = APP_DEFAULT_MODEL_ID;
 
   let pendingAssistantResponse: WebAgentUIMessage =
     latestMessage.role === "assistant"
@@ -486,8 +600,8 @@ export async function runAgentWorkflow(options: Options) {
           ...latestMessage,
           metadata: withModelMetadata(
             latestMessage.metadata,
-            options.selectedModelId,
-            options.modelId,
+            selectedModelId,
+            modelId,
           ),
           parts: [...latestMessage.parts],
         }
@@ -495,11 +609,7 @@ export async function runAgentWorkflow(options: Options) {
           role: "assistant",
           id: assistantId,
           parts: [],
-          metadata: withModelMetadata(
-            undefined,
-            options.selectedModelId,
-            options.modelId,
-          ),
+          metadata: withModelMetadata(undefined, selectedModelId, modelId),
         };
 
   let originalMessagesForStep: WebAgentUIMessage[] = [latestMessage];
@@ -518,16 +628,34 @@ export async function runAgentWorkflow(options: Options) {
   let sandboxState: OpenAgentCallOptions["sandbox"]["state"] | undefined;
 
   try {
-    const [runtime, modelMessages] = await Promise.all([
+    const [runtime, modelRuntime, modelMessages] = await Promise.all([
       resolveChatSandboxRuntime({
         userId: options.userId,
         sessionId: options.sessionId,
         assistantId,
       }),
+      resolveChatModelRuntime({
+        userId: options.userId,
+        sessionId: options.sessionId,
+        chatId: options.chatId,
+        requestUrl: options.requestUrl,
+        authSession: options.authSession,
+      }),
       modelMessagesPromise,
     ]);
+    selectedModelId = options.selectedModelId ?? modelRuntime.selectedModelId;
+    modelId = options.modelId ?? modelRuntime.modelId;
+    pendingAssistantResponse = {
+      ...pendingAssistantResponse,
+      metadata: withModelMetadata(
+        pendingAssistantResponse.metadata,
+        selectedModelId,
+        modelId,
+      ),
+    };
 
     const agentOptions: OpenAgentCallOptions = {
+      ...modelRuntime.agentOptions,
       ...options.agentOptions,
       sandbox: {
         state: runtime.sandboxState,
@@ -555,8 +683,8 @@ export async function runAgentWorkflow(options: Options) {
           workflowRunId,
           options.chatId,
           options.sessionId,
-          options.selectedModelId,
-          options.modelId,
+          selectedModelId,
+          modelId,
           agentOptions,
           step + 1,
         );
@@ -635,7 +763,7 @@ export async function runAgentWorkflow(options: Options) {
 
     const canAutoCommit =
       finishedNaturally &&
-      options.autoCommitEnabled &&
+      (options.autoCommitEnabled ?? modelRuntime.autoCommitEnabled) &&
       sandboxState != null &&
       repoOwner != null &&
       repoName != null;
@@ -692,7 +820,10 @@ export async function runAgentWorkflow(options: Options) {
       !autoCommitResult.error &&
       (autoCommitResult.pushed || !autoCommitResult.committed);
 
-    if (canAutoCommit && options.autoCreatePrEnabled) {
+    if (
+      canAutoCommit &&
+      (options.autoCreatePrEnabled ?? modelRuntime.autoCreatePrEnabled)
+    ) {
       if (canAutoCreatePr) {
         const pendingPrPart = {
           type: "data-pr" as const,
@@ -782,7 +913,7 @@ export async function runAgentWorkflow(options: Options) {
       const runFinishedAt = new Date();
       await recordWorkflowUsage(
         options.userId,
-        options.modelId,
+        modelId,
         totalUsage,
         pendingAssistantResponse,
         previousResponseMessage,

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -19,7 +19,6 @@ import type {
   WebAgentPrData,
   WebAgentStepFinishMetadata,
   WebAgentUIMessage,
-  WebAgentWorkspaceStatusData,
 } from "@/app/types";
 import {
   claimActiveStream,
@@ -38,10 +37,7 @@ import type {
   WorkflowRunStatus,
   WorkflowRunStepTiming,
 } from "@/lib/db/workflow-runs";
-import {
-  resolveChatSandboxRuntime,
-  shouldEmitWorkspaceSetupStatus,
-} from "./chat-sandbox-runtime";
+import { resolveChatSandboxRuntime } from "./chat-sandbox-runtime";
 
 type Options = {
   messages: WebAgentUIMessage[];
@@ -449,24 +445,6 @@ async function sendDataPart(
   }
 }
 
-async function sendWorkspaceStatus(
-  writable: Writable,
-  data: WebAgentWorkspaceStatusData,
-) {
-  "use step";
-  const writer = writable.getWriter();
-  try {
-    await writer.write({
-      type: "data-workspace-status",
-      id: "workspace-status",
-      data,
-      transient: true,
-    });
-  } finally {
-    writer.releaseLock();
-  }
-}
-
 export async function runAgentWorkflow(options: Options) {
   "use workflow";
 
@@ -498,6 +476,7 @@ export async function runAgentWorkflow(options: Options) {
     return;
   }
 
+  const modelMessagesPromise = convertMessages(options.messages);
   const assistantId =
     latestMessage.role === "assistant" ? latestMessage.id : await generateId();
 
@@ -539,30 +518,13 @@ export async function runAgentWorkflow(options: Options) {
   let sandboxState: OpenAgentCallOptions["sandbox"]["state"] | undefined;
 
   try {
-    const shouldShowWorkspaceSetup = await shouldEmitWorkspaceSetupStatus(
-      options.sessionId,
-    );
-    if (shouldShowWorkspaceSetup) {
-      await sendWorkspaceStatus(writable, {
-        status: "setting-up",
-        message: "Setting up the workspace...",
-      });
-    }
-
     const [runtime, modelMessages] = await Promise.all([
       resolveChatSandboxRuntime({
         userId: options.userId,
         sessionId: options.sessionId,
       }),
-      convertMessages(options.messages),
+      modelMessagesPromise,
     ]);
-
-    if (!shouldShowWorkspaceSetup && runtime.didSetupWorkspace) {
-      await sendWorkspaceStatus(writable, {
-        status: "setting-up",
-        message: "Setting up the workspace...",
-      });
-    }
 
     const agentOptions: OpenAgentCallOptions = {
       ...options.agentOptions,

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -522,6 +522,7 @@ export async function runAgentWorkflow(options: Options) {
       resolveChatSandboxRuntime({
         userId: options.userId,
         sessionId: options.sessionId,
+        assistantId,
       }),
       modelMessagesPromise,
     ]);
@@ -537,8 +538,6 @@ export async function runAgentWorkflow(options: Options) {
       ...(runtime.skills.length > 0 ? { skills: runtime.skills } : {}),
     };
     sandboxState = runtime.sandboxState;
-
-    await sendStart(writable, assistantId);
 
     for (
       let step = 0;
@@ -1119,16 +1118,6 @@ function delay(ms: number) {
 
 function isAbortError(error: unknown) {
   return error instanceof Error && error.name === "AbortError";
-}
-
-async function sendStart(writable: Writable, messageId: string) {
-  "use step";
-  const writer = writable.getWriter();
-  try {
-    await writer.write({ type: "start", messageId });
-  } finally {
-    writer.releaseLock();
-  }
 }
 
 async function sendFinish(writable: Writable) {

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -26,7 +26,9 @@ import {
   clearActiveStream,
   hasAutoCommitChangesStep,
   persistAssistantMessage,
+  persistAssistantMessageWithToolResults,
   persistSandboxState,
+  persistUserMessage,
   recordWorkflowUsage,
   refreshDiffCache,
   refreshLifecycleActivity,
@@ -209,6 +211,23 @@ const generateId = async () => {
   "use step";
   return generateIdAi();
 };
+
+async function persistInputMessages(
+  chatId: string,
+  messages: WebAgentUIMessage[],
+): Promise<void> {
+  "use step";
+
+  const latestMessage = messages[messages.length - 1];
+  if (!latestMessage) {
+    return;
+  }
+
+  await Promise.all([
+    persistUserMessage(chatId, latestMessage),
+    persistAssistantMessageWithToolResults(chatId, latestMessage),
+  ]);
+}
 
 function buildStepTiming(
   stepNumber: number,
@@ -589,6 +608,10 @@ export async function runAgentWorkflow(options: Options) {
   }
 
   const modelMessagesPromise = convertMessages(options.messages);
+  const inputMessagesPersistPromise = persistInputMessages(
+    options.chatId,
+    options.messages,
+  );
   const assistantId =
     latestMessage.role === "assistant" ? latestMessage.id : await generateId();
   let selectedModelId = APP_DEFAULT_MODEL_ID;
@@ -642,6 +665,7 @@ export async function runAgentWorkflow(options: Options) {
         authSession: options.authSession,
       }),
       modelMessagesPromise,
+      inputMessagesPersistPromise,
     ]);
     selectedModelId = options.selectedModelId ?? modelRuntime.selectedModelId;
     modelId = options.modelId ?? modelRuntime.modelId;

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -87,6 +87,23 @@ const shouldPauseForToolInteraction = (parts: WebAgentUIMessage["parts"]) =>
       (part.state === "input-available" || part.state === "approval-requested"),
   );
 
+const DIFF_REFRESHING_TOOL_TYPES = new Set([
+  "tool-write",
+  "tool-edit",
+  "tool-bash",
+]);
+
+function shouldRefreshDiffCacheForParts(
+  parts: WebAgentUIMessage["parts"],
+): boolean {
+  return parts.some(
+    (part) =>
+      isToolUIPart(part) &&
+      DIFF_REFRESHING_TOOL_TYPES.has(part.type) &&
+      (part.state === "output-available" || part.state === "output-error"),
+  );
+}
+
 const convertMessages = async (
   messages: WebAgentUIMessage[],
 ): Promise<ModelMessage[]> => {
@@ -649,6 +666,7 @@ export async function runAgentWorkflow(options: Options) {
   let workflowStatus: WorkflowRunStatus = "completed";
   let caughtError: unknown;
   let sandboxState: OpenAgentCallOptions["sandbox"]["state"] | undefined;
+  let shouldRefreshCachedDiff = false;
 
   try {
     const [runtime, modelRuntime, modelMessages] = await Promise.all([
@@ -722,6 +740,9 @@ export async function runAgentWorkflow(options: Options) {
       stepTimings.push(result.stepTiming);
       pendingAssistantResponse =
         result.responseMessage ?? pendingAssistantResponse;
+      shouldRefreshCachedDiff =
+        shouldRefreshCachedDiff ||
+        shouldRefreshDiffCacheForParts(pendingAssistantResponse.parts);
       originalMessagesForStep = [pendingAssistantResponse];
       modelMessages.push(...result.responseMessages);
       wasAborted = wasAborted || result.stepWasAborted;
@@ -836,6 +857,7 @@ export async function runAgentWorkflow(options: Options) {
           resolvedCommitPart,
         );
         await sendDataPart(writable, resolvedCommitPart);
+        shouldRefreshCachedDiff = true;
       }
     }
 
@@ -880,6 +902,7 @@ export async function runAgentWorkflow(options: Options) {
           resolvedPrPart,
         );
         await sendDataPart(writable, resolvedPrPart);
+        shouldRefreshCachedDiff = true;
       } else {
         const skippedPrPart = {
           type: "data-pr" as const,
@@ -911,7 +934,7 @@ export async function runAgentWorkflow(options: Options) {
     streamClosed = true;
 
     // Refresh the diff cache so the UI shows current changes.
-    if (sandboxState) {
+    if (sandboxState && shouldRefreshCachedDiff) {
       await refreshDiffCache(options.sessionId, sandboxState);
     }
 

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -19,6 +19,7 @@ import type {
   WebAgentPrData,
   WebAgentStepFinishMetadata,
   WebAgentUIMessage,
+  WebAgentWorkspaceStatusData,
 } from "@/app/types";
 import {
   claimActiveStream,
@@ -37,6 +38,10 @@ import type {
   WorkflowRunStatus,
   WorkflowRunStepTiming,
 } from "@/lib/db/workflow-runs";
+import {
+  resolveChatSandboxRuntime,
+  shouldEmitWorkspaceSetupStatus,
+} from "./chat-sandbox-runtime";
 
 type Options = {
   messages: WebAgentUIMessage[];
@@ -45,18 +50,12 @@ type Options = {
   userId: string;
   selectedModelId: string;
   modelId: string;
-  agentOptions: OpenAgentCallOptions;
+  agentOptions: Omit<OpenAgentCallOptions, "sandbox" | "skills">;
   maxSteps?: number;
   /** Whether auto-commit+push should run after a natural finish. */
   autoCommitEnabled?: boolean;
   /** Whether auto PR creation should run after auto-commit on a natural finish. */
   autoCreatePrEnabled?: boolean;
-  /** Session title for commit message generation. */
-  sessionTitle?: string;
-  /** GitHub repo owner (required for auto-commit and diff refresh). */
-  repoOwner?: string;
-  /** GitHub repo name (required for auto-commit). */
-  repoName?: string;
 };
 
 type Writable = WritableStream<UIMessageChunk>;
@@ -450,6 +449,24 @@ async function sendDataPart(
   }
 }
 
+async function sendWorkspaceStatus(
+  writable: Writable,
+  data: WebAgentWorkspaceStatusData,
+) {
+  "use step";
+  const writer = writable.getWriter();
+  try {
+    await writer.write({
+      type: "data-workspace-status",
+      id: "workspace-status",
+      data,
+      transient: true,
+    });
+  } finally {
+    writer.releaseLock();
+  }
+}
+
 export async function runAgentWorkflow(options: Options) {
   "use workflow";
 
@@ -481,12 +498,8 @@ export async function runAgentWorkflow(options: Options) {
     return;
   }
 
-  const [modelMessages, assistantId] = await Promise.all([
-    convertMessages(options.messages),
-    latestMessage.role === "assistant"
-      ? Promise.resolve(latestMessage.id)
-      : generateId(),
-  ]);
+  const assistantId =
+    latestMessage.role === "assistant" ? latestMessage.id : await generateId();
 
   let pendingAssistantResponse: WebAgentUIMessage =
     latestMessage.role === "assistant"
@@ -512,8 +525,6 @@ export async function runAgentWorkflow(options: Options) {
 
   let originalMessagesForStep: WebAgentUIMessage[] = [latestMessage];
 
-  await sendStart(writable, assistantId);
-
   const runStartedAt = new Date();
   const previousResponseMessage =
     latestMessage.role === "assistant" ? latestMessage : undefined;
@@ -525,9 +536,48 @@ export async function runAgentWorkflow(options: Options) {
   let streamClosed = false;
   let workflowStatus: WorkflowRunStatus = "completed";
   let caughtError: unknown;
-  const sandboxState = options.agentOptions.sandbox?.state;
+  let sandboxState: OpenAgentCallOptions["sandbox"]["state"] | undefined;
 
   try {
+    const shouldShowWorkspaceSetup = await shouldEmitWorkspaceSetupStatus(
+      options.sessionId,
+    );
+    if (shouldShowWorkspaceSetup) {
+      await sendWorkspaceStatus(writable, {
+        status: "setting-up",
+        message: "Setting up the workspace...",
+      });
+    }
+
+    const [runtime, modelMessages] = await Promise.all([
+      resolveChatSandboxRuntime({
+        userId: options.userId,
+        sessionId: options.sessionId,
+      }),
+      convertMessages(options.messages),
+    ]);
+
+    if (!shouldShowWorkspaceSetup && runtime.didSetupWorkspace) {
+      await sendWorkspaceStatus(writable, {
+        status: "setting-up",
+        message: "Setting up the workspace...",
+      });
+    }
+
+    const agentOptions: OpenAgentCallOptions = {
+      ...options.agentOptions,
+      sandbox: {
+        state: runtime.sandboxState,
+        workingDirectory: runtime.workingDirectory,
+        currentBranch: runtime.currentBranch,
+        environmentDetails: runtime.environmentDetails,
+      },
+      ...(runtime.skills.length > 0 ? { skills: runtime.skills } : {}),
+    };
+    sandboxState = runtime.sandboxState;
+
+    await sendStart(writable, assistantId);
+
     for (
       let step = 0;
       options.maxSteps === undefined || step < options.maxSteps;
@@ -546,7 +596,7 @@ export async function runAgentWorkflow(options: Options) {
           options.sessionId,
           options.selectedModelId,
           options.modelId,
-          options.agentOptions,
+          agentOptions,
           step + 1,
         );
       } catch (error) {
@@ -615,8 +665,8 @@ export async function runAgentWorkflow(options: Options) {
       finalFinishReason !== "tool-calls";
     const commitPartId = `${assistantId}:commit`;
     const prPartId = `${assistantId}:pr`;
-    const repoOwner = options.repoOwner;
-    const repoName = options.repoName;
+    const repoOwner = runtime.repoOwner;
+    const repoName = runtime.repoName;
     let didUpdateGitData = false;
 
     let autoCommitResult: Awaited<ReturnType<typeof runAutoCommitStep>> | null =
@@ -652,7 +702,7 @@ export async function runAgentWorkflow(options: Options) {
         ? await runAutoCommitStep({
             userId: options.userId,
             sessionId: options.sessionId,
-            sessionTitle: options.sessionTitle ?? "",
+            sessionTitle: runtime.sessionTitle,
             repoOwner,
             repoName,
             sandboxState,
@@ -698,7 +748,7 @@ export async function runAgentWorkflow(options: Options) {
         const autoPrResult = await runAutoCreatePrStep({
           userId: options.userId,
           sessionId: options.sessionId,
-          sessionTitle: options.sessionTitle ?? "",
+          sessionTitle: runtime.sessionTitle,
           repoOwner,
           repoName,
           sandboxState,

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -275,6 +275,22 @@ function withModelMetadata(
   };
 }
 
+function getSetupErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return "Workspace setup failed. Try again in a moment.";
+  }
+
+  if (error.message.includes("Connect GitHub")) {
+    return "Connect GitHub to access this repository, then try again.";
+  }
+
+  if (error.message === "Session is archived") {
+    return "This session is archived. Unarchive it to continue.";
+  }
+
+  return "Workspace setup failed. Try again in a moment.";
+}
+
 function isStepTimingError(
   error: unknown,
 ): error is Error & { stepTiming: WorkflowRunStepTiming } {
@@ -946,6 +962,16 @@ export async function runAgentWorkflow(options: Options) {
   } catch (error) {
     workflowStatus = wasAborted ? "aborted" : "failed";
     caughtError = error;
+
+    if (pendingAssistantResponse.parts.length === 0 && !streamClosed) {
+      const errorText = getSetupErrorMessage(error);
+      pendingAssistantResponse = {
+        ...pendingAssistantResponse,
+        parts: [{ type: "text", text: errorText }],
+      };
+      await sendTextMessage(writable, "setup-error", errorText);
+      await persistAssistantMessage(options.chatId, pendingAssistantResponse);
+    }
   } finally {
     try {
       // On unexpected errors, still clear the active stream and close
@@ -1303,6 +1329,18 @@ async function sendFinish(writable: Writable) {
   const writer = writable.getWriter();
   try {
     await writer.write({ type: "finish", finishReason: "stop" });
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+async function sendTextMessage(writable: Writable, id: string, text: string) {
+  "use step";
+  const writer = writable.getWriter();
+  try {
+    await writer.write({ type: "text-start", id });
+    await writer.write({ type: "text-delta", id, delta: text });
+    await writer.write({ type: "text-end", id });
   } finally {
     writer.releaseLock();
   }

--- a/apps/web/lib/chat-route-cleanup.test.ts
+++ b/apps/web/lib/chat-route-cleanup.test.ts
@@ -3,11 +3,16 @@ import { describe, expect, mock, test } from "bun:test";
 const spies = {
   abortChatInstanceTransport: mock((_chatId: string) => {}),
   removeChatInstance: mock((_chatId: string) => {}),
+  clearChatWorkspaceStatus: mock((_chatId: string) => {}),
 };
 
 mock.module("@/lib/chat-instance-manager", () => ({
   abortChatInstanceTransport: spies.abortChatInstanceTransport,
   removeChatInstance: spies.removeChatInstance,
+}));
+
+mock.module("@/lib/workspace-status-store", () => ({
+  clearChatWorkspaceStatus: spies.clearChatWorkspaceStatus,
 }));
 
 const cleanupModulePromise = import("./chat-route-cleanup");
@@ -23,15 +28,32 @@ describe("cleanupChatRouteOnUnmount", () => {
     const removeInstance = mock((chatId: string) => {
       calls.push(`remove:${chatId}`);
     });
+    const clearWorkspaceStatus = mock((chatId: string) => {
+      calls.push(`clear:${chatId}`);
+    });
 
     cleanupChatRouteOnUnmount("chat-123", {
       abortTransport,
       removeInstance,
+      clearWorkspaceStatus,
     });
 
     expect(abortTransport).toHaveBeenCalledWith("chat-123");
     expect(removeInstance).toHaveBeenCalledWith("chat-123");
-    expect(calls).toEqual(["abort:chat-123", "remove:chat-123"]);
+    expect(clearWorkspaceStatus).toHaveBeenCalledWith("chat-123");
+    expect(calls).toEqual([
+      "abort:chat-123",
+      "remove:chat-123",
+      "clear:chat-123",
+    ]);
+  });
+
+  test("clears workspace status with default dependencies", async () => {
+    const { cleanupChatRouteOnUnmount } = await cleanupModulePromise;
+
+    cleanupChatRouteOnUnmount("chat-789");
+
+    expect(spies.clearChatWorkspaceStatus).toHaveBeenCalledWith("chat-789");
   });
 
   test("never issues a server stop signal during route teardown", async () => {

--- a/apps/web/lib/chat-route-cleanup.ts
+++ b/apps/web/lib/chat-route-cleanup.ts
@@ -2,16 +2,19 @@ import {
   abortChatInstanceTransport,
   removeChatInstance,
 } from "@/lib/chat-instance-manager";
+import { clearChatWorkspaceStatus } from "@/lib/workspace-status-store";
 
 type ChatRouteCleanupDependencies = {
   abortTransport: (chatId: string) => void;
   removeInstance: (chatId: string) => void;
+  clearWorkspaceStatus?: (chatId: string) => void;
   stopStream?: (chatId: string) => void;
 };
 
 const defaultDependencies: ChatRouteCleanupDependencies = {
   abortTransport: abortChatInstanceTransport,
   removeInstance: removeChatInstance,
+  clearWorkspaceStatus: clearChatWorkspaceStatus,
 };
 
 /**
@@ -26,4 +29,5 @@ export function cleanupChatRouteOnUnmount(
 ): void {
   dependencies.abortTransport(chatId);
   dependencies.removeInstance(chatId);
+  dependencies.clearWorkspaceStatus?.(chatId);
 }

--- a/apps/web/lib/workspace-status-store.test.ts
+++ b/apps/web/lib/workspace-status-store.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  clearChatWorkspaceStatus,
+  getChatWorkspaceStatusSnapshot,
+  setChatWorkspaceStatus,
+  subscribeChatWorkspaceStatus,
+} from "@/lib/workspace-status-store";
+
+describe("workspace status store", () => {
+  test("stores the latest workspace status per chat", () => {
+    clearChatWorkspaceStatus("chat-store-a");
+    clearChatWorkspaceStatus("chat-store-b");
+
+    setChatWorkspaceStatus("chat-store-a", {
+      status: "setting-up",
+      message: "Setting up workspace A...",
+    });
+    setChatWorkspaceStatus("chat-store-b", {
+      status: "setting-up",
+      message: "Setting up workspace B...",
+    });
+
+    expect(getChatWorkspaceStatusSnapshot("chat-store-a")?.message).toBe(
+      "Setting up workspace A...",
+    );
+    expect(getChatWorkspaceStatusSnapshot("chat-store-b")?.message).toBe(
+      "Setting up workspace B...",
+    );
+
+    clearChatWorkspaceStatus("chat-store-a");
+    clearChatWorkspaceStatus("chat-store-b");
+  });
+
+  test("notifies subscribers when status changes", () => {
+    clearChatWorkspaceStatus("chat-store-subscribe");
+
+    const listener = mock(() => {});
+    const unsubscribe = subscribeChatWorkspaceStatus(
+      "chat-store-subscribe",
+      listener,
+    );
+
+    setChatWorkspaceStatus("chat-store-subscribe", {
+      status: "setting-up",
+      message: "Setting up workspace...",
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    clearChatWorkspaceStatus("chat-store-subscribe");
+
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  test("does not notify after unsubscribe", () => {
+    clearChatWorkspaceStatus("chat-store-unsubscribe");
+
+    const listener = mock(() => {});
+    const unsubscribe = subscribeChatWorkspaceStatus(
+      "chat-store-unsubscribe",
+      listener,
+    );
+
+    unsubscribe();
+
+    setChatWorkspaceStatus("chat-store-unsubscribe", {
+      status: "setting-up",
+      message: "Setting up workspace...",
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+
+    clearChatWorkspaceStatus("chat-store-unsubscribe");
+  });
+});

--- a/apps/web/lib/workspace-status-store.ts
+++ b/apps/web/lib/workspace-status-store.ts
@@ -1,0 +1,67 @@
+import type { WebAgentWorkspaceStatusData } from "@/app/types";
+
+type WorkspaceStatusListener = () => void;
+
+const workspaceStatuses = new Map<string, WebAgentWorkspaceStatusData>();
+const workspaceStatusListeners = new Map<
+  string,
+  Set<WorkspaceStatusListener>
+>();
+
+function notifyWorkspaceStatusListeners(chatId: string): void {
+  const listeners = workspaceStatusListeners.get(chatId);
+  if (!listeners) {
+    return;
+  }
+
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function setChatWorkspaceStatus(
+  chatId: string,
+  status: WebAgentWorkspaceStatusData,
+): void {
+  workspaceStatuses.set(chatId, status);
+  notifyWorkspaceStatusListeners(chatId);
+}
+
+export function clearChatWorkspaceStatus(chatId: string): void {
+  const hadStatus = workspaceStatuses.delete(chatId);
+  if (hadStatus) {
+    notifyWorkspaceStatusListeners(chatId);
+  }
+}
+
+export function getChatWorkspaceStatusSnapshot(
+  chatId: string,
+): WebAgentWorkspaceStatusData | null {
+  return workspaceStatuses.get(chatId) ?? null;
+}
+
+export function subscribeChatWorkspaceStatus(
+  chatId: string,
+  listener: WorkspaceStatusListener,
+): () => void {
+  const existingListeners = workspaceStatusListeners.get(chatId);
+  const listeners = existingListeners ?? new Set<WorkspaceStatusListener>();
+
+  if (!existingListeners) {
+    workspaceStatusListeners.set(chatId, listeners);
+  }
+
+  listeners.add(listener);
+
+  return () => {
+    const currentListeners = workspaceStatusListeners.get(chatId);
+    if (!currentListeners) {
+      return;
+    }
+
+    currentListeners.delete(listener);
+    if (currentListeners.size === 0) {
+      workspaceStatusListeners.delete(chatId);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Resolve sandbox and model runtime inside the chat workflow, including lazy sandbox setup and transient workspace setup status.
- Persist incoming user/tool-result messages during workflow startup so resumed workflow state stays consistent.
- Refresh the cached diff only when file-changing tools or auto git operations update the workspace.

## Testing
- Not run; PR creation only.