### PR TITLE
Suppress existing auto PR sync status

### DIFF
--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -98,6 +98,8 @@ let testSessionRecord: {
   autoCreatePrOverride: boolean | null;
   repoOwner: string | null;
   repoName: string | null;
+  prNumber: number | null;
+  prStatus: "open" | "merged" | "closed" | null;
 };
 let testChatRecord: {
   id: string;
@@ -395,6 +397,8 @@ beforeEach(() => {
     autoCreatePrOverride: null,
     repoOwner: "acme",
     repoName: "repo",
+    prNumber: null,
+    prStatus: null,
   };
   testChatRecord = {
     id: "chat-1",
@@ -1409,6 +1413,62 @@ describe("runAgentWorkflow", () => {
 
     expect(spies.runAutoCommitStep).toHaveBeenCalledTimes(1);
     expect(spies.runAutoCreatePrStep).not.toHaveBeenCalled();
+  });
+
+  test("skips auto PR creation when the session already has a PR", async () => {
+    testSessionRecord.prNumber = 42;
+    testSessionRecord.prStatus = "open";
+    spies.runAutoCommitStep.mockImplementationOnce(() =>
+      Promise.resolve({
+        committed: true,
+        pushed: true,
+        commitSha: "abc123",
+      }),
+    );
+
+    await runAgentWorkflow(
+      makeOptions({
+        autoCommitEnabled: true,
+        autoCreatePrEnabled: true,
+        repoOwner: "acme",
+        repoName: "repo",
+      }),
+    );
+
+    expect(spies.runAutoCommitStep).toHaveBeenCalledTimes(1);
+    expect(spies.runAutoCreatePrStep).not.toHaveBeenCalled();
+    expect(writtenChunks.some((chunk) => chunk.type === "data-pr")).toBe(false);
+  });
+
+  test("does not stream PR data when auto PR only syncs an existing PR", async () => {
+    spies.runAutoCommitStep.mockImplementationOnce(() =>
+      Promise.resolve({
+        committed: true,
+        pushed: true,
+        commitSha: "abc123",
+      }),
+    );
+    spies.runAutoCreatePrStep.mockImplementationOnce(() =>
+      Promise.resolve({
+        created: false,
+        syncedExisting: true,
+        skipped: false,
+        prNumber: 42,
+        prUrl: "https://github.com/acme/repo/pull/42",
+      }),
+    );
+
+    await runAgentWorkflow(
+      makeOptions({
+        autoCommitEnabled: true,
+        autoCreatePrEnabled: true,
+        repoOwner: "acme",
+        repoName: "repo",
+      }),
+    );
+
+    expect(spies.runAutoCreatePrStep).toHaveBeenCalledTimes(1);
+    expect(writtenChunks.some((chunk) => chunk.type === "data-pr")).toBe(false);
   });
 
   test("skips post-finish automation when the agent pauses for tool input", async () => {

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -22,6 +22,14 @@ type TestResolvedChatSandboxRuntime = {
   repoName?: string;
 };
 
+type TestSuccessfulAutoCreatePrResult = {
+  created: boolean;
+  syncedExisting: boolean;
+  skipped: boolean;
+  prNumber: number;
+  prUrl: string;
+};
+
 function createResolvedChatSandboxRuntime(
   overrides: Partial<TestResolvedChatSandboxRuntime> = {},
 ): TestResolvedChatSandboxRuntime {
@@ -369,6 +377,30 @@ function makeOptions(overrides?: Record<string, unknown>) {
     maxSteps: 1,
     ...overrides,
   } as Parameters<typeof runAgentWorkflow>[0];
+}
+
+async function waitForCondition(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+
+  throw new Error("Timed out waiting for condition");
+}
+
+function isPendingPrChunk(chunk: UIMessageChunk): boolean {
+  return (
+    chunk.type === "data-pr" &&
+    typeof chunk.data === "object" &&
+    chunk.data !== null &&
+    "status" in chunk.data &&
+    chunk.data.status === "pending"
+  );
 }
 
 // ── Tests ──────────────────────────────────────────────────────────
@@ -1415,7 +1447,7 @@ describe("runAgentWorkflow", () => {
     expect(spies.runAutoCreatePrStep).not.toHaveBeenCalled();
   });
 
-  test("skips auto PR creation when the session already has a PR", async () => {
+  test("skips auto PR creation when the session already has an open PR", async () => {
     testSessionRecord.prNumber = 42;
     testSessionRecord.prStatus = "open";
     spies.runAutoCommitStep.mockImplementationOnce(() =>
@@ -1440,7 +1472,105 @@ describe("runAgentWorkflow", () => {
     expect(writtenChunks.some((chunk) => chunk.type === "data-pr")).toBe(false);
   });
 
-  test("does not stream PR data when auto PR only syncs an existing PR", async () => {
+  test("allows auto PR creation when the existing PR is closed", async () => {
+    testSessionRecord.prNumber = 42;
+    testSessionRecord.prStatus = "closed";
+    spies.runAutoCommitStep.mockImplementationOnce(() =>
+      Promise.resolve({
+        committed: true,
+        pushed: true,
+        commitSha: "abc123",
+      }),
+    );
+
+    await runAgentWorkflow(
+      makeOptions({
+        autoCommitEnabled: true,
+        autoCreatePrEnabled: true,
+        repoOwner: "acme",
+        repoName: "repo",
+      }),
+    );
+
+    expect(spies.runAutoCreatePrStep).toHaveBeenCalledTimes(1);
+  });
+
+  test("allows auto PR creation when the existing PR is merged", async () => {
+    testSessionRecord.prNumber = 42;
+    testSessionRecord.prStatus = "merged";
+    spies.runAutoCommitStep.mockImplementationOnce(() =>
+      Promise.resolve({
+        committed: true,
+        pushed: true,
+        commitSha: "abc123",
+      }),
+    );
+
+    await runAgentWorkflow(
+      makeOptions({
+        autoCommitEnabled: true,
+        autoCreatePrEnabled: true,
+        repoOwner: "acme",
+        repoName: "repo",
+      }),
+    );
+
+    expect(spies.runAutoCreatePrStep).toHaveBeenCalledTimes(1);
+  });
+
+  test("streams pending PR data before auto PR creation resolves", async () => {
+    let resolveAutoPrResult:
+      | ((result: TestSuccessfulAutoCreatePrResult) => void)
+      | undefined;
+    const autoPrResultPromise = new Promise<TestSuccessfulAutoCreatePrResult>(
+      (resolve) => {
+        resolveAutoPrResult = resolve;
+      },
+    );
+    spies.runAutoCommitStep.mockImplementationOnce(() =>
+      Promise.resolve({
+        committed: true,
+        pushed: true,
+        commitSha: "abc123",
+      }),
+    );
+    spies.runAutoCreatePrStep.mockImplementationOnce(() => autoPrResultPromise);
+
+    const workflowPromise = runAgentWorkflow(
+      makeOptions({
+        autoCommitEnabled: true,
+        autoCreatePrEnabled: true,
+        repoOwner: "acme",
+        repoName: "repo",
+      }),
+    );
+
+    await waitForCondition(() => writtenChunks.some(isPendingPrChunk));
+
+    expect(writtenChunks.filter((chunk) => chunk.type === "data-pr")).toEqual([
+      {
+        type: "data-pr",
+        id: "gen-id-1:pr",
+        data: { status: "pending" },
+      },
+    ]);
+
+    if (!resolveAutoPrResult) {
+      throw new Error("Auto PR promise resolver was not initialized");
+    }
+
+    resolveAutoPrResult({
+      created: true,
+      syncedExisting: false,
+      skipped: false,
+      prNumber: 42,
+      prUrl: "https://github.com/acme/repo/pull/42",
+    });
+
+    await workflowPromise;
+  });
+
+  test("does not persist PR data when auto PR only syncs an existing PR", async () => {
     spies.runAutoCommitStep.mockImplementationOnce(() =>
       Promise.resolve({
         committed: true,
@@ -1468,7 +1598,25 @@ describe("runAgentWorkflow", () => {
     );
 
     expect(spies.runAutoCreatePrStep).toHaveBeenCalledTimes(1);
-    expect(writtenChunks.some((chunk) => chunk.type === "data-pr")).toBe(false);
+    expect(writtenChunks.filter((chunk) => chunk.type === "data-pr")).toEqual([
+      {
+        type: "data-pr",
+        id: "gen-id-1:pr",
+        data: { status: "pending" },
+      },
+    ]);
+    expect(spies.persistAssistantMessage).toHaveBeenLastCalledWith(
+      "chat-1",
+      expect.objectContaining({
+        parts: expect.not.arrayContaining([
+          {
+            type: "data-pr",
+            id: "gen-id-1:pr",
+            data: { status: "pending" },
+          },
+        ]),
+      }),
+    );
   });
 
   test("skips post-finish automation when the agent pauses for tool input", async () => {

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -80,7 +80,7 @@ type ChatModelRuntime = {
   agentOptions: Omit<OpenAgentCallOptions, "sandbox" | "skills">;
   autoCommitEnabled: boolean;
   autoCreatePrEnabled: boolean;
-  hasPullRequest: boolean;
+  hasOpenPullRequest: boolean;
 };
 
 type Writable = WritableStream<UIMessageChunk>;
@@ -226,7 +226,8 @@ async function resolveChatModelRuntime(params: {
     },
     autoCommitEnabled,
     autoCreatePrEnabled,
-    hasPullRequest: sessionRecord.prNumber != null,
+    hasOpenPullRequest:
+      sessionRecord.prNumber != null && sessionRecord.prStatus === "open",
   };
 }
 
@@ -582,6 +583,19 @@ function upsertAssistantDataPart(
   };
 }
 
+function removeAssistantDataPart(
+  message: WebAgentUIMessage,
+  part: WebAgentCommitDataPart | WebAgentPrDataPart,
+): WebAgentUIMessage {
+  return {
+    ...message,
+    parts: message.parts.filter(
+      (messagePart) =>
+        messagePart.type !== part.type || messagePart.id !== part.id,
+    ),
+  };
+}
+
 async function sendDataPart(
   writable: Writable,
   part: WebAgentCommitDataPart | WebAgentPrDataPart,
@@ -868,9 +882,20 @@ export async function runAgentWorkflow(options: Options) {
     if (
       canAutoCommit &&
       (options.autoCreatePrEnabled ?? modelRuntime.autoCreatePrEnabled) &&
-      !modelRuntime.hasPullRequest
+      !modelRuntime.hasOpenPullRequest
     ) {
       if (canAutoCreatePr) {
+        const pendingPrPart: WebAgentPrDataPart = {
+          type: "data-pr",
+          id: prPartId,
+          data: { status: "pending" },
+        };
+        pendingAssistantResponse = upsertAssistantDataPart(
+          pendingAssistantResponse,
+          pendingPrPart,
+        );
+        await sendDataPart(writable, pendingPrPart);
+
         const autoPrResult = await runAutoCreatePrStep({
           userId: options.userId,
           sessionId: options.sessionId,
@@ -881,19 +906,12 @@ export async function runAgentWorkflow(options: Options) {
         });
 
         if (autoPrResult.syncedExisting && !autoPrResult.error) {
-          shouldRefreshCachedDiff = true;
-        } else {
-          const pendingPrPart: WebAgentPrDataPart = {
-            type: "data-pr",
-            id: prPartId,
-            data: { status: "pending" },
-          };
-          pendingAssistantResponse = upsertAssistantDataPart(
+          pendingAssistantResponse = removeAssistantDataPart(
             pendingAssistantResponse,
             pendingPrPart,
           );
-          await sendDataPart(writable, pendingPrPart);
-
+          shouldRefreshCachedDiff = true;
+        } else {
           const resolvedPrPart: WebAgentPrDataPart = {
             type: "data-pr",
             id: prPartId,

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -80,6 +80,7 @@ type ChatModelRuntime = {
   agentOptions: Omit<OpenAgentCallOptions, "sandbox" | "skills">;
   autoCommitEnabled: boolean;
   autoCreatePrEnabled: boolean;
+  hasPullRequest: boolean;
 };
 
 type Writable = WritableStream<UIMessageChunk>;
@@ -225,6 +226,7 @@ async function resolveChatModelRuntime(params: {
     },
     autoCommitEnabled,
     autoCreatePrEnabled,
+    hasPullRequest: sessionRecord.prNumber != null,
   };
 }
 
@@ -865,19 +867,10 @@ export async function runAgentWorkflow(options: Options) {
 
     if (
       canAutoCommit &&
-      (options.autoCreatePrEnabled ?? modelRuntime.autoCreatePrEnabled)
+      (options.autoCreatePrEnabled ?? modelRuntime.autoCreatePrEnabled) &&
+      !modelRuntime.hasPullRequest
     ) {
       if (canAutoCreatePr) {
-        const pendingPrPart: WebAgentPrDataPart = {
-          type: "data-pr",
-          id: prPartId,
-          data: { status: "pending" },
-        };
-        pendingAssistantResponse = upsertAssistantDataPart(
-          pendingAssistantResponse,
-          pendingPrPart,
-        );
-        await sendDataPart(writable, pendingPrPart);
         const autoPrResult = await runAutoCreatePrStep({
           userId: options.userId,
           sessionId: options.sessionId,
@@ -887,18 +880,33 @@ export async function runAgentWorkflow(options: Options) {
           sandboxState,
         });
 
-        const resolvedPrPart: WebAgentPrDataPart = {
-          type: "data-pr",
-          id: prPartId,
-          data: buildPrData(autoPrResult),
-        };
-        pendingAssistantResponse = upsertAssistantDataPart(
-          pendingAssistantResponse,
-          resolvedPrPart,
-        );
-        await sendDataPart(writable, resolvedPrPart);
-        didUpdateGitData = true;
-        shouldRefreshCachedDiff = true;
+        if (autoPrResult.syncedExisting && !autoPrResult.error) {
+          shouldRefreshCachedDiff = true;
+        } else {
+          const pendingPrPart: WebAgentPrDataPart = {
+            type: "data-pr",
+            id: prPartId,
+            data: { status: "pending" },
+          };
+          pendingAssistantResponse = upsertAssistantDataPart(
+            pendingAssistantResponse,
+            pendingPrPart,
+          );
+          await sendDataPart(writable, pendingPrPart);
+
+          const resolvedPrPart: WebAgentPrDataPart = {
+            type: "data-pr",
+            id: prPartId,
+            data: buildPrData(autoPrResult),
+          };
+          pendingAssistantResponse = upsertAssistantDataPart(
+            pendingAssistantResponse,
+            resolvedPrPart,
+          );
+          await sendDataPart(writable, resolvedPrPart);
+          didUpdateGitData = true;
+          shouldRefreshCachedDiff = true;
+        }
       } else {
         const skippedPrPart: WebAgentPrDataPart = {
           type: "data-pr",


### PR DESCRIPTION
## Summary
- Skip auto-PR creation when session PR metadata already exists.
- Keep stale metadata repair silent when auto-PR only finds an existing PR.
- Add workflow tests for both skip paths.

## Tests
- bun test \"apps/web/app/workflows/chat.test.ts\"
- bun run check \"apps/web/app/workflows/chat.ts\" \"apps/web/app/workflows/chat.test.ts\"
- turbo typecheck --filter=web