### PR TITLE
Update hosted demo trial copy

### DIFF
--- a/apps/web/app/api/auth/info/route.test.ts
+++ b/apps/web/app/api/auth/info/route.test.ts
@@ -146,7 +146,7 @@ describe("GET /api/auth/info", () => {
     });
   });
 
-  test("reports local development non-Vercel users as managed template trial users", async () => {
+  test("reports local development managed template trial users", async () => {
     Object.assign(process.env, { NODE_ENV: "development" });
     const { GET } = await routeModulePromise;
 

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -347,7 +347,7 @@ describe("/api/chat route", () => {
     );
   });
 
-  test("blocks a sixth message for non-Vercel trial users on the managed deployment", async () => {
+  test("blocks a sixth message for managed template trial users", async () => {
     const { POST } = await routeModulePromise;
     currentAuthSession = {
       authProvider: "vercel",
@@ -378,7 +378,7 @@ describe("/api/chat route", () => {
 
     expect(response.status).toBe(403);
     expect(body.error).toBe(
-      "This hosted deployment has a 5 message limit. Deploy your own copy for no limit at open-agents.dev/deploy-your-own.",
+      "This hosted demo has a 5 message limit. Deploy your own copy to unlock the full Open Agents template.",
     );
     expect(startCalls).toHaveLength(0);
   });

--- a/apps/web/app/api/github/create-repo/route.test.ts
+++ b/apps/web/app/api/github/create-repo/route.test.ts
@@ -71,7 +71,7 @@ describe("/api/github/create-repo", () => {
     expect(response.status).toBe(501);
     expect(await response.json()).toEqual({
       error:
-        "Creating repositories from Open Harness is temporarily disabled. Create the repository on GitHub first, then connect it to a session.",
+        "Creating repositories from Open Agents is temporarily disabled. Create the repository on GitHub first, then connect it to a session.",
     });
   });
 });

--- a/apps/web/app/api/github/create-repo/route.ts
+++ b/apps/web/app/api/github/create-repo/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   return Response.json(
     {
       error:
-        "Creating repositories from Open Harness is temporarily disabled. Create the repository on GitHub first, then connect it to a session.",
+        "Creating repositories from Open Agents is temporarily disabled. Create the repository on GitHub first, then connect it to a session.",
     },
     { status: 501 },
   );

--- a/apps/web/app/api/sessions/[sessionId]/chats/[chatId]/messages/[messageId]/route.test.ts
+++ b/apps/web/app/api/sessions/[sessionId]/chats/[chatId]/messages/[messageId]/route.test.ts
@@ -182,7 +182,7 @@ describe("/api/sessions/[sessionId]/chats/[chatId]/messages/[messageId]", () => 
 
     expect(response.status).toBe(403);
     expect(body.error).toBe(
-      "This hosted deployment does not allow message deletion for non-Vercel trial accounts. Deploy your own copy for full controls.",
+      "Message deletion is disabled in the hosted demo. Deploy your own copy to unlock full controls.",
     );
     expect(deleteCalls).toHaveLength(0);
   });

--- a/apps/web/app/api/sessions/[sessionId]/code-editor/route.test.ts
+++ b/apps/web/app/api/sessions/[sessionId]/code-editor/route.test.ts
@@ -244,7 +244,7 @@ describe("/api/sessions/[sessionId]/code-editor", () => {
     };
     const { POST } = await routeModulePromise;
     const expectedError =
-      "This hosted deployment does not allow the code editor for non-Vercel trial accounts. Deploy your own copy for full controls.";
+      "The code editor is disabled in the hosted demo. Deploy your own copy to unlock the full Open Agents template.";
 
     const response = await POST(
       new Request(

--- a/apps/web/app/api/sessions/route.test.ts
+++ b/apps/web/app/api/sessions/route.test.ts
@@ -136,7 +136,7 @@ describe("/api/sessions POST vercel project linking", () => {
     upsertCalls.length = 0;
   });
 
-  test("blocks additional sessions for non-Vercel trial users on the managed deployment", async () => {
+  test("blocks additional sessions for managed template trial users", async () => {
     const { POST } = await routeModulePromise;
 
     currentSession = {
@@ -165,7 +165,7 @@ describe("/api/sessions POST vercel project linking", () => {
 
     expect(response.status).toBe(403);
     expect(body.error).toBe(
-      "This hosted deployment includes 1 trial session for non-Vercel accounts. Deploy your own copy to start more.",
+      "This hosted demo includes 1 trial session. Deploy your own copy to unlock the full Open Agents template.",
     );
     expect(createCalls).toHaveLength(0);
   });
@@ -196,7 +196,7 @@ describe("/api/sessions POST vercel project linking", () => {
 
     expect(response.status).toBe(403);
     expect(body.error).toBe(
-      "This hosted deployment does not allow GitHub-backed sessions for non-Vercel trial accounts. Start a new chat without a repository.",
+      "GitHub-backed sessions are disabled in the hosted demo. Deploy your own copy to unlock repository support, or start a new chat without a repository.",
     );
     expect(createCalls).toHaveLength(0);
   });

--- a/apps/web/app/deploy-your-own/page.tsx
+++ b/apps/web/app/deploy-your-own/page.tsx
@@ -37,7 +37,7 @@ const DEPLOY_TEMPLATE_URL = (() => {
     ["project-name", "open-agents"],
     ["repository-name", "open-agents"],
     ["repository-url", "https://github.com/vercel-labs/open-agents"],
-    ["demo-title", "Open Harness"],
+    ["demo-title", "Open Agents"],
     [
       "demo-description",
       "Open-source reference app for building and running background coding agents on Vercel.",
@@ -58,7 +58,7 @@ const DEPLOY_TEMPLATE_URL = (() => {
 export const metadata: Metadata = {
   title: "Deploy your own",
   description:
-    "Deploy your own copy of Open Harness to sign in with your own account.",
+    "Deploy your own copy of Open Agents to unlock the full template.",
 };
 
 export default function DeployYourOwnPage() {
@@ -66,15 +66,14 @@ export default function DeployYourOwnPage() {
     <main className="flex min-h-screen items-center justify-center bg-background px-6 py-24 text-foreground">
       <div className="flex max-w-xl flex-col items-center text-center">
         <p className="text-sm font-medium text-muted-foreground">
-          Open Harness
+          Open Agents
         </p>
         <h1 className="mt-4 text-4xl font-semibold tracking-tight">
           Deploy your own
         </h1>
         <p className="mt-4 text-base leading-7 text-muted-foreground">
-          This hosted deployment only supports sign-ins from @vercel.com email
-          addresses. To use the template with your own account, deploy your own
-          copy.
+          This hosted demo has limited functionality. Deploy your own copy to
+          unlock the full Open Agents template.
         </p>
         <Button asChild className="mt-8" size="lg">
           <Link href={DEPLOY_TEMPLATE_URL} rel="noreferrer" target="_blank">

--- a/apps/web/app/deploy-your-own/page.tsx
+++ b/apps/web/app/deploy-your-own/page.tsx
@@ -65,9 +65,7 @@ export default function DeployYourOwnPage() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-background px-6 py-24 text-foreground">
       <div className="flex max-w-xl flex-col items-center text-center">
-        <p className="text-sm font-medium text-muted-foreground">
-          Open Agents
-        </p>
+        <p className="text-sm font-medium text-muted-foreground">Open Agents</p>
         <h1 className="mt-4 text-4xl font-semibold tracking-tight">
           Deploy your own
         </h1>

--- a/apps/web/app/get-started/get-started-flow.tsx
+++ b/apps/web/app/get-started/get-started-flow.tsx
@@ -298,7 +298,7 @@ function GitHubConnectStep({
     return (
       <div className="space-y-3">
         <p className="text-xs text-zinc-500">
-          Hosted trial accounts can start chats without connecting GitHub.
+          In the hosted demo, you can start chats without connecting GitHub.
         </p>
         <Button
           size="sm"

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/git-panel.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/git-panel.tsx
@@ -101,7 +101,7 @@ const mergeMethodDescriptions: Record<MergeMethod, string> = {
 };
 
 const createRepoDisabledReason =
-  "Creating repositories from Open Harness is temporarily disabled. Create the repository on GitHub first, then connect it to a session.";
+  "Creating repositories from Open Agents is temporarily disabled. Create the repository on GitHub first, then connect it to a session.";
 
 /* ------------------------------------------------------------------ */
 /* Types                                                               */

--- a/apps/web/app/settings/accounts-section.tsx
+++ b/apps/web/app/settings/accounts-section.tsx
@@ -178,7 +178,7 @@ function useGitHubReturnToast() {
       case "trial_blocked":
         toast.error("GitHub connections are disabled", {
           description:
-            "Hosted trial accounts can start chats without connecting GitHub.",
+            "In the hosted demo, you can start chats without connecting GitHub.",
         });
         break;
       case "invalid_state":
@@ -568,7 +568,7 @@ function NotConnectedState({
     <div className="flex items-center justify-between">
       <p className="text-sm text-muted-foreground">
         {connectionDisabled
-          ? "GitHub connections are disabled for hosted trial accounts"
+          ? "GitHub connections are disabled in the hosted demo. Deploy your own copy to connect repositories."
           : "No GitHub account connected"}
       </p>
       <Button

--- a/apps/web/components/session-starter.tsx
+++ b/apps/web/components/session-starter.tsx
@@ -305,7 +305,7 @@ export function SessionStarter({
         {mode === "empty" && (
           <p className="text-center text-sm text-muted-foreground dark:text-neutral-500">
             {isTrialUser
-              ? "Hosted trial accounts can start chats without connecting GitHub."
+              ? "In the hosted demo, you can start chats without connecting GitHub."
               : "Start a new chat -- no repository required."}
           </p>
         )}

--- a/apps/web/lib/managed-template-trial.ts
+++ b/apps/web/lib/managed-template-trial.ts
@@ -10,15 +10,15 @@ const LOCAL_DEVELOPMENT_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 export const MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT = 5;
 export const MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT = 1;
 export const MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT_ERROR =
-  "This hosted deployment has a 5 message limit. Deploy your own copy for no limit at open-agents.dev/deploy-your-own.";
+  "This hosted demo has a 5 message limit. Deploy your own copy to unlock the full Open Agents template.";
 export const MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT_ERROR =
-  "This hosted deployment includes 1 trial session for non-Vercel accounts. Deploy your own copy to start more.";
+  "This hosted demo includes 1 trial session. Deploy your own copy to unlock the full Open Agents template.";
 export const MANAGED_TEMPLATE_TRIAL_DELETE_MESSAGE_ERROR =
-  "This hosted deployment does not allow message deletion for non-Vercel trial accounts. Deploy your own copy for full controls.";
+  "Message deletion is disabled in the hosted demo. Deploy your own copy to unlock full controls.";
 export const MANAGED_TEMPLATE_TRIAL_CODE_EDITOR_ERROR =
-  "This hosted deployment does not allow the code editor for non-Vercel trial accounts. Deploy your own copy for full controls.";
+  "The code editor is disabled in the hosted demo. Deploy your own copy to unlock the full Open Agents template.";
 export const MANAGED_TEMPLATE_TRIAL_GITHUB_SESSION_ERROR =
-  "This hosted deployment does not allow GitHub-backed sessions for non-Vercel trial accounts. Start a new chat without a repository.";
+  "GitHub-backed sessions are disabled in the hosted demo. Deploy your own copy to unlock repository support, or start a new chat without a repository.";
 
 function normalizeHost(value?: string | URL) {
   const rawValue =

--- a/apps/web/lib/model-access.ts
+++ b/apps/web/lib/model-access.ts
@@ -11,7 +11,7 @@ import type { Session } from "@/lib/session/types";
 const RESTRICTED_MODEL_PREFIXES = ["anthropic/claude-opus-"];
 
 export const MANAGED_TEMPLATE_TRIAL_MODEL_ACCESS_ERROR =
-  "This hosted deployment does not allow Claude Opus models for non-Vercel trial accounts. Deploy your own copy for full model access.";
+  "Claude Opus models are disabled in the hosted demo. Deploy your own copy to unlock full model access.";
 
 type SessionLike = Pick<Session, "authProvider" | "user"> | null | undefined;
 


### PR DESCRIPTION
## Summary
- Replace confusing non-Vercel trial copy with hosted demo language
- Point users toward deploying their own copy to unlock the full Open Agents template
- Update lingering Open Harness user-facing strings to Open Agents

## Testing
- Targeted tests run; some existing route test modules failed to load due to missing mocked/named exports: getSessionsWithUnreadByUserId, CODE_SERVER_PORT, requireOwnedSessionChat