### PR TITLE
Fix OAuth signup username creation

### DIFF
--- a/apps/web/lib/auth/config.ts
+++ b/apps/web/lib/auth/config.ts
@@ -1,6 +1,11 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import type {
+  GithubProfile,
+  VercelProfile,
+} from "better-auth/social-providers";
 import { nanoid } from "nanoid";
+import { deriveAuthUsername } from "@/lib/auth/username";
 import { db } from "@/lib/db/client";
 import * as schema from "@/lib/db/schema";
 
@@ -65,6 +70,28 @@ function getAllowedAuthHosts(): string[] {
   return [...hosts];
 }
 
+function mapVercelProfileToUser(profile: VercelProfile): { username: string } {
+  return {
+    username: deriveAuthUsername({
+      id: profile.sub,
+      preferred_username: profile.preferred_username,
+      email: profile.email,
+      name: profile.name,
+    }),
+  };
+}
+
+function mapGitHubProfileToUser(profile: GithubProfile): { username: string } {
+  return {
+    username: deriveAuthUsername({
+      id: profile.id,
+      username: profile.login,
+      email: profile.email,
+      name: profile.name,
+    }),
+  };
+}
+
 const authBaseURLFallback = getAuthBaseURLFallback();
 const authAllowedHosts = getAllowedAuthHosts();
 
@@ -96,6 +123,18 @@ export const auth = betterAuth({
     },
   },
 
+  databaseHooks: {
+    user: {
+      create: {
+        before: async (user) => ({
+          data: {
+            username: deriveAuthUsername(user),
+          },
+        }),
+      },
+    },
+  },
+
   session: {
     modelName: "auth_sessions",
   },
@@ -115,10 +154,12 @@ export const auth = betterAuth({
       clientSecret: process.env.VERCEL_APP_CLIENT_SECRET ?? "",
       scope: ["openid", "email", "profile", "offline_access"],
       overrideUserInfoOnSignIn: true,
+      mapProfileToUser: mapVercelProfileToUser,
     },
     github: {
       clientId: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ?? "",
       clientSecret: process.env.GITHUB_CLIENT_SECRET ?? "",
+      mapProfileToUser: mapGitHubProfileToUser,
     },
   },
 

--- a/apps/web/lib/auth/username.test.ts
+++ b/apps/web/lib/auth/username.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { deriveAuthUsername, normalizeAuthUsername } from "./username";
+
+describe("auth username helpers", () => {
+  test("normalizes usernames for safe storage", () => {
+    expect(normalizeAuthUsername(" Gioacchino Albanese! ")).toBe(
+      "gioacchino-albanese",
+    );
+  });
+
+  test("prefers provider username fields", () => {
+    expect(
+      deriveAuthUsername({
+        preferred_username: "gioacchinoalbanese-2373",
+        email: "gioacchinoalbanese@icloud.com",
+        name: "na-test-open-agents",
+      }),
+    ).toBe("gioacchinoalbanese-2373");
+  });
+
+  test("falls back to email local part", () => {
+    expect(
+      deriveAuthUsername({
+        email: "gioacchinoalbanese@icloud.com",
+        name: "na-test-open-agents",
+      }),
+    ).toBe("gioacchinoalbanese");
+  });
+});

--- a/apps/web/lib/auth/username.ts
+++ b/apps/web/lib/auth/username.ts
@@ -1,0 +1,59 @@
+const USERNAME_FALLBACK = "user";
+
+function getNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function getEmailLocalPart(email: string): string | null {
+  const localPart = email.split("@", 1)[0]?.trim();
+  return localPart ? localPart : null;
+}
+
+export function normalizeAuthUsername(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^[._-]+|[._-]+$/g, "");
+
+  return normalized || USERNAME_FALLBACK;
+}
+
+export function deriveAuthUsername(user: Record<string, unknown>): string {
+  const explicitUsername = getNonEmptyString(user.username);
+  if (explicitUsername) {
+    return normalizeAuthUsername(explicitUsername);
+  }
+
+  const preferredUsername =
+    getNonEmptyString(user.preferredUsername) ??
+    getNonEmptyString(user.preferred_username);
+  if (preferredUsername) {
+    return normalizeAuthUsername(preferredUsername);
+  }
+
+  const email = getNonEmptyString(user.email);
+  if (email) {
+    const localPart = getEmailLocalPart(email);
+    if (localPart) {
+      return normalizeAuthUsername(localPart);
+    }
+  }
+
+  const name = getNonEmptyString(user.name);
+  if (name) {
+    return normalizeAuthUsername(name);
+  }
+
+  const id = getNonEmptyString(user.id);
+  if (id) {
+    return normalizeAuthUsername(`user-${id.slice(0, 12)}`);
+  }
+
+  return USERNAME_FALLBACK;
+}


### PR DESCRIPTION
## Summary
- Populate usernames from Vercel and GitHub OAuth profile data during signup.
- Add a Better Auth user-create hook fallback so OAuth inserts satisfy the non-null username column.
- Cover username normalization and fallback behavior with tests.

## Verification
- bun run ci

Fixes #862 