### PR TITLE
fix: reduce noisy session startup errors

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,6 +1,5 @@
-import { checkBotId } from "botid/server";
 import { createUIMessageStreamResponse, type InferUIMessageChunk } from "ai";
-import { botIdConfig } from "@/lib/botid";
+import { checkBotProtection } from "@/lib/botid";
 import { start } from "workflow/api";
 import type { WebAgentUIMessage } from "@/app/types";
 import {
@@ -53,7 +52,7 @@ export async function POST(req: Request) {
   const userId = authResult.userId;
   const session = await getServerSession();
 
-  const botVerification = await checkBotId(botIdConfig);
+  const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }

--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -1,6 +1,5 @@
-import { checkBotId } from "botid/server";
 import { connectSandbox } from "@open-agents/sandbox";
-import { botIdConfig } from "@/lib/botid";
+import { checkBotProtection } from "@/lib/botid";
 import { generateBranchName, looksLikeCommitHash } from "@/lib/git/helpers";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { generatePullRequestContentFromSandbox } from "@/lib/github/pr-content";
@@ -25,7 +24,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const botVerification = await checkBotId(botIdConfig);
+  const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }

--- a/apps/web/app/api/generate-title/route.ts
+++ b/apps/web/app/api/generate-title/route.ts
@@ -1,5 +1,4 @@
-import { checkBotId } from "botid/server";
-import { botIdConfig } from "@/lib/botid";
+import { checkBotProtection } from "@/lib/botid";
 import { gateway, generateText } from "ai";
 import { z } from "zod";
 import { getServerSession } from "@/lib/session/get-server-session";
@@ -46,7 +45,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const botVerification = await checkBotId(botIdConfig);
+  const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -1,11 +1,10 @@
-import { checkBotId } from "botid/server";
 import { connectSandbox, type SandboxState } from "@open-agents/sandbox";
 import {
   requireAuthenticatedUser,
   requireOwnedSession,
   type SessionRecord,
 } from "@/app/api/sessions/_lib/session-context";
-import { botIdConfig } from "@/lib/botid";
+import { checkBotProtection } from "@/lib/botid";
 import { getGitHubUserProfile } from "@/lib/github/users";
 import { updateSession } from "@/lib/db/sessions";
 import { parseGitHubUrl } from "@/lib/github/client";
@@ -112,7 +111,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const botVerification = await checkBotId(botIdConfig);
+  const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }

--- a/apps/web/app/api/sessions/[sessionId]/generate-commit-message/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/generate-commit-message/route.ts
@@ -1,7 +1,6 @@
-import { checkBotId } from "botid/server";
 import { connectSandbox } from "@open-agents/sandbox";
 import { gateway, generateText } from "ai";
-import { botIdConfig } from "@/lib/botid";
+import { checkBotProtection } from "@/lib/botid";
 import { getSessionById } from "@/lib/db/sessions";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
@@ -17,7 +16,7 @@ export async function POST(
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const botVerification = await checkBotId(botIdConfig);
+  const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }

--- a/apps/web/app/api/sessions/route.test.ts
+++ b/apps/web/app/api/sessions/route.test.ts
@@ -20,6 +20,7 @@ let existingSessionCount = 0;
 let savedLink: VercelProjectSelection | null = null;
 let currentVercelToken: string | null = "vercel-token";
 let matchingProjects: VercelProjectSelection[] = [];
+let matchingProjectsError: Error | null = null;
 const createCalls: Array<Record<string, unknown>> = [];
 const upsertCalls: Array<Record<string, unknown>> = [];
 
@@ -60,7 +61,14 @@ mock.module("@/lib/vercel/token", () => ({
 }));
 
 mock.module("@/lib/vercel/projects", () => ({
-  listMatchingVercelProjects: async () => matchingProjects,
+  isVercelInvalidTokenError: (error: unknown) =>
+    matchingProjectsError !== null && error === matchingProjectsError,
+  listMatchingVercelProjects: async () => {
+    if (matchingProjectsError) {
+      throw matchingProjectsError;
+    }
+    return matchingProjects;
+  },
 }));
 
 mock.module("@/lib/db/sessions", () => ({
@@ -117,6 +125,7 @@ describe("/api/sessions POST vercel project linking", () => {
     savedLink = null;
     currentVercelToken = "vercel-token";
     matchingProjects = [];
+    matchingProjectsError = null;
     createCalls.length = 0;
     upsertCalls.length = 0;
   });

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -23,7 +23,10 @@ import {
   MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT,
   MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT_ERROR,
 } from "@/lib/managed-template-trial";
-import { listMatchingVercelProjects } from "@/lib/vercel/projects";
+import {
+  isVercelInvalidTokenError,
+  listMatchingVercelProjects,
+} from "@/lib/vercel/projects";
 import { getUserVercelToken } from "@/lib/vercel/token";
 import {
   vercelProjectSelectionSchema,
@@ -359,6 +362,16 @@ export async function POST(req: Request) {
 
     return Response.json(result);
   } catch (error) {
+    if (isVercelInvalidTokenError(error)) {
+      console.warn(
+        `Vercel token is invalid for user ${session.user.id}; reconnect required to create a session with env sync.`,
+      );
+      return Response.json(
+        { error: "Reconnect Vercel to select a Vercel project" },
+        { status: 403 },
+      );
+    }
+
     console.error("Failed to create session:", error);
     return Response.json(
       { error: "Failed to create session" },

--- a/apps/web/app/api/transcribe/route.ts
+++ b/apps/web/app/api/transcribe/route.ts
@@ -1,5 +1,4 @@
-import { checkBotId } from "botid/server";
-import { botIdConfig } from "@/lib/botid";
+import { checkBotProtection } from "@/lib/botid";
 import { experimental_transcribe as transcribe } from "ai";
 import { elevenlabs } from "@ai-sdk/elevenlabs";
 import { getServerSession } from "@/lib/session/get-server-session";
@@ -15,7 +14,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const botVerification = await checkBotId(botIdConfig);
+  const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }

--- a/apps/web/app/api/vercel/repo-projects/route.test.ts
+++ b/apps/web/app/api/vercel/repo-projects/route.test.ts
@@ -7,6 +7,7 @@ let currentSession: { user: { id: string } } | null = {
 let currentToken: string | null = "token";
 let savedLink: VercelProjectSelection | null = null;
 let projects: VercelProjectSelection[] = [];
+let projectsError: Error | null = null;
 
 mock.module("@/lib/session/get-server-session", () => ({
   getServerSession: async () => currentSession,
@@ -21,7 +22,14 @@ mock.module("@/lib/db/vercel-project-links", () => ({
 }));
 
 mock.module("@/lib/vercel/projects", () => ({
-  listMatchingVercelProjects: async () => projects,
+  isVercelInvalidTokenError: (error: unknown) =>
+    projectsError !== null && error === projectsError,
+  listMatchingVercelProjects: async () => {
+    if (projectsError) {
+      throw projectsError;
+    }
+    return projects;
+  },
 }));
 
 const routeModulePromise = import("./route");
@@ -32,6 +40,7 @@ describe("/api/vercel/repo-projects", () => {
     currentToken = "token";
     savedLink = null;
     projects = [];
+    projectsError = null;
   });
 
   test("returns the remembered default when it still exists in live candidates", async () => {
@@ -91,5 +100,21 @@ describe("/api/vercel/repo-projects", () => {
 
     expect(response.status).toBe(200);
     expect(body.selectedProjectId).toBe("project-1");
+  });
+
+  test("asks the client to reconnect Vercel when the token is invalid", async () => {
+    const { GET } = await routeModulePromise;
+
+    projectsError = new Error("invalid Vercel token");
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/vercel/repo-projects?repoOwner=vercel&repoName=open-agents",
+      ),
+    );
+    const body = (await response.json()) as { error?: string };
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Reconnect Vercel to load matching projects");
   });
 });

--- a/apps/web/app/api/vercel/repo-projects/route.ts
+++ b/apps/web/app/api/vercel/repo-projects/route.ts
@@ -1,6 +1,9 @@
 import { getVercelProjectLinkByRepo } from "@/lib/db/vercel-project-links";
 import { getServerSession } from "@/lib/session/get-server-session";
-import { listMatchingVercelProjects } from "@/lib/vercel/projects";
+import {
+  isVercelInvalidTokenError,
+  listMatchingVercelProjects,
+} from "@/lib/vercel/projects";
 import { getUserVercelToken } from "@/lib/vercel/token";
 
 export async function GET(req: Request) {
@@ -51,6 +54,16 @@ export async function GET(req: Request) {
       selectedProjectId,
     });
   } catch (error) {
+    if (isVercelInvalidTokenError(error)) {
+      console.warn(
+        `Vercel token is invalid for user ${session.user.id}; reconnect required to load repo projects.`,
+      );
+      return Response.json(
+        { error: "Reconnect Vercel to load matching projects" },
+        { status: 403 },
+      );
+    }
+
     console.error("Failed to load Vercel repo projects:", error);
     return Response.json(
       { error: "Failed to load Vercel projects" },

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-context.tsx
@@ -671,8 +671,8 @@ export function SessionChatProvider({
   );
 
   const checkBranchAndPr = useCallback(async () => {
-    // Only check if the session has repo info. The server action will throw
-    // if the sandbox is not active, which we silently ignore.
+    // Only check if the session has repo info. While provisioning, the server
+    // action returns the current DB metadata without touching the sandbox.
     if (!sessionRecord.repoOwner || !sessionRecord.repoName) return;
 
     try {

--- a/apps/web/components/branch-picker-dialog.tsx
+++ b/apps/web/components/branch-picker-dialog.tsx
@@ -8,6 +8,7 @@ import { fetcher } from "@/lib/swr";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -79,6 +80,9 @@ export function BranchPickerDialog({
               Select branch for {owner}/{repo}
             </span>
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Search and select the branch to use for this session.
+          </DialogDescription>
         </DialogHeader>
         {isCreating ? (
           <div className="flex items-center justify-center gap-2 px-4 py-8 text-sm text-muted-foreground">

--- a/apps/web/components/new-session-dialog.tsx
+++ b/apps/web/components/new-session-dialog.tsx
@@ -8,6 +8,7 @@ import type { VercelProjectSelection } from "@/lib/vercel/types";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -61,6 +62,9 @@ export function NewSessionDialog({
       <DialogContent className="w-[calc(100%-2rem)] max-w-none gap-0 overflow-hidden border-none bg-transparent p-0 shadow-none [&>button]:hidden">
         <DialogHeader className="sr-only">
           <DialogTitle>New Session</DialogTitle>
+          <DialogDescription>
+            Choose a repository or start an empty session.
+          </DialogDescription>
         </DialogHeader>
         <div className="min-w-0 rounded-2xl sm:rounded-[28px] border border-border/60 bg-card shadow-[0_10px_30px_rgba(0,0,0,0.08)]">
           <SessionStarter

--- a/apps/web/components/snippet-chip.tsx
+++ b/apps/web/components/snippet-chip.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -53,6 +54,9 @@ export function SnippetChip({
                 {meta}
               </span>
             </DialogTitle>
+            <DialogDescription className="sr-only">
+              Preview the attached text snippet content.
+            </DialogDescription>
           </DialogHeader>
           <div className="min-h-0 flex-1 overflow-auto rounded-md border bg-muted/40 p-4">
             <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground">

--- a/apps/web/components/text-attachments-preview.tsx
+++ b/apps/web/components/text-attachments-preview.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -85,6 +86,9 @@ function TextAttachmentPreviewDialog({
               {meta}
             </span>
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Preview the attached text file content.
+          </DialogDescription>
         </DialogHeader>
         <div className="min-h-0 flex-1 overflow-auto rounded-md border bg-muted/40 p-4">
           <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground">

--- a/apps/web/lib/botid.ts
+++ b/apps/web/lib/botid.ts
@@ -1,3 +1,5 @@
+import { checkBotId } from "botid/server";
+
 /**
  * Shared Vercel BotID server-side configuration.
  *
@@ -16,3 +18,16 @@ export const botIdConfig = {
     ],
   },
 };
+
+export async function checkBotProtection() {
+  if (process.env.NODE_ENV !== "production") {
+    return {
+      isHuman: true,
+      isBot: false,
+      isVerifiedBot: false,
+      bypassed: true,
+    };
+  }
+
+  return checkBotId(botIdConfig);
+}

--- a/apps/web/lib/github/queries/pr.ts
+++ b/apps/web/lib/github/queries/pr.ts
@@ -117,7 +117,11 @@ export async function checkPullRequest(params: { sessionId: string }): Promise<{
   const sessionRecord = await requireOwnedSession(session.user.id, sessionId);
 
   if (!isSandboxActive(sessionRecord.sandboxState)) {
-    throw new Error("Sandbox not active");
+    return {
+      branch: sessionRecord.branch ?? null,
+      prNumber: sessionRecord.prNumber ?? null,
+      prStatus: sessionRecord.prStatus ?? null,
+    };
   }
 
   const sandboxState = sessionRecord.sandboxState;

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -3,8 +3,12 @@
  * All timeout values are in milliseconds.
  */
 
-/** Default timeout for new cloud sandboxes (5 hours) */
-export const DEFAULT_SANDBOX_TIMEOUT_MS = 5 * 60 * 60 * 1000;
+/** SDK safety buffer reserved for sandbox before-stop hooks (30 seconds) */
+const VERCEL_SANDBOX_TIMEOUT_BUFFER_MS = 30 * 1000;
+
+/** Default timeout for new cloud sandboxes (5 hours minus hook buffer) */
+export const DEFAULT_SANDBOX_TIMEOUT_MS =
+  5 * 60 * 60 * 1000 - VERCEL_SANDBOX_TIMEOUT_BUFFER_MS;
 
 /** Manual extension duration for explicit fallback flows (20 minutes) */
 export const EXTEND_TIMEOUT_DURATION_MS = 20 * 60 * 1000;

--- a/apps/web/lib/vercel/projects.test.ts
+++ b/apps/web/lib/vercel/projects.test.ts
@@ -86,6 +86,39 @@ describe("Vercel project helpers", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
+  test("identifies invalid token API responses", async () => {
+    const fetchMock = mock(async () =>
+      Response.json(
+        {
+          error: {
+            code: "forbidden",
+            message: "Not authorized",
+            invalidToken: true,
+          },
+        },
+        { status: 403 },
+      ),
+    );
+    globalThis.fetch = Object.assign(fetchMock, {
+      preconnect: originalFetch.preconnect,
+    });
+
+    const { isVercelInvalidTokenError, listMatchingVercelProjects } =
+      await projectsModulePromise;
+    let thrownError: unknown = null;
+    try {
+      await listMatchingVercelProjects({
+        token: "token",
+        repoOwner: "vercel",
+        repoName: "open-agents",
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(isVercelInvalidTokenError(thrownError)).toBe(true);
+  });
+
   test("selectDevelopmentEnvVars prefers more specific development targets and newer values", async () => {
     const { selectDevelopmentEnvVars } = await projectsModulePromise;
 

--- a/apps/web/lib/vercel/projects.ts
+++ b/apps/web/lib/vercel/projects.ts
@@ -3,6 +3,28 @@ import type { VercelProjectSelection } from "@/lib/vercel/types";
 
 const VERCEL_API_BASE_URL = "https://api.vercel.com";
 
+export class VercelApiError extends Error {
+  readonly status: number;
+  readonly details: string | null;
+  readonly invalidToken: boolean;
+
+  constructor(params: {
+    status: number;
+    details: string | null;
+    invalidToken: boolean;
+  }) {
+    super(
+      params.details
+        ? `Vercel API request failed with ${params.status}: ${params.details}`
+        : `Vercel API request failed with ${params.status}`,
+    );
+    this.name = "VercelApiError";
+    this.status = params.status;
+    this.details = params.details;
+    this.invalidToken = params.invalidToken;
+  }
+}
+
 interface VercelTeam {
   id?: string;
   slug?: string;
@@ -43,8 +65,46 @@ export interface DevelopmentEnvVar {
   value: string;
 }
 
-function createVercelApiError(message: string, details?: string): Error {
-  return new Error(details ? `${message}: ${details}` : message);
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseVercelErrorDetails(details: string): unknown {
+  try {
+    return JSON.parse(details);
+  } catch {
+    return null;
+  }
+}
+
+function hasInvalidTokenFlag(value: unknown): boolean {
+  if (!isUnknownRecord(value)) {
+    return false;
+  }
+
+  if (value.invalidToken === true || value.code === "invalid_token") {
+    return true;
+  }
+
+  return hasInvalidTokenFlag(value.error);
+}
+
+function createVercelApiError(status: number, details: string): VercelApiError {
+  const normalizedDetails = details.trim() || null;
+  return new VercelApiError({
+    status,
+    details: normalizedDetails,
+    invalidToken: normalizedDetails
+      ? hasInvalidTokenFlag(parseVercelErrorDetails(normalizedDetails))
+      : false,
+  });
+}
+
+export function isVercelInvalidTokenError(error: unknown): boolean {
+  return (
+    error instanceof VercelApiError &&
+    (error.invalidToken || error.status === 401)
+  );
 }
 
 async function fetchVercelJson<T>(params: {
@@ -66,10 +126,7 @@ async function fetchVercelJson<T>(params: {
 
   if (!response.ok) {
     const body = await response.text();
-    throw createVercelApiError(
-      `Vercel API request failed with ${response.status}`,
-      body,
-    );
+    throw createVercelApiError(response.status, body);
   }
 
   return response.json() as Promise<T>;


### PR DESCRIPTION
## Summary
- Treat invalid Vercel tokens as reconnect-required errors when loading or selecting linked projects.
- Bypass BotID checks outside production and preserve branch/PR metadata while sandboxes are still provisioning.
- Add accessible dialog descriptions and reserve a sandbox timeout buffer for before-stop hooks.

## Testing
- bun test "apps/web/lib/vercel/projects.test.ts" "apps/web/app/api/vercel/repo-projects/route.test.ts" "apps/web/app/api/sessions/route.test.ts"
- turbo typecheck --filter=web