### PR TITLE
fix: gate github sessions for trial users

### DIFF
--- a/apps/web/app/api/auth/info/route.test.ts
+++ b/apps/web/app/api/auth/info/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { NextRequest } from "next/server";
 
 type TestSession = {
@@ -17,6 +17,8 @@ let hasGitHubLinked = false;
 let installations: Array<{ installationId: number }> = [];
 let isAdmin = false;
 
+const originalNodeEnv = process.env.NODE_ENV;
+
 mock.module("server-only", () => ({}));
 
 mock.module("@/lib/session/server", () => ({
@@ -30,6 +32,9 @@ mock.module("@/lib/db/users", () => ({
 
 mock.module("@/lib/github/users", () => ({
   hasGitHubAccount: async () => hasGitHubLinked,
+  getGitHubAccountId: async () => null,
+  getGitHubUsername: async () => null,
+  deleteGitHubAccountLink: async () => undefined,
 }));
 
 mock.module("@/lib/db/installations", () => ({
@@ -38,14 +43,18 @@ mock.module("@/lib/db/installations", () => ({
 
 const routeModulePromise = import("./route");
 
-function createRequest(): NextRequest {
+function createRequest(url = "http://localhost/api/auth/info"): NextRequest {
   return {
-    nextUrl: new URL("http://localhost/api/auth/info"),
-    url: "http://localhost/api/auth/info",
+    nextUrl: new URL(url),
+    url,
   } as NextRequest;
 }
 
 describe("GET /api/auth/info", () => {
+  afterEach(() => {
+    Object.assign(process.env, { NODE_ENV: originalNodeEnv });
+  });
+
   beforeEach(() => {
     session = {
       authProvider: "vercel",
@@ -94,6 +103,7 @@ describe("GET /api/auth/info", () => {
       user: session?.user,
       authProvider: "vercel",
       isAdmin: false,
+      isManagedTemplateTrialUser: false,
       hasGitHub: true,
       hasGitHubAccount: true,
       hasGitHubInstallations: true,
@@ -110,6 +120,44 @@ describe("GET /api/auth/info", () => {
       user: session?.user,
       authProvider: "vercel",
       isAdmin: false,
+      isManagedTemplateTrialUser: false,
+      hasGitHub: false,
+      hasGitHubAccount: false,
+      hasGitHubInstallations: false,
+    });
+  });
+
+  test("reports managed template trial users", async () => {
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(
+      createRequest("https://open-agents.dev/api/auth/info"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      user: session?.user,
+      authProvider: "vercel",
+      isAdmin: false,
+      isManagedTemplateTrialUser: true,
+      hasGitHub: false,
+      hasGitHubAccount: false,
+      hasGitHubInstallations: false,
+    });
+  });
+
+  test("reports local development non-Vercel users as managed template trial users", async () => {
+    Object.assign(process.env, { NODE_ENV: "development" });
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      user: session?.user,
+      authProvider: "vercel",
+      isAdmin: false,
+      isManagedTemplateTrialUser: true,
       hasGitHub: false,
       hasGitHubAccount: false,
       hasGitHubInstallations: false,

--- a/apps/web/app/api/auth/info/route.ts
+++ b/apps/web/app/api/auth/info/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from "next/server";
 import { hasGitHubAccount as checkGitHubLinked } from "@/lib/github/users";
 import { getInstallationsByUserId } from "@/lib/db/installations";
 import { isUserAdmin, userExists } from "@/lib/db/users";
+import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
 import { getSessionFromReq } from "@/lib/session/server";
 import type { SessionUserInfo } from "@/lib/session/types";
 
@@ -33,6 +34,7 @@ export async function GET(req: NextRequest) {
     user: session.user,
     authProvider: session.authProvider,
     isAdmin,
+    isManagedTemplateTrialUser: isManagedTemplateTrialUser(session, req.url),
     hasGitHub,
     hasGitHubAccount,
     hasGitHubInstallations,

--- a/apps/web/app/api/github/app/callback/route.ts
+++ b/apps/web/app/api/github/app/callback/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { syncUserInstallations } from "@/lib/github/sync";
 import { getUserGitHubToken } from "@/lib/github/token";
 import { getGitHubUsername } from "@/lib/github/users";
+import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 function sanitizeRedirectTo(rawRedirectTo: string | null | undefined): string {
@@ -54,6 +55,12 @@ export async function GET(req: Request): Promise<Response> {
   }
 
   const redirectUrl = new URL(redirectTo, req.url);
+
+  if (isManagedTemplateTrialUser(session, req.url)) {
+    redirectUrl.searchParams.set("github", "trial_blocked");
+    return redirectAndClearCookies(redirectUrl);
+  }
+
   const requestUrl = new URL(req.url);
   const installationId = parseInstallationId(
     requestUrl.searchParams.get("installation_id"),

--- a/apps/web/app/api/github/app/install/route.test.ts
+++ b/apps/web/app/api/github/app/install/route.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { NextRequest } from "next/server";
 
-let authSession: { user: { id: string } } | null;
+let authSession: {
+  authProvider: "vercel";
+  user: { id: string; email?: string };
+} | null;
 let hasLinkedGitHub = false;
 let installations: Array<{ installationId: number }> = [];
 
@@ -54,7 +57,10 @@ function createRequest(url: string): NextRequest {
 
 describe("GET /api/github/app/install", () => {
   beforeEach(() => {
-    authSession = { user: { id: "user-1" } };
+    authSession = {
+      authProvider: "vercel",
+      user: { id: "user-1", email: "person@vercel.com" },
+    };
     hasLinkedGitHub = true;
     installations = [{ installationId: 1 }];
 
@@ -104,5 +110,26 @@ describe("GET /api/github/app/install", () => {
     const redirectUrl = new URL(location as string);
     expect(redirectUrl.origin).toBe("https://github.com");
     expect(redirectUrl.pathname).toContain("open-agents");
+  });
+
+  test("blocks managed template trial users", async () => {
+    authSession = {
+      authProvider: "vercel",
+      user: { id: "user-1", email: "person@example.com" },
+    };
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(
+      createRequest(
+        "https://open-agents.dev/api/github/app/install?next=/settings/connections",
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const redirectUrl = new URL(location as string);
+    expect(redirectUrl.pathname).toBe("/settings/connections");
+    expect(redirectUrl.searchParams.get("github")).toBe("trial_blocked");
   });
 });

--- a/apps/web/app/api/github/app/install/route.ts
+++ b/apps/web/app/api/github/app/install/route.ts
@@ -8,6 +8,7 @@ import {
   getGitHubUsername,
   hasGitHubAccount,
 } from "@/lib/github/users";
+import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 function sanitizeRedirectTo(rawRedirectTo: string | null): string {
@@ -51,6 +52,12 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   if (!session?.user?.id) {
     return NextResponse.redirect(new URL("/", req.url));
+  }
+
+  if (isManagedTemplateTrialUser(session, req.url)) {
+    const fallbackUrl = new URL(redirectTo, req.url);
+    fallbackUrl.searchParams.set("github", "trial_blocked");
+    return NextResponse.redirect(fallbackUrl);
   }
 
   const appSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG;

--- a/apps/web/app/api/github/post-link/route.ts
+++ b/apps/web/app/api/github/post-link/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
-import { getInstallationsByUserId } from "@/lib/db/installations";
+import {
+  deleteInstallationsByUserId,
+  getInstallationsByUserId,
+} from "@/lib/db/installations";
 import { getUserGitHubToken } from "@/lib/github/token";
-import { getGitHubUsername } from "@/lib/github/users";
+import { deleteGitHubAccountLink, getGitHubUsername } from "@/lib/github/users";
 import { syncUserInstallations } from "@/lib/github/sync";
+import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 function sanitizeRedirectTo(rawRedirectTo: string | null | undefined): string {
@@ -30,6 +34,15 @@ export async function GET(req: Request): Promise<Response> {
   const requestUrl = new URL(req.url);
   const next = sanitizeRedirectTo(requestUrl.searchParams.get("next"));
   const redirectUrl = new URL(next, req.url);
+
+  if (isManagedTemplateTrialUser(session, req.url)) {
+    await Promise.all([
+      deleteGitHubAccountLink(session.user.id),
+      deleteInstallationsByUserId(session.user.id),
+    ]);
+    redirectUrl.searchParams.set("github", "trial_blocked");
+    return NextResponse.redirect(redirectUrl);
+  }
 
   const token = await getUserGitHubToken(session.user.id);
   if (!token) {

--- a/apps/web/app/api/sessions/route.test.ts
+++ b/apps/web/app/api/sessions/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { VercelProjectSelection } from "@/lib/vercel/types";
 
 let currentSession: {
@@ -23,6 +23,8 @@ let matchingProjects: VercelProjectSelection[] = [];
 let matchingProjectsError: Error | null = null;
 const createCalls: Array<Record<string, unknown>> = [];
 const upsertCalls: Array<Record<string, unknown>> = [];
+
+const originalNodeEnv = process.env.NODE_ENV;
 
 mock.module("@/lib/session/get-server-session", () => ({
   getServerSession: async () => currentSession,
@@ -113,6 +115,10 @@ function createJsonRequest(
 }
 
 describe("/api/sessions POST vercel project linking", () => {
+  afterEach(() => {
+    Object.assign(process.env, { NODE_ENV: originalNodeEnv });
+  });
+
   beforeEach(() => {
     currentSession = {
       user: {
@@ -160,6 +166,37 @@ describe("/api/sessions POST vercel project linking", () => {
     expect(response.status).toBe(403);
     expect(body.error).toBe(
       "This hosted deployment includes 1 trial session for non-Vercel accounts. Deploy your own copy to start more.",
+    );
+    expect(createCalls).toHaveLength(0);
+  });
+
+  test("blocks repo-backed sessions for trial users", async () => {
+    Object.assign(process.env, { NODE_ENV: "development" });
+    const { POST } = await routeModulePromise;
+
+    currentSession = {
+      authProvider: "vercel",
+      user: {
+        id: "user-1",
+        username: "nico",
+        name: "Nico",
+        email: "person@example.com",
+      },
+    };
+
+    const response = await POST(
+      createJsonRequest({
+        branch: "main",
+        cloneUrl: "https://github.com/vercel-labs/open-agents",
+        repoOwner: "vercel-labs",
+        repoName: "open-agents",
+      }),
+    );
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe(
+      "This hosted deployment does not allow GitHub-backed sessions for non-Vercel trial accounts. Start a new chat without a repository.",
     );
     expect(createCalls).toHaveLength(0);
   });

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -20,6 +20,7 @@ import { getRandomCityName } from "@/lib/random-city";
 import { getServerSession } from "@/lib/session/get-server-session";
 import {
   isManagedTemplateTrialUser,
+  MANAGED_TEMPLATE_TRIAL_GITHUB_SESSION_ERROR,
   MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT,
   MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT_ERROR,
 } from "@/lib/managed-template-trial";
@@ -175,7 +176,8 @@ export async function POST(req: Request) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  if (isManagedTemplateTrialUser(session, req.url)) {
+  const isTrialUser = isManagedTemplateTrialUser(session, req.url);
+  if (isTrialUser) {
     const existingSessionCount = await countSessionsByUserId(session.user.id);
     if (existingSessionCount >= MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT) {
       return Response.json(
@@ -190,6 +192,13 @@ export async function POST(req: Request) {
     body = (await req.json()) as CreateSessionRequest;
   } catch {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (isTrialUser && (body.repoOwner || body.repoName || body.cloneUrl)) {
+    return Response.json(
+      { error: MANAGED_TEMPLATE_TRIAL_GITHUB_SESSION_ERROR },
+      { status: 403 },
+    );
   }
 
   if (body.sandboxType && body.sandboxType !== "vercel") {

--- a/apps/web/app/get-started/get-started-flow.tsx
+++ b/apps/web/app/get-started/get-started-flow.tsx
@@ -58,6 +58,7 @@ export function GetStartedFlow() {
     hasGitHubAccount,
     hasGitHubInstallations,
   } = useSession();
+  const isTrialUser = session?.isManagedTemplateTrialUser ?? false;
   const isGitHubReconnect = searchParams.get("step") === "github";
   const redirectPath = sanitizeRedirectPath(searchParams.get("next"));
   const [activeStep, setActiveStep] = useState<StepId>(
@@ -185,6 +186,7 @@ export function GetStartedFlow() {
                             hasGitHubAccount={hasGitHubAccount}
                             hasGitHubInstallations={hasGitHubInstallations}
                             forceReconnect={isGitHubReconnect}
+                            connectionDisabled={isTrialUser}
                             redirectPath={redirectPath}
                             onComplete={() => {
                               markComplete(2);
@@ -267,6 +269,7 @@ function GitHubConnectStep({
   hasGitHubAccount,
   hasGitHubInstallations,
   forceReconnect,
+  connectionDisabled,
   redirectPath,
   onComplete,
 }: {
@@ -275,6 +278,7 @@ function GitHubConnectStep({
   hasGitHubAccount: boolean;
   hasGitHubInstallations: boolean;
   forceReconnect: boolean;
+  connectionDisabled: boolean;
   redirectPath: string;
   onComplete: () => void;
 }) {
@@ -288,6 +292,23 @@ function GitHubConnectStep({
 
   if (loading) {
     return <Skeleton className="h-10 w-full rounded bg-white/5" />;
+  }
+
+  if (connectionDisabled) {
+    return (
+      <div className="space-y-3">
+        <p className="text-xs text-zinc-500">
+          Hosted trial accounts can start chats without connecting GitHub.
+        </p>
+        <Button
+          size="sm"
+          onClick={onComplete}
+          className="gap-2 bg-white text-black hover:bg-zinc-200"
+        >
+          Continue without GitHub
+        </Button>
+      </div>
+    );
   }
 
   if (isConnected) {

--- a/apps/web/app/get-started/page.tsx
+++ b/apps/web/app/get-started/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
 import { getServerSession } from "@/lib/session/get-server-session";
 import { needsOnboarding } from "@/lib/onboarding";
 import { GetStartedFlow } from "./get-started-flow";
@@ -35,6 +37,12 @@ export default async function GetStartedPage({
 
   const resolvedSearchParams = await searchParams;
   const requestedStep = getSingleSearchParam(resolvedSearchParams.step);
+  const requestHost = (await headers()).get("host") ?? "";
+
+  if (isManagedTemplateTrialUser(session, requestHost)) {
+    redirect("/sessions");
+  }
+
   const onboarding = await needsOnboarding(session.user.id);
 
   if (!onboarding && requestedStep !== "github") {

--- a/apps/web/app/settings/accounts-section.tsx
+++ b/apps/web/app/settings/accounts-section.tsx
@@ -175,6 +175,12 @@ function useGitHubReturnToast() {
           description: "Contact the administrator.",
         });
         break;
+      case "trial_blocked":
+        toast.error("GitHub connections are disabled", {
+          description:
+            "Hosted trial accounts can start chats without connecting GitHub.",
+        });
+        break;
       case "invalid_state":
         toast.error("Callback expired", {
           description: "Please start the installation again.",
@@ -258,7 +264,13 @@ function InstallBadge({
   );
 }
 
-function OrgRow({ org }: { org: OrgInstallStatus }) {
+function OrgRow({
+  org,
+  connectionDisabled,
+}: {
+  org: OrgInstallStatus;
+  connectionDisabled: boolean;
+}) {
   const isInstalled = org.installStatus === "installed";
   const avatarSrc =
     org.avatarUrl ||
@@ -288,6 +300,7 @@ function OrgRow({ org }: { org: OrgInstallStatus }) {
           variant="ghost"
           size="sm"
           className="h-6 px-2 text-[11px]"
+          disabled={connectionDisabled}
           onClick={() => startGitHubInstallForOrg(org.githubId)}
         >
           Install
@@ -339,12 +352,14 @@ function ConnectionStatusButton({
   onReconnect,
   onDisconnect,
   unlinking,
+  connectionDisabled,
 }: {
   status: "connected" | "reconnect" | "not_connected";
   configureUrl?: string | null;
   onReconnect?: () => void;
   onDisconnect: () => void;
   unlinking: boolean;
+  connectionDisabled: boolean;
 }) {
   if (status === "not_connected") {
     return (
@@ -352,6 +367,7 @@ function ConnectionStatusButton({
         variant="ghost"
         size="sm"
         className="h-8 gap-1 text-xs"
+        disabled={connectionDisabled}
         onClick={startGitHubInstallFromSettings}
       >
         Connect
@@ -391,7 +407,7 @@ function ConnectionStatusButton({
             </Link>
           </DropdownMenuItem>
         ) : null}
-        <DropdownMenuItem onClick={onReconnect}>
+        <DropdownMenuItem onClick={onReconnect} disabled={connectionDisabled}>
           Re-authenticate
         </DropdownMenuItem>
         <DropdownMenuItem
@@ -408,7 +424,8 @@ function ConnectionStatusButton({
 }
 
 export function AccountsSection() {
-  const { hasGitHubAccount, hasGitHub, loading } = useSession();
+  const { hasGitHubAccount, hasGitHub, loading, session } = useSession();
+  const isTrialUser = session?.isManagedTemplateTrialUser ?? false;
   const { mutate } = useSWRConfig();
   const [unlinking, setUnlinking] = useState(false);
   const [disconnectOpen, setDisconnectOpen] = useState(false);
@@ -483,7 +500,7 @@ export function AccountsSection() {
       {/* Body */}
       <div className="space-y-4 p-4">
         {!hasGitHub ? (
-          <NotConnectedState />
+          <NotConnectedState connectionDisabled={isTrialUser} />
         ) : (connectionLoading || connectionStatusLoading || !connectionData) &&
           !connectionError ? (
           <ConnectionLoadingSkeleton />
@@ -492,6 +509,7 @@ export function AccountsSection() {
             reconnectReason={reason}
             onDisconnect={() => setDisconnectOpen(true)}
             unlinking={unlinking}
+            connectionDisabled={isTrialUser}
           />
         ) : connectionError && !connectionData ? (
           <ConnectionErrorState onRetry={handleRefresh} />
@@ -502,9 +520,10 @@ export function AccountsSection() {
             reconnectReason={reason}
             onDisconnect={() => setDisconnectOpen(true)}
             unlinking={unlinking}
+            connectionDisabled={isTrialUser}
           />
         ) : (
-          <NotConnectedState />
+          <NotConnectedState connectionDisabled={isTrialUser} />
         )}
       </div>
 
@@ -538,20 +557,28 @@ export function AccountsSection() {
   );
 }
 
-function NotConnectedState() {
+function NotConnectedState({
+  connectionDisabled,
+}: {
+  connectionDisabled: boolean;
+}) {
   const [isLinking, setIsLinking] = useState(false);
 
   return (
     <div className="flex items-center justify-between">
       <p className="text-sm text-muted-foreground">
-        No GitHub account connected
+        {connectionDisabled
+          ? "GitHub connections are disabled for hosted trial accounts"
+          : "No GitHub account connected"}
       </p>
       <Button
         variant="outline"
         size="sm"
         className="shrink-0 gap-1"
-        disabled={isLinking}
+        disabled={isLinking || connectionDisabled}
         onClick={async () => {
+          if (connectionDisabled) return;
+
           setIsLinking(true);
           await authClient.linkSocial({
             provider: "github",
@@ -574,10 +601,12 @@ function DisconnectedState({
   reconnectReason,
   onDisconnect,
   unlinking,
+  connectionDisabled,
 }: {
   reconnectReason: GitHubConnectionReason | null;
   onDisconnect: () => void;
   unlinking: boolean;
+  connectionDisabled: boolean;
 }) {
   return (
     <div className="flex items-center justify-between gap-3">
@@ -590,6 +619,7 @@ function DisconnectedState({
         onReconnect={() => void startGitHubReconnect(reconnectReason)}
         onDisconnect={onDisconnect}
         unlinking={unlinking}
+        connectionDisabled={connectionDisabled}
       />
     </div>
   );
@@ -635,12 +665,14 @@ function ConnectedState({
   reconnectReason,
   onDisconnect,
   unlinking,
+  connectionDisabled,
 }: {
   data: ConnectionStatusResponse;
   reconnectRequired: boolean;
   reconnectReason: GitHubConnectionReason | null;
   onDisconnect: () => void;
   unlinking: boolean;
+  connectionDisabled: boolean;
 }) {
   const [orgsExpanded, setOrgsExpanded] = useState(false);
 
@@ -688,6 +720,7 @@ function ConnectedState({
           onReconnect={() => void startGitHubReconnect(reconnectReason)}
           onDisconnect={onDisconnect}
           unlinking={unlinking}
+          connectionDisabled={connectionDisabled}
         />
       </div>
 
@@ -711,7 +744,11 @@ function ConnectedState({
           {orgsExpanded ? (
             <div className="mt-2 space-y-0 divide-y divide-border/30">
               {allAccounts.map((org) => (
-                <OrgRow key={org.login} org={org} />
+                <OrgRow
+                  key={org.login}
+                  org={org}
+                  connectionDisabled={connectionDisabled}
+                />
               ))}
 
               <div className="flex items-center py-1.5">
@@ -719,6 +756,7 @@ function ConnectedState({
                   variant="ghost"
                   size="sm"
                   className="h-6 px-2 text-[11px] text-muted-foreground"
+                  disabled={connectionDisabled}
                   onClick={startGitHubInstallFromSettings}
                 >
                   <Plus className="size-3.5" />

--- a/apps/web/components/session-starter.tsx
+++ b/apps/web/components/session-starter.tsx
@@ -63,6 +63,7 @@ export function SessionStarter({
   >(undefined);
 
   const { session, loading: sessionLoading, hasGitHub } = useSession();
+  const isTrialUser = session?.isManagedTemplateTrialUser ?? false;
   const { reconnectRequired, isLoading: githubConnectionLoading } =
     useGitHubConnectionStatus({
       enabled: hasGitHub,
@@ -76,9 +77,11 @@ export function SessionStarter({
   const sandboxType = preferences?.defaultSandboxType ?? DEFAULT_SANDBOX_TYPE;
   const sandboxName =
     SANDBOX_OPTIONS.find((s) => s.id === sandboxType)?.name ?? sandboxType;
+  const isRepoModeDisabled = sessionLoading || isTrialUser;
 
   const shouldLoadVercelProjects =
     mode === "repo" &&
+    !isTrialUser &&
     !githubConnectionLoading &&
     !reconnectRequired &&
     !!selectedOwner &&
@@ -93,6 +96,18 @@ export function SessionStarter({
     repoOwner: selectedOwner,
     repoName: selectedRepo,
   });
+
+  useEffect(() => {
+    if (!isTrialUser || mode === "empty") return;
+
+    setMode("empty");
+    setSelectedOwner("");
+    setSelectedRepo("");
+    setSelectedBranch(null);
+    setIsNewBranch(false);
+    setVercelProjectChoice(undefined);
+    setGitSettingsExpanded(false);
+  }, [isTrialUser, mode]);
 
   useEffect(() => {
     if (!shouldLoadVercelProjects) {
@@ -133,6 +148,8 @@ export function SessionStarter({
   };
 
   const handleModeChange = (newMode: SessionMode) => {
+    if (isRepoModeDisabled && newMode === "repo") return;
+
     setMode(newMode);
     if (newMode === "empty") handleRepoClear();
   };
@@ -155,6 +172,7 @@ export function SessionStarter({
   const controlsDisabled = isLoading || preferencesLoading;
   const isSubmitDisabled =
     controlsDisabled ||
+    (isRepoModeDisabled && mode === "repo") ||
     (mode === "repo" && (githubConnectionLoading || reconnectRequired)) ||
     !isRepoSelectionComplete ||
     isVercelLookupPending ||
@@ -163,6 +181,7 @@ export function SessionStarter({
   const effectiveAutoCreatePr = autoCreatePr ?? defaultAutoCreatePr;
   const showVercelProjectSection =
     mode === "repo" &&
+    !isTrialUser &&
     !githubConnectionLoading &&
     !reconnectRequired &&
     !!selectedOwner &&
@@ -234,11 +253,14 @@ export function SessionStarter({
           <button
             type="button"
             onClick={() => handleModeChange("repo")}
+            disabled={isRepoModeDisabled}
             className={cn(
               "flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-all",
-              mode === "repo"
-                ? "border border-border/70 bg-background text-foreground shadow-sm dark:border-transparent dark:bg-white/10 dark:text-neutral-100"
-                : "text-muted-foreground hover:text-foreground dark:text-neutral-400 dark:hover:text-neutral-300",
+              isRepoModeDisabled
+                ? "cursor-not-allowed text-muted-foreground/50 dark:text-neutral-600"
+                : mode === "repo"
+                  ? "border border-border/70 bg-background text-foreground shadow-sm dark:border-transparent dark:bg-white/10 dark:text-neutral-100"
+                  : "text-muted-foreground hover:text-foreground dark:text-neutral-400 dark:hover:text-neutral-300",
             )}
           >
             <GitBranch className="h-3.5 w-3.5" />
@@ -282,7 +304,9 @@ export function SessionStarter({
 
         {mode === "empty" && (
           <p className="text-center text-sm text-muted-foreground dark:text-neutral-500">
-            Start a new chat -- no repository required.
+            {isTrialUser
+              ? "Hosted trial accounts can start chats without connecting GitHub."
+              : "Start a new chat -- no repository required."}
           </p>
         )}
 

--- a/apps/web/lib/managed-template-trial.ts
+++ b/apps/web/lib/managed-template-trial.ts
@@ -5,6 +5,7 @@ const MANAGED_TEMPLATE_HOSTS = new Set([
   "open-agents.dev",
   "www.open-agents.dev",
 ]);
+const LOCAL_DEVELOPMENT_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 export const MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT = 5;
 export const MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT = 1;
@@ -16,6 +17,8 @@ export const MANAGED_TEMPLATE_TRIAL_DELETE_MESSAGE_ERROR =
   "This hosted deployment does not allow message deletion for non-Vercel trial accounts. Deploy your own copy for full controls.";
 export const MANAGED_TEMPLATE_TRIAL_CODE_EDITOR_ERROR =
   "This hosted deployment does not allow the code editor for non-Vercel trial accounts. Deploy your own copy for full controls.";
+export const MANAGED_TEMPLATE_TRIAL_GITHUB_SESSION_ERROR =
+  "This hosted deployment does not allow GitHub-backed sessions for non-Vercel trial accounts. Start a new chat without a repository.";
 
 function normalizeHost(value?: string | URL) {
   const rawValue =
@@ -40,6 +43,14 @@ function normalizeHost(value?: string | URL) {
 export function isManagedTemplateDeployment(url: string | URL) {
   const requestHost = normalizeHost(url);
   if (requestHost && MANAGED_TEMPLATE_HOSTS.has(requestHost)) {
+    return true;
+  }
+
+  if (
+    process.env.NODE_ENV === "development" &&
+    requestHost &&
+    LOCAL_DEVELOPMENT_HOSTS.has(requestHost)
+  ) {
     return true;
   }
 

--- a/apps/web/lib/session/types.ts
+++ b/apps/web/lib/session/types.ts
@@ -14,6 +14,7 @@ export interface SessionUserInfo {
   user: Session["user"] | undefined;
   authProvider?: "vercel" | "github";
   isAdmin?: boolean;
+  isManagedTemplateTrialUser?: boolean;
   hasGitHub?: boolean;
   hasGitHubAccount?: boolean;
   hasGitHubInstallations?: boolean;


### PR DESCRIPTION
## Summary
- Disable repo-backed session starts and GitHub connection actions for managed-template trial users.
- Expose trial status through auth info and make local development reflect managed-template trial behavior for non-Vercel emails.
- Add server-side guards and tests for GitHub install/link flows and repo-backed session creation.

## Verification
- bun run ci