### PR TITLE
Make sandbox runtime resources deployable by profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A few details that matter for understanding the current implementation:
 - Chat requests start a workflow run instead of executing the agent inline.
 - Each agent turn can continue across many persisted workflow steps.
 - Active runs can be resumed by reconnecting to the stream for the existing workflow.
-- Sandboxes use a base snapshot, expose ports `3000`, `5173`, `4321`, and `8000`, and hibernate after inactivity.
+- Sandboxes expose ports `3000`, `5173`, `4321`, and `8000`, can optionally use a configured base snapshot, and hibernate after inactivity.
 - Auto-commit and auto-PR are supported, but they are preference-driven features, not always-on behavior.
 
 ## What is actually required today
@@ -100,7 +100,7 @@ ELEVENLABS_API_KEY=
 
 - `REDIS_URL` / `KV_URL`: optional skills metadata cache (falls back to in-memory when not configured).
 - `VERCEL_PROJECT_PRODUCTION_URL` / `NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL`: canonical production URL for metadata and some callback behavior.
-- `VERCEL_SANDBOX_BASE_SNAPSHOT_ID`: override the default sandbox snapshot.
+- `VERCEL_SANDBOX_BASE_SNAPSHOT_ID`: optional base snapshot for fresh sandboxes. If unset, sandboxes start from Vercel's standard Sandbox runtime. Use a snapshot created in/accessible to your own Vercel scope.
 - `ELEVENLABS_API_KEY`: voice transcription.
 
 ## Deploy your own copy on Vercel
@@ -151,7 +151,7 @@ Recommended path: deploy this repo at the repo root on Vercel, then layer on aut
    - make the app public if you want org installs to work cleanly
 
 10. Add the GitHub App env vars and redeploy.
-11. Optionally add Redis/KV and the canonical production URL vars.
+11. Optionally add Redis/KV, the canonical production URL vars, and your own `VERCEL_SANDBOX_BASE_SNAPSHOT_ID` if you want fresh sandboxes to start from a preconfigured image.
 
 ## Local setup
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ GITHUB_WEBHOOK_SECRET=
 ```env
 REDIS_URL=
 KV_URL=
+OPEN_AGENTS_RESOURCE_PROFILE=
 VERCEL_PROJECT_PRODUCTION_URL=
 NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL=
 VERCEL_SANDBOX_BASE_SNAPSHOT_ID=
@@ -99,6 +100,7 @@ ELEVENLABS_API_KEY=
 ```
 
 - `REDIS_URL` / `KV_URL`: optional skills metadata cache (falls back to in-memory when not configured).
+- `OPEN_AGENTS_RESOURCE_PROFILE`: optional deployment resource profile. Set to `hobby` to use Hobby-compatible defaults for chat and sandbox resources; leave unset for standard behavior.
 - `VERCEL_PROJECT_PRODUCTION_URL` / `NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL`: canonical production URL for metadata and some callback behavior.
 - `VERCEL_SANDBOX_BASE_SNAPSHOT_ID`: optional base snapshot for fresh sandboxes. If unset, sandboxes start from Vercel's standard Sandbox runtime. Use a snapshot created in/accessible to your own Vercel scope.
 - `ELEVENLABS_API_KEY`: voice transcription.
@@ -151,7 +153,7 @@ Recommended path: deploy this repo at the repo root on Vercel, then layer on aut
    - make the app public if you want org installs to work cleanly
 
 10. Add the GitHub App env vars and redeploy.
-11. Optionally add Redis/KV, the canonical production URL vars, and your own `VERCEL_SANDBOX_BASE_SNAPSHOT_ID` if you want fresh sandboxes to start from a preconfigured image.
+11. Optionally add Redis/KV, `OPEN_AGENTS_RESOURCE_PROFILE=hobby` for Hobby-compatible resource defaults, the canonical production URL vars, and your own `VERCEL_SANDBOX_BASE_SNAPSHOT_ID` if you want fresh sandboxes to start from a preconfigured image.
 
 ## Local setup
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -29,6 +29,9 @@ REDIS_URL=
 KV_URL=
 
 # Optional deployment refinements
+# Set to "hobby" to use lower resource defaults for constrained deployments.
+# Leave unset for standard behavior.
+OPEN_AGENTS_RESOURCE_PROFILE=
 VERCEL_PROJECT_PRODUCTION_URL=
 NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL=
 # Optional base snapshot for fresh sandboxes. If unset, sandboxes use Vercel's standard Sandbox runtime.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -31,4 +31,6 @@ KV_URL=
 # Optional deployment refinements
 VERCEL_PROJECT_PRODUCTION_URL=
 NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL=
+# Optional base snapshot for fresh sandboxes. If unset, sandboxes use Vercel's standard Sandbox runtime.
+# Use a snapshot created in/accessible to your own Vercel scope.
 VERCEL_SANDBOX_BASE_SNAPSHOT_ID=

--- a/apps/web/SANDBOX-LIFECYCLE.md
+++ b/apps/web/SANDBOX-LIFECYCLE.md
@@ -6,10 +6,10 @@ This document describes how sandbox lifecycle management works, including automa
 
 | Constant | Test | Production | Purpose |
 |---|---|---|---|
-| `DEFAULT_SANDBOX_TIMEOUT_MS` | 3 min | 5 hours | Hard VM expiry from Vercel |
+| `DEFAULT_SANDBOX_TIMEOUT_MS` | 3 min | 5 hours standard / 40 minutes hobby | Hard VM expiry from Vercel |
 | `SANDBOX_INACTIVITY_TIMEOUT_MS` | 30 min | 30 min | Inactivity window before hibernate |
 
-Configured in `lib/sandbox/config.ts`.
+Configured in `lib/sandbox/config.ts`. Set `OPEN_AGENTS_RESOURCE_PROFILE=hobby` to opt into the hobby profile; unset keeps standard behavior.
 
 ## State machine
 
@@ -44,7 +44,7 @@ Configured in `lib/sandbox/config.ts`.
 
 Where **I** = inactivity timeout, **H** = hard timeout.
 
-When the hard timeout is reached while the sandbox is still active, it hibernates the same way as inactivity - snapshot and stop. The user can manually resume if needed. This is simpler than automatic rollover and sufficient because the hard timeout (5 hours) is long enough that inactivity hibernation will almost always trigger first.
+When the hard timeout is reached while the sandbox is still active, it hibernates the same way as inactivity - snapshot and stop. The user can manually resume if needed. This is simpler than automatic rollover and sufficient because the standard hard timeout (5 hours) is long enough that inactivity hibernation will almost always trigger first.
 
 ## How workflows work
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -28,8 +28,6 @@ import { parseChatRequestBody, requireChatIdentifiers } from "./_lib/request";
 import { runAgentWorkflow } from "@/app/workflows/chat";
 import { persistAssistantMessagesWithToolResults } from "./_lib/persist-tool-results";
 
-export const maxDuration = 800;
-
 type WebAgentUIMessageChunk = InferUIMessageChunk<WebAgentUIMessage>;
 
 function getLatestUserMessage(messages: WebAgentUIMessage[]) {

--- a/apps/web/app/api/sandbox/route.test.ts
+++ b/apps/web/app/api/sandbox/route.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { DEFAULT_SANDBOX_TIMEOUT_MS } from "@/lib/sandbox/config";
+import {
+  DEFAULT_SANDBOX_TIMEOUT_MS,
+  DEFAULT_SANDBOX_VCPUS,
+} from "@/lib/sandbox/config";
 
 mock.module("server-only", () => ({}));
 
@@ -47,6 +50,8 @@ interface ConnectConfig {
     persistent?: boolean;
     resume?: boolean;
     createIfMissing?: boolean;
+    timeout?: number;
+    vcpus?: number;
   };
 }
 
@@ -286,6 +291,8 @@ describe("/api/sandbox lifecycle kicks", () => {
         sandboxName: "session_session-1",
       },
       options: {
+        timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+        vcpus: DEFAULT_SANDBOX_VCPUS,
         persistent: true,
         resume: true,
         createIfMissing: true,

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
   DEFAULT_SANDBOX_PORTS,
   DEFAULT_SANDBOX_TIMEOUT_MS,
+  DEFAULT_SANDBOX_VCPUS,
 } from "@/lib/sandbox/config";
 import {
   buildActiveLifecycleUpdate,
@@ -204,6 +205,7 @@ export async function POST(req: Request) {
         githubToken: setupToken?.token,
         gitUser,
         timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+        vcpus: DEFAULT_SANDBOX_VCPUS,
         ports: DEFAULT_SANDBOX_PORTS,
         baseSnapshotId: DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
         persistent: !!sandboxName,

--- a/apps/web/app/api/sandbox/snapshot/route.ts
+++ b/apps/web/app/api/sandbox/snapshot/route.ts
@@ -8,6 +8,7 @@ import { updateSession } from "@/lib/db/sessions";
 import {
   DEFAULT_SANDBOX_PORTS,
   DEFAULT_SANDBOX_TIMEOUT_MS,
+  DEFAULT_SANDBOX_VCPUS,
 } from "@/lib/sandbox/config";
 import {
   buildActiveLifecycleUpdate,
@@ -184,6 +185,7 @@ export async function PUT(req: Request) {
       },
       {
         timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+        vcpus: DEFAULT_SANDBOX_VCPUS,
         ports: DEFAULT_SANDBOX_PORTS,
         resume: true,
         createIfMissing: true,
@@ -202,6 +204,7 @@ export async function PUT(req: Request) {
               { type: sandboxType, sandboxName: persistentSandboxName },
               {
                 timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+                vcpus: DEFAULT_SANDBOX_VCPUS,
                 ports: DEFAULT_SANDBOX_PORTS,
                 resume: true,
               },

--- a/apps/web/app/workflows/chat-sandbox-runtime.ts
+++ b/apps/web/app/workflows/chat-sandbox-runtime.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
   DEFAULT_SANDBOX_PORTS,
   DEFAULT_SANDBOX_TIMEOUT_MS,
+  DEFAULT_SANDBOX_VCPUS,
 } from "@/lib/sandbox/config";
 import {
   getResumableSandboxName,
@@ -237,6 +238,7 @@ export async function resolveChatSandboxRuntime(params: {
         githubToken: setupToken?.token,
         gitUser,
         timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+        vcpus: DEFAULT_SANDBOX_VCPUS,
         ports: DEFAULT_SANDBOX_PORTS,
         baseSnapshotId: DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
         persistent: true,

--- a/apps/web/lib/deployment/resource-profile.ts
+++ b/apps/web/lib/deployment/resource-profile.ts
@@ -1,0 +1,11 @@
+export type OpenAgentsResourceProfile = "standard" | "hobby";
+
+export function getOpenAgentsResourceProfile(): OpenAgentsResourceProfile {
+  return process.env.OPEN_AGENTS_RESOURCE_PROFILE === "hobby"
+    ? "hobby"
+    : "standard";
+}
+
+export function isHobbyResourceProfile(): boolean {
+  return getOpenAgentsResourceProfile() === "hobby";
+}

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -3,12 +3,26 @@
  * All timeout values are in milliseconds.
  */
 
+import { isHobbyResourceProfile } from "@/lib/deployment/resource-profile";
+
 /** SDK safety buffer reserved for sandbox before-stop hooks (30 seconds) */
 const VERCEL_SANDBOX_TIMEOUT_BUFFER_MS = 30 * 1000;
 
-/** Default timeout for new cloud sandboxes (5 hours minus hook buffer) */
-export const DEFAULT_SANDBOX_TIMEOUT_MS =
+/** Standard timeout for new cloud sandboxes (5 hours minus hook buffer) */
+const STANDARD_SANDBOX_TIMEOUT_MS =
   5 * 60 * 60 * 1000 - VERCEL_SANDBOX_TIMEOUT_BUFFER_MS;
+
+/** Hobby-compatible timeout for new cloud sandboxes (40 minutes minus hook buffer) */
+const HOBBY_SANDBOX_TIMEOUT_MS =
+  40 * 60 * 1000 - VERCEL_SANDBOX_TIMEOUT_BUFFER_MS;
+
+/** Default timeout for new cloud sandboxes */
+export const DEFAULT_SANDBOX_TIMEOUT_MS = isHobbyResourceProfile()
+  ? HOBBY_SANDBOX_TIMEOUT_MS
+  : STANDARD_SANDBOX_TIMEOUT_MS;
+
+/** Default vCPU count for new cloud sandboxes */
+export const DEFAULT_SANDBOX_VCPUS = isHobbyResourceProfile() ? 1 : 4;
 
 /** Manual extension duration for explicit fallback flows (20 minutes) */
 export const EXTEND_TIMEOUT_DURATION_MS = 20 * 60 * 1000;

--- a/apps/web/lib/sandbox/config.ts
+++ b/apps/web/lib/sandbox/config.ts
@@ -41,13 +41,11 @@ export const CODE_SERVER_PORT = 8000;
 export const DEFAULT_WORKING_DIRECTORY = "/vercel/sandbox";
 
 /**
- * Base snapshot for fresh cloud sandboxes.
- * - Current snapshot includes: bun + jq + agent-browser + chromium + code-server
- * - Previous snapshot includes: bun + jq + agent-browser + chromium
+ * Optional base snapshot for fresh cloud sandboxes.
+ *
+ * Forked deployments should provide their own snapshot ID if they want a
+ * preconfigured image. When unset, sandboxes start from Vercel's standard
+ * runtime so deployments are not tied to a private snapshot in another scope.
  */
 export const DEFAULT_SANDBOX_BASE_SNAPSHOT_ID =
-  process.env.VERCEL_SANDBOX_BASE_SNAPSHOT_ID ??
-  // Previous snapshot (bun + jq): "snap_MQ0NqdLL5qEXiYusgWL3K0yaMmql"
-  // Previous snapshot (bun + jq + agent-browser + chromium): "snap_C8tUFhwRXZky4MaFvTuwO7DH66wx"
-  // Current snapshot (bun + jq + agent-browser + chromium + code-server):
-  "snap_EjsphVxi07bFKrfojljJdIS41KHT";
+  process.env.VERCEL_SANDBOX_BASE_SNAPSHOT_ID;

--- a/packages/sandbox/factory.ts
+++ b/packages/sandbox/factory.ts
@@ -26,6 +26,8 @@ export interface ConnectOptions {
   hooks?: SandboxHooks;
   /** Timeout in milliseconds for sandboxes (default: 300,000 = 5 minutes) */
   timeout?: number;
+  /** Number of vCPUs for new sandboxes */
+  vcpus?: number;
   /** Ports to expose from the sandbox for dev server preview URLs */
   ports?: number[];
   /** Snapshot ID used as the base image for new sandboxes */

--- a/packages/sandbox/vercel/connect.ts
+++ b/packages/sandbox/vercel/connect.ts
@@ -9,6 +9,7 @@ interface ConnectOptions {
   gitUser?: { name: string; email: string };
   hooks?: SandboxHooks;
   timeout?: number;
+  vcpus?: number;
   ports?: number[];
   baseSnapshotId?: string;
   resume?: boolean;
@@ -77,6 +78,7 @@ function buildCreateConfig(
     gitUser: options?.gitUser,
     hooks: options?.hooks,
     ...(options?.timeout !== undefined && { timeout: options.timeout }),
+    ...(options?.vcpus !== undefined && { vcpus: options.vcpus }),
     ...(options?.ports && { ports: options.ports }),
     ...(options?.baseSnapshotId && {
       baseSnapshotId: options.baseSnapshotId,


### PR DESCRIPTION
## Summary
- remove the hardcoded private sandbox base snapshot fallback so fresh sandboxes use Vercel's standard Sandbox runtime when no base snapshot is configured
- add `OPEN_AGENTS_RESOURCE_PROFILE=hobby` for Hobby-compatible sandbox defaults, including lower timeout and vCPU settings
- pass configured sandbox timeout and vCPU values through creation, resume, snapshot, and chat runtime paths
- document the optional deployment settings for self-hosted and constrained Vercel deployments

## Validation
- bun run typecheck --filter=web
- bun run check