### PR TITLE
feat: add AI Gateway attribution headers

### DIFF
--- a/packages/agent/models.test.ts
+++ b/packages/agent/models.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { ProviderOptionsByProvider } from "./models";
 
+const createGatewayCalls: Array<Record<string, unknown>> = [];
+
 mock.module("ai", () => {
   const gateway = (modelId: string) => ({ modelId });
 
   return {
-    createGateway: () => gateway,
+    createGateway: (settings?: Record<string, unknown>) => {
+      createGatewayCalls.push(settings ?? {});
+      return gateway;
+    },
     defaultSettingsMiddleware: (_settings: unknown) => ({
       kind: "default-settings-middleware",
     }),
@@ -19,6 +24,7 @@ mock.module("@ai-sdk/devtools", () => ({
 }));
 
 const {
+  gateway,
   getProviderOptionsForModel,
   mergeProviderOptions,
   shouldApplyOpenAIReasoningDefaults,
@@ -229,6 +235,50 @@ describe("mergeProviderOptions", () => {
     expect(mergeProviderOptions(defaults, overrides)).toEqual({
       openai: {
         include: ["reasoning.summary"],
+      },
+    });
+  });
+});
+
+describe("gateway attribution headers", () => {
+  test("sends default attribution headers", () => {
+    createGatewayCalls.length = 0;
+    gateway("anthropic/claude-sonnet-4.6" as never);
+
+    expect(createGatewayCalls).toHaveLength(1);
+    expect(createGatewayCalls[0].headers).toEqual({
+      "http-referer": "https://open-agents.dev",
+      "x-title": "Open Agents",
+    });
+  });
+
+  test("allows overriding attribution via appName and appUrl", () => {
+    createGatewayCalls.length = 0;
+    gateway("anthropic/claude-sonnet-4.6" as never, {
+      appName: "My App",
+      appUrl: "https://myapp.com",
+    });
+
+    expect(createGatewayCalls).toHaveLength(1);
+    expect(createGatewayCalls[0].headers).toEqual({
+      "http-referer": "https://myapp.com",
+      "x-title": "My App",
+    });
+  });
+
+  test("passes attribution headers with custom gateway config", () => {
+    createGatewayCalls.length = 0;
+    gateway("anthropic/claude-sonnet-4.6" as never, {
+      config: { baseURL: "https://custom.api", apiKey: "sk-test" },
+    });
+
+    expect(createGatewayCalls).toHaveLength(1);
+    expect(createGatewayCalls[0]).toEqual({
+      baseURL: "https://custom.api",
+      apiKey: "sk-test",
+      headers: {
+        "http-referer": "https://open-agents.dev",
+        "x-title": "Open Agents",
       },
     });
   });

--- a/packages/agent/models.test.ts
+++ b/packages/agent/models.test.ts
@@ -245,11 +245,14 @@ describe("gateway attribution headers", () => {
     createGatewayCalls.length = 0;
     gateway("anthropic/claude-sonnet-4.6" as never);
 
-    expect(createGatewayCalls).toHaveLength(1);
-    expect(createGatewayCalls[0].headers).toEqual({
-      "http-referer": "https://open-agents.dev",
-      "x-title": "Open Agents",
-    });
+    expect(createGatewayCalls).toEqual([
+      {
+        headers: {
+          "http-referer": "https://open-agents.dev",
+          "x-title": "Open Agents",
+        },
+      },
+    ]);
   });
 
   test("allows overriding attribution via appName and appUrl", () => {
@@ -259,11 +262,14 @@ describe("gateway attribution headers", () => {
       appUrl: "https://myapp.com",
     });
 
-    expect(createGatewayCalls).toHaveLength(1);
-    expect(createGatewayCalls[0].headers).toEqual({
-      "http-referer": "https://myapp.com",
-      "x-title": "My App",
-    });
+    expect(createGatewayCalls).toEqual([
+      {
+        headers: {
+          "http-referer": "https://myapp.com",
+          "x-title": "My App",
+        },
+      },
+    ]);
   });
 
   test("passes attribution headers with custom gateway config", () => {
@@ -272,14 +278,15 @@ describe("gateway attribution headers", () => {
       config: { baseURL: "https://custom.api", apiKey: "sk-test" },
     });
 
-    expect(createGatewayCalls).toHaveLength(1);
-    expect(createGatewayCalls[0]).toEqual({
-      baseURL: "https://custom.api",
-      apiKey: "sk-test",
-      headers: {
-        "http-referer": "https://open-agents.dev",
-        "x-title": "Open Agents",
+    expect(createGatewayCalls).toEqual([
+      {
+        baseURL: "https://custom.api",
+        apiKey: "sk-test",
+        headers: {
+          "http-referer": "https://open-agents.dev",
+          "x-title": "Open Agents",
+        },
       },
-    });
+    ]);
   });
 });

--- a/packages/agent/models.ts
+++ b/packages/agent/models.ts
@@ -181,7 +181,11 @@ export function gateway(
   };
 
   const baseGateway = config
-    ? createGateway({ baseURL: config.baseURL, apiKey: config.apiKey, headers: attributionHeaders })
+    ? createGateway({
+        baseURL: config.baseURL,
+        apiKey: config.apiKey,
+        headers: attributionHeaders,
+      })
     : createGateway({ headers: attributionHeaders });
 
   let model: LanguageModel = baseGateway(modelId);

--- a/packages/agent/models.ts
+++ b/packages/agent/models.ts
@@ -1,7 +1,6 @@
 import {
   createGateway,
   defaultSettingsMiddleware,
-  gateway as aiGateway,
   wrapLanguageModel,
   type GatewayModelId,
   type JSONValue,
@@ -96,6 +95,8 @@ export interface GatewayConfig {
 export interface GatewayOptions {
   config?: GatewayConfig;
   providerOptionsOverrides?: ProviderOptionsByProvider;
+  appName?: string;
+  appUrl?: string;
 }
 
 export type { GatewayModelId, LanguageModel, JSONValue };
@@ -172,12 +173,16 @@ export function gateway(
   modelId: GatewayModelId,
   options: GatewayOptions = {},
 ): LanguageModel {
-  const { config, providerOptionsOverrides } = options;
+  const { config, providerOptionsOverrides, appName, appUrl } = options;
 
-  // Use custom gateway config or default AI SDK gateway
+  const attributionHeaders = {
+    "http-referer": appUrl ?? "https://open-agents.dev",
+    "x-title": appName ?? "Open Agents",
+  };
+
   const baseGateway = config
-    ? createGateway({ baseURL: config.baseURL, apiKey: config.apiKey })
-    : aiGateway;
+    ? createGateway({ baseURL: config.baseURL, apiKey: config.apiKey, headers: attributionHeaders })
+    : createGateway({ headers: attributionHeaders });
 
   let model: LanguageModel = baseGateway(modelId);
 


### PR DESCRIPTION
## Summary

- Sends `http-referer` and `x-title` headers on all AI Gateway requests, defaulting to `https://open-agents.dev` / `Open Agents`
- Adds optional `appName` and `appUrl` fields to `GatewayOptions` so self-hosted deployments can override the defaults
- Removes unused `aiGateway` import

## Test plan

- [x] `bun test packages/agent/models.test.ts` — 15/15 pass
- [ ] After deploy, verify attribution appears in AI Gateway telemetry (`appName` / `referrerUrl` columns in Tinybird)

🤖 Generated with [Claude Code](https://claude.com/claude-code)