### PR TITLE
Fix DeepSec security findings

### DIFF
--- a/apps/web/app/[username]/[repo]/page.tsx
+++ b/apps/web/app/[username]/[repo]/page.tsx
@@ -2,12 +2,19 @@ import { nanoid } from "nanoid";
 import { headers as nextHeaders } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import {
+  countSessionsByUserId,
   createSessionWithInitialChat,
   getUsedSessionTitles,
 } from "@/lib/db/sessions";
 import { getVercelProjectLinkByRepo } from "@/lib/db/vercel-project-links";
 import { getUserPreferences } from "@/lib/db/user-preferences";
 import { getUserGitHubToken } from "@/lib/github/token";
+import {
+  isManagedTemplateTrialUser,
+  MANAGED_TEMPLATE_TRIAL_GITHUB_SESSION_ERROR,
+  MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT,
+  MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT_ERROR,
+} from "@/lib/managed-template-trial";
 import { sanitizeUserPreferencesForSession } from "@/lib/model-access";
 import { getRandomCityName } from "@/lib/random-city";
 import { getServerSession } from "@/lib/session/get-server-session";
@@ -57,6 +64,16 @@ export default async function RepoPage({ params }: RepoPageProps) {
     redirect("/");
   }
 
+  const requestHost = (await nextHeaders()).get("host") ?? "";
+  if (isManagedTemplateTrialUser(session, requestHost)) {
+    const existingSessionCount = await countSessionsByUserId(session.user.id);
+    const error =
+      existingSessionCount >= MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT
+        ? MANAGED_TEMPLATE_TRIAL_SESSION_LIMIT_ERROR
+        : MANAGED_TEMPLATE_TRIAL_GITHUB_SESSION_ERROR;
+    redirect(`/?error=${encodeURIComponent(error)}`);
+  }
+
   const preferencesPromise = getUserPreferences(session.user.id);
   const savedVercelProjectPromise = getVercelProjectLinkByRepo(
     session.user.id,
@@ -85,7 +102,6 @@ export default async function RepoPage({ params }: RepoPageProps) {
   }
 
   // Use the user's preferred sandbox type and model
-  const requestHost = (await nextHeaders()).get("host") ?? "";
   const [rawPreferences, savedVercelProject] = await Promise.all([
     preferencesPromise,
     savedVercelProjectPromise,

--- a/apps/web/app/[username]/og/route.tsx
+++ b/apps/web/app/[username]/og/route.tsx
@@ -11,7 +11,8 @@ interface OgRouteContext {
 export async function GET(request: Request, context: OgRouteContext) {
   const { username } = await context.params;
   const { searchParams } = new URL(request.url);
-  const date = searchParams.get("date");
+  const rawDate = searchParams.get("date") ?? "30d";
+  const date = ["7d", "30d", "all"].includes(rawDate) ? rawDate : "30d";
   const profile = await getPublicUsageProfile(username, date);
 
   if (!profile) {

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -35,6 +35,7 @@ let currentAuthSession: {
 } | null;
 let existingUserMessageCount = 0;
 let existingChatMessage: { id: string } | null = null;
+let existingScopedChatMessage: { id: string } | null = null;
 let isSandboxActive = true;
 let existingRunStatus: string = "completed";
 let getRunShouldThrow = false;
@@ -177,6 +178,7 @@ mock.module("@/lib/db/sessions", () => ({
   createChatMessageIfNotExists: createChatMessageIfNotExistsSpy,
   getChatById: async () => chatRecord,
   getChatMessageById: async () => existingChatMessage,
+  getChatMessageByIdForChat: async () => existingScopedChatMessage,
   getSessionById: async () => sessionRecord,
   isFirstChatMessage: isFirstChatMessageSpy,
   touchChat: touchChatSpy,
@@ -264,6 +266,7 @@ describe("/api/chat route", () => {
     discoverSkillDirsCalls = [];
     existingUserMessageCount = 0;
     existingChatMessage = null;
+    existingScopedChatMessage = null;
     preferencesState = {
       autoCommitPush: true,
       autoCreatePr: false,
@@ -380,6 +383,40 @@ describe("/api/chat route", () => {
     expect(body.error).toBe(
       "This hosted demo has a 5 message limit. Deploy your own copy to unlock the full Open Agents template.",
     );
+    expect(startCalls).toHaveLength(0);
+  });
+
+  test("does not let trial users replay a message id from another chat", async () => {
+    const { POST } = await routeModulePromise;
+    currentAuthSession = {
+      authProvider: "vercel",
+      user: {
+        id: "user-1",
+        email: "person@example.com",
+      },
+    };
+    existingUserMessageCount = 5;
+    existingChatMessage = { id: "user-1" };
+    existingScopedChatMessage = null;
+
+    const response = await POST(
+      createRequest(
+        JSON.stringify({
+          sessionId: "session-1",
+          chatId: "chat-1",
+          messages: [
+            {
+              id: "user-1",
+              role: "user",
+              parts: [{ type: "text", text: "Replay this" }],
+            },
+          ],
+        }),
+        "https://open-agents.dev/api/chat",
+      ),
+    );
+
+    expect(response.status).toBe(403);
     expect(startCalls).toHaveLength(0);
   });
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -8,7 +8,7 @@ import {
   countUserMessagesByUserId,
   createChatMessageIfNotExists,
   getChatById,
-  getChatMessageById,
+  getChatMessageByIdForChat,
   isFirstChatMessage,
   touchChat,
   updateChat,
@@ -91,7 +91,10 @@ export async function POST(req: Request) {
   if (isManagedTemplateTrialUser(session, req.url)) {
     const latestUserMessage = getLatestUserMessage(messages);
     if (latestUserMessage) {
-      const existingMessage = await getChatMessageById(latestUserMessage.id);
+      const existingMessage = await getChatMessageByIdForChat(
+        latestUserMessage.id,
+        chatId,
+      );
       if (!existingMessage) {
         const userMessageCount = await countUserMessagesByUserId(userId);
         if (userMessageCount >= MANAGED_TEMPLATE_TRIAL_MESSAGE_LIMIT) {

--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -3,6 +3,7 @@ import { checkBotProtection } from "@/lib/botid";
 import { generateBranchName, looksLikeCommitHash } from "@/lib/git/helpers";
 import { getSessionById, updateSession } from "@/lib/db/sessions";
 import { generatePullRequestContentFromSandbox } from "@/lib/github/pr-content";
+import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 
@@ -27,6 +28,15 @@ export async function POST(req: Request) {
   const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const limited = checkRateLimit({
+    key: rateLimitKey(["generate-pr", session.user.id]),
+    limit: 5,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
   }
 
   // 2. parse request

--- a/apps/web/app/api/generate-title/route.ts
+++ b/apps/web/app/api/generate-title/route.ts
@@ -1,6 +1,7 @@
 import { checkBotProtection } from "@/lib/botid";
 import { gateway, generateText } from "ai";
 import { z } from "zod";
+import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 /**
@@ -48,6 +49,15 @@ export async function POST(req: Request) {
   const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const limited = checkRateLimit({
+    key: rateLimitKey(["generate-title", session.user.id]),
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
   }
 
   let body: unknown;

--- a/apps/web/app/api/github/app/callback/route.ts
+++ b/apps/web/app/api/github/app/callback/route.ts
@@ -4,19 +4,8 @@ import { syncUserInstallations } from "@/lib/github/sync";
 import { getUserGitHubToken } from "@/lib/github/token";
 import { getGitHubUsername } from "@/lib/github/users";
 import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
+import { sanitizeInternalRedirect } from "@/lib/redirect-safety";
 import { getServerSession } from "@/lib/session/get-server-session";
-
-function sanitizeRedirectTo(rawRedirectTo: string | null | undefined): string {
-  if (!rawRedirectTo) {
-    return "/get-started";
-  }
-
-  if (!rawRedirectTo.startsWith("/") || rawRedirectTo.startsWith("//")) {
-    return "/get-started";
-  }
-
-  return rawRedirectTo;
-}
 
 function parseInstallationId(value: string | null): number | null {
   if (!value) {
@@ -45,8 +34,10 @@ function redirectAndClearCookies(url: string | URL): NextResponse {
  */
 export async function GET(req: Request): Promise<Response> {
   const cookieStore = await cookies();
-  const redirectTo = sanitizeRedirectTo(
+  const redirectTo = sanitizeInternalRedirect(
     cookieStore.get("github_app_install_redirect_to")?.value,
+    "/get-started",
+    req.url,
   );
 
   const session = await getServerSession();

--- a/apps/web/app/api/github/app/install/route.ts
+++ b/apps/web/app/api/github/app/install/route.ts
@@ -9,19 +9,8 @@ import {
   hasGitHubAccount,
 } from "@/lib/github/users";
 import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
+import { sanitizeInternalRedirect } from "@/lib/redirect-safety";
 import { getServerSession } from "@/lib/session/get-server-session";
-
-function sanitizeRedirectTo(rawRedirectTo: string | null): string {
-  if (!rawRedirectTo) {
-    return "/get-started";
-  }
-
-  if (!rawRedirectTo.startsWith("/") || rawRedirectTo.startsWith("//")) {
-    return "/get-started";
-  }
-
-  return rawRedirectTo;
-}
 
 const COOKIE_OPTIONS = {
   path: "/",
@@ -48,7 +37,11 @@ function redirectWithInstallCookies(
 
 export async function GET(req: NextRequest): Promise<Response> {
   const session = await getServerSession();
-  const redirectTo = sanitizeRedirectTo(req.nextUrl.searchParams.get("next"));
+  const redirectTo = sanitizeInternalRedirect(
+    req.nextUrl.searchParams.get("next"),
+    "/get-started",
+    req.url,
+  );
 
   if (!session?.user?.id) {
     return NextResponse.redirect(new URL("/", req.url));

--- a/apps/web/app/api/github/post-link/route.ts
+++ b/apps/web/app/api/github/post-link/route.ts
@@ -7,19 +7,8 @@ import { getUserGitHubToken } from "@/lib/github/token";
 import { deleteGitHubAccountLink, getGitHubUsername } from "@/lib/github/users";
 import { syncUserInstallations } from "@/lib/github/sync";
 import { isManagedTemplateTrialUser } from "@/lib/managed-template-trial";
+import { sanitizeInternalRedirect } from "@/lib/redirect-safety";
 import { getServerSession } from "@/lib/session/get-server-session";
-
-function sanitizeRedirectTo(rawRedirectTo: string | null | undefined): string {
-  if (!rawRedirectTo) {
-    return "/sessions";
-  }
-
-  if (!rawRedirectTo.startsWith("/") || rawRedirectTo.startsWith("//")) {
-    return "/sessions";
-  }
-
-  return rawRedirectTo;
-}
 
 /**
  * After better-auth completes the GitHub OAuth link, it redirects here.
@@ -32,7 +21,11 @@ export async function GET(req: Request): Promise<Response> {
   }
 
   const requestUrl = new URL(req.url);
-  const next = sanitizeRedirectTo(requestUrl.searchParams.get("next"));
+  const next = sanitizeInternalRedirect(
+    requestUrl.searchParams.get("next"),
+    "/sessions",
+    req.url,
+  );
   const redirectUrl = new URL(next, req.url);
 
   if (isManagedTemplateTrialUser(session, req.url)) {

--- a/apps/web/app/api/sandbox/extend/route.ts
+++ b/apps/web/app/api/sandbox/extend/route.ts
@@ -11,6 +11,8 @@ import {
   getNextLifecycleVersion,
 } from "@/lib/sandbox/lifecycle";
 import { isSandboxActive } from "@/lib/sandbox/utils";
+import { checkBotProtection } from "@/lib/botid";
+import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 
 interface ExtendRequest {
   sessionId: string;
@@ -20,6 +22,20 @@ export async function POST(req: Request) {
   const authResult = await requireAuthenticatedUser();
   if (!authResult.ok) {
     return authResult.response;
+  }
+
+  const botVerification = await checkBotProtection();
+  if (botVerification.isBot) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const limited = checkRateLimit({
+    key: rateLimitKey(["sandbox-extend", authResult.userId]),
+    limit: 3,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
   }
 
   let body: ExtendRequest;
@@ -87,6 +103,10 @@ export async function POST(req: Request) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return Response.json({ error: message }, { status: 500 });
+    console.error("Failed to extend sandbox timeout:", message);
+    return Response.json(
+      { error: "Failed to extend sandbox timeout" },
+      { status: 500 },
+    );
   }
 }

--- a/apps/web/app/api/sandbox/route.test.ts
+++ b/apps/web/app/api/sandbox/route.test.ts
@@ -306,6 +306,7 @@ describe("/api/sandbox lifecycle kicks", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          sessionId: "session-1",
           repoUrl: "https://github.com/acme/private-repo",
           branch: "main",
           sandboxType: "vercel",
@@ -317,6 +318,7 @@ describe("/api/sandbox lifecycle kicks", () => {
     expect(connectConfigs[0]).toMatchObject({
       state: {
         type: "vercel",
+        sandboxName: "session_session-1",
         source: {
           repo: "https://github.com/acme/private-repo",
           branch: "main",

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -35,6 +35,7 @@ import {
   hasResumableSandboxState,
 } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
+import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 // import { buildDevelopmentDotenvFromVercelProject } from "@/lib/vercel/projects";
 // import { getUserVercelToken } from "@/lib/vercel/token";
 
@@ -105,6 +106,10 @@ export async function POST(req: Request) {
 
   const { repoUrl, branch = "main", isNewBranch = false, sessionId } = body;
 
+  if (!sessionId) {
+    return Response.json({ error: "Missing sessionId" }, { status: 400 });
+  }
+
   // Get session for auth
   const session = await getServerSession();
   if (!session?.user) {
@@ -116,21 +121,28 @@ export async function POST(req: Request) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  // Validate session ownership before minting any short-lived setup tokens.
-  let sessionRecord: SessionRecord | undefined;
-  if (sessionId) {
-    const sessionContext = await requireOwnedSession({
-      userId: session.user.id,
-      sessionId,
-    });
-    if (!sessionContext.ok) {
-      return sessionContext.response;
-    }
-
-    sessionRecord = sessionContext.sessionRecord;
+  const limited = checkRateLimit({
+    key: rateLimitKey(["sandbox-create", session.user.id]),
+    limit: 20,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
   }
 
-  const sandboxName = sessionId ? getSessionSandboxName(sessionId) : undefined;
+  // Validate session ownership before minting any short-lived setup tokens.
+  let sessionRecord: SessionRecord | undefined;
+  const sessionContext = await requireOwnedSession({
+    userId: session.user.id,
+    sessionId,
+  });
+  if (!sessionContext.ok) {
+    return sessionContext.response;
+  }
+
+  sessionRecord = sessionContext.sessionRecord;
+
+  const sandboxName = getSessionSandboxName(sessionId);
 
   const source = repoUrl
     ? {
@@ -278,6 +290,20 @@ export async function DELETE(req: Request) {
   const authResult = await requireAuthenticatedUser();
   if (!authResult.ok) {
     return authResult.response;
+  }
+
+  const botVerification = await checkBotProtection();
+  if (botVerification.isBot) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const limited = checkRateLimit({
+    key: rateLimitKey(["sandbox-delete", authResult.userId]),
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
   }
 
   let body: unknown;

--- a/apps/web/app/api/sessions/[sessionId]/checks/fix/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/checks/fix/route.ts
@@ -4,6 +4,7 @@ import {
 } from "@/app/api/sessions/_lib/session-context";
 import type { CheckRun } from "@/lib/github/pulls";
 import { getUserGitHubToken } from "@/lib/github/token";
+import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 import { Octokit } from "@octokit/rest";
 import { gateway, generateText } from "ai";
 
@@ -197,6 +198,15 @@ export async function POST(req: Request, context: RouteContext) {
   });
   if (!sessionContext.ok) {
     return sessionContext.response;
+  }
+
+  const limited = checkRateLimit({
+    key: rateLimitKey(["fix-checks", authResult.userId, sessionId]),
+    limit: 5,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
   }
 
   const { sessionRecord } = sessionContext;

--- a/apps/web/app/api/sessions/[sessionId]/code-editor/route.test.ts
+++ b/apps/web/app/api/sessions/[sessionId]/code-editor/route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const CODE_EDITOR_PID_FILE = "/tmp/open-agents-code-server.pid";
+const CODE_EDITOR_LOCK_DIR = "/tmp/open-agents-code-server.lock";
 const RUNNING_CODE_SERVER_PID = "9001";
 
 const currentSessionRecord = {
@@ -13,6 +14,7 @@ const currentSessionRecord = {
 };
 
 let fileContents = new Map<string, string>();
+let directories = new Set<string>();
 let runningPids = new Set<string>();
 let processListOutput = "";
 let portProbeStatusCode: string | null = null;
@@ -90,6 +92,19 @@ const execMock = mock(async (command: string) => {
     return successResult();
   }
 
+  if (command === `mkdir '${CODE_EDITOR_LOCK_DIR}'`) {
+    if (directories.has(CODE_EDITOR_LOCK_DIR)) {
+      return failureResult("File exists");
+    }
+    directories.add(CODE_EDITOR_LOCK_DIR);
+    return successResult();
+  }
+
+  if (command === `rmdir '${CODE_EDITOR_LOCK_DIR}'`) {
+    directories.delete(CODE_EDITOR_LOCK_DIR);
+    return successResult();
+  }
+
   if (command.includes("curl -s -o /dev/null")) {
     return portProbeStatusCode === null
       ? failureResult("connection refused")
@@ -148,6 +163,7 @@ function createRouteContext(sessionId = "session-1") {
 describe("/api/sessions/[sessionId]/code-editor", () => {
   beforeEach(() => {
     fileContents = new Map<string, string>();
+    directories = new Set<string>();
     runningPids = new Set<string>();
     processListOutput = "";
     portProbeStatusCode = null;

--- a/apps/web/app/api/sessions/[sessionId]/code-editor/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/code-editor/route.ts
@@ -31,6 +31,7 @@ export type CodeEditorStopResponse = {
 };
 
 const CODE_SERVER_PIDFILE = "/tmp/open-agents-code-server.pid";
+const CODE_SERVER_LOCKDIR = "/tmp/open-agents-code-server.lock";
 
 type ConnectedSandbox = Awaited<ReturnType<typeof connectSandbox>>;
 
@@ -202,6 +203,25 @@ async function stopCodeServer(sandbox: ConnectedSandbox): Promise<boolean> {
   return !checkResult.success;
 }
 
+async function acquireCodeServerLaunchLock(
+  sandbox: ConnectedSandbox,
+): Promise<boolean> {
+  const result = await sandbox.exec(
+    `mkdir ${shellQuote(CODE_SERVER_LOCKDIR)}`,
+    "/tmp",
+    5_000,
+  );
+  return result.success;
+}
+
+async function releaseCodeServerLaunchLock(
+  sandbox: ConnectedSandbox,
+): Promise<void> {
+  await sandbox
+    .exec(`rmdir ${shellQuote(CODE_SERVER_LOCKDIR)}`, "/tmp", 5_000)
+    .catch(() => undefined);
+}
+
 export async function GET(_req: Request, context: RouteContext) {
   const authResult = await requireAuthenticatedUser();
   if (!authResult.ok) {
@@ -280,44 +300,56 @@ export async function POST(req: Request, context: RouteContext) {
     const port = CODE_SERVER_PORT;
     const workingDirectory = sandbox.workingDirectory;
 
-    // Reuse an existing code-server process when we can positively identify it.
-    if (await isCodeServerRunning(sandbox)) {
-      return Response.json({
-        url: sandbox.domain(port),
-        port,
-      } satisfies CodeEditorLaunchResponse);
-    }
-
-    if (await isPortInUse(sandbox, port)) {
+    const hasLaunchLock = await acquireCodeServerLaunchLock(sandbox);
+    if (!hasLaunchLock) {
       return Response.json(
-        { error: `Port ${port} is already in use by another process` },
+        { error: "Code editor is already launching" },
         { status: 409 },
       );
     }
 
-    // Launch code-server in detached mode
-    const launchCommand = [
-      `printf '%s' "$$" > ${shellQuote(CODE_SERVER_PIDFILE)}`,
-      `exec code-server --port ${port} --auth none --bind-addr 0.0.0.0:${port} --disable-telemetry ${shellQuote(workingDirectory)}`,
-    ].join(" && ");
-
     try {
-      await sandbox.execDetached(launchCommand, workingDirectory);
-    } catch (error) {
-      await sandbox
-        .exec(
-          `rm -f ${shellQuote(CODE_SERVER_PIDFILE)}`,
-          workingDirectory,
-          5_000,
-        )
-        .catch(() => undefined);
-      throw error;
-    }
+      // Reuse an existing code-server process when we can positively identify it.
+      if (await isCodeServerRunning(sandbox)) {
+        return Response.json({
+          url: sandbox.domain(port),
+          port,
+        } satisfies CodeEditorLaunchResponse);
+      }
 
-    return Response.json({
-      url: sandbox.domain(port),
-      port,
-    } satisfies CodeEditorLaunchResponse);
+      if (await isPortInUse(sandbox, port)) {
+        return Response.json(
+          { error: `Port ${port} is already in use by another process` },
+          { status: 409 },
+        );
+      }
+
+      // Launch code-server in detached mode
+      const launchCommand = [
+        `printf '%s' "$$" > ${shellQuote(CODE_SERVER_PIDFILE)}`,
+        `exec code-server --port ${port} --auth none --bind-addr 0.0.0.0:${port} --disable-telemetry ${shellQuote(workingDirectory)}`,
+      ].join(" && ");
+
+      try {
+        await sandbox.execDetached(launchCommand, workingDirectory);
+      } catch (error) {
+        await sandbox
+          .exec(
+            `rm -f ${shellQuote(CODE_SERVER_PIDFILE)}`,
+            workingDirectory,
+            5_000,
+          )
+          .catch(() => undefined);
+        throw error;
+      }
+
+      return Response.json({
+        url: sandbox.domain(port),
+        port,
+      } satisfies CodeEditorLaunchResponse);
+    } finally {
+      await releaseCodeServerLaunchLock(sandbox);
+    }
   } catch (error) {
     console.error("Failed to launch code editor:", error);
     return Response.json(

--- a/apps/web/app/api/sessions/[sessionId]/generate-commit-message/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/generate-commit-message/route.ts
@@ -2,6 +2,7 @@ import { connectSandbox } from "@open-agents/sandbox";
 import { gateway, generateText } from "ai";
 import { checkBotProtection } from "@/lib/botid";
 import { getSessionById } from "@/lib/db/sessions";
+import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getServerSession } from "@/lib/session/get-server-session";
 
@@ -19,6 +20,15 @@ export async function POST(
   const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const limited = checkRateLimit({
+    key: rateLimitKey(["generate-commit-message", session.user.id]),
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
   }
 
   const { sessionId } = await params;

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import { checkBotProtection } from "@/lib/botid";
 import {
   countSessionsByUserId,
   createSessionWithInitialChat,
@@ -16,6 +17,7 @@ import {
   isValidGitHubRepoName,
   isValidGitHubRepoOwner,
 } from "@/lib/github/urls";
+import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 import { getRandomCityName } from "@/lib/random-city";
 import { getServerSession } from "@/lib/session/get-server-session";
 import {
@@ -176,6 +178,20 @@ export async function POST(req: Request) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
+  const botVerification = await checkBotProtection();
+  if (botVerification.isBot) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const limited = checkRateLimit({
+    key: rateLimitKey(["sessions-create", session.user.id]),
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
+  }
+
   const isTrialUser = isManagedTemplateTrialUser(session, req.url);
   if (isTrialUser) {
     const existingSessionCount = await countSessionsByUserId(session.user.id);
@@ -241,6 +257,44 @@ export async function POST(req: Request) {
     (typeof body.repoName !== "string" || !isValidGitHubRepoName(body.repoName))
   ) {
     return Response.json({ error: "Invalid repository name" }, { status: 400 });
+  }
+
+  if (body.cloneUrl !== undefined) {
+    if (typeof body.cloneUrl !== "string") {
+      return Response.json({ error: "Invalid clone URL" }, { status: 400 });
+    }
+
+    let parsedCloneUrl: URL;
+    try {
+      parsedCloneUrl = new URL(body.cloneUrl);
+    } catch {
+      return Response.json({ error: "Invalid clone URL" }, { status: 400 });
+    }
+
+    if (
+      parsedCloneUrl.protocol !== "https:" ||
+      parsedCloneUrl.hostname.toLowerCase() !== "github.com"
+    ) {
+      return Response.json({ error: "Invalid clone URL" }, { status: 400 });
+    }
+
+    const clonePathParts = parsedCloneUrl.pathname
+      .replace(/^\/+/, "")
+      .split("/");
+    const [cloneOwner, cloneRepoWithSuffix] = clonePathParts;
+    const cloneRepo = cloneRepoWithSuffix?.replace(/\.git$/, "");
+    if (
+      clonePathParts.length !== 2 ||
+      !cloneOwner ||
+      !cloneRepo ||
+      cloneOwner !== body.repoOwner ||
+      cloneRepo !== body.repoName
+    ) {
+      return Response.json(
+        { error: "Clone URL must match repository owner and name" },
+        { status: 400 },
+      );
+    }
   }
 
   let explicitVercelProject: VercelProjectSelection | null | undefined;

--- a/apps/web/app/api/settings/preferences/route.ts
+++ b/apps/web/app/api/settings/preferences/route.ts
@@ -52,6 +52,8 @@ export async function PATCH(req: Request) {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
+  const updates: UpdatePreferencesRequest = {};
+
   if (body.defaultSandboxType !== undefined) {
     const validTypes = ["vercel"];
     if (
@@ -60,6 +62,7 @@ export async function PATCH(req: Request) {
     ) {
       return Response.json({ error: "Invalid sandbox type" }, { status: 400 });
     }
+    updates.defaultSandboxType = body.defaultSandboxType;
   }
 
   if (body.defaultDiffMode !== undefined) {
@@ -70,6 +73,30 @@ export async function PATCH(req: Request) {
     ) {
       return Response.json({ error: "Invalid diff mode" }, { status: 400 });
     }
+    updates.defaultDiffMode = body.defaultDiffMode;
+  }
+
+  if (body.defaultModelId !== undefined) {
+    if (typeof body.defaultModelId !== "string") {
+      return Response.json(
+        { error: "Invalid defaultModelId" },
+        { status: 400 },
+      );
+    }
+    updates.defaultModelId = body.defaultModelId;
+  }
+
+  if (body.defaultSubagentModelId !== undefined) {
+    if (
+      body.defaultSubagentModelId !== null &&
+      typeof body.defaultSubagentModelId !== "string"
+    ) {
+      return Response.json(
+        { error: "Invalid defaultSubagentModelId" },
+        { status: 400 },
+      );
+    }
+    updates.defaultSubagentModelId = body.defaultSubagentModelId;
   }
 
   if (
@@ -81,6 +108,9 @@ export async function PATCH(req: Request) {
       { status: 400 },
     );
   }
+  if (body.autoCommitPush !== undefined) {
+    updates.autoCommitPush = body.autoCommitPush;
+  }
 
   if (
     body.autoCreatePr !== undefined &&
@@ -90,6 +120,9 @@ export async function PATCH(req: Request) {
       { error: "Invalid autoCreatePr value" },
       { status: 400 },
     );
+  }
+  if (body.autoCreatePr !== undefined) {
+    updates.autoCreatePr = body.autoCreatePr;
   }
 
   if (
@@ -101,6 +134,9 @@ export async function PATCH(req: Request) {
       { status: 400 },
     );
   }
+  if (body.alertsEnabled !== undefined) {
+    updates.alertsEnabled = body.alertsEnabled;
+  }
 
   if (
     body.alertSoundEnabled !== undefined &&
@@ -111,6 +147,9 @@ export async function PATCH(req: Request) {
       { status: 400 },
     );
   }
+  if (body.alertSoundEnabled !== undefined) {
+    updates.alertSoundEnabled = body.alertSoundEnabled;
+  }
 
   if (
     body.publicUsageEnabled !== undefined &&
@@ -120,6 +159,9 @@ export async function PATCH(req: Request) {
       { error: "Invalid publicUsageEnabled value" },
       { status: 400 },
     );
+  }
+  if (body.publicUsageEnabled !== undefined) {
+    updates.publicUsageEnabled = body.publicUsageEnabled;
   }
 
   if (body.globalSkillRefs !== undefined) {
@@ -132,8 +174,7 @@ export async function PATCH(req: Request) {
         { status: 400 },
       );
     }
-
-    body.globalSkillRefs = parsedGlobalSkillRefs.data;
+    updates.globalSkillRefs = parsedGlobalSkillRefs.data;
   }
 
   if (body.enabledModelIds !== undefined) {
@@ -146,11 +187,12 @@ export async function PATCH(req: Request) {
         { status: 400 },
       );
     }
+    updates.enabledModelIds = body.enabledModelIds;
   }
 
   try {
     const preferences = sanitizeUserPreferencesForSession(
-      await updateUserPreferences(session.user.id, body),
+      await updateUserPreferences(session.user.id, updates),
       session,
       req.url,
     );

--- a/apps/web/app/api/transcribe/route.ts
+++ b/apps/web/app/api/transcribe/route.ts
@@ -1,6 +1,7 @@
 import { checkBotProtection } from "@/lib/botid";
 import { experimental_transcribe as transcribe } from "ai";
 import { elevenlabs } from "@ai-sdk/elevenlabs";
+import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 import { getServerSession } from "@/lib/session/get-server-session";
 
 interface TranscribeRequestBody {
@@ -17,6 +18,15 @@ export async function POST(req: Request) {
   const botVerification = await checkBotProtection();
   if (botVerification.isBot) {
     return Response.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const limited = checkRateLimit({
+    key: rateLimitKey(["transcribe", session.user.id]),
+    limit: 5,
+    windowMs: 60_000,
+  });
+  if (limited) {
+    return limited;
   }
 
   let body: TranscribeRequestBody;
@@ -66,9 +76,6 @@ export async function POST(req: Request) {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Transcription failed:", message);
-    return Response.json(
-      { error: "Transcription failed", details: message },
-      { status: 500 },
-    );
+    return Response.json({ error: "Transcription failed" }, { status: 500 });
   }
 }

--- a/apps/web/app/get-started/get-started-flow.tsx
+++ b/apps/web/app/get-started/get-started-flow.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useSession } from "@/hooks/use-session";
 import { authClient } from "@/lib/auth/client";
+import { sanitizeInternalRedirect } from "@/lib/redirect-safety";
 
 type StepId = 1 | 2;
 
@@ -37,18 +38,6 @@ function OpenAgentsLogo({ className }: { className?: string }) {
   );
 }
 
-function sanitizeRedirectPath(rawPath: string | null): string {
-  if (!rawPath) {
-    return "/sessions";
-  }
-
-  if (!rawPath.startsWith("/") || rawPath.startsWith("//")) {
-    return "/sessions";
-  }
-
-  return rawPath;
-}
-
 export function GetStartedFlow() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -60,7 +49,10 @@ export function GetStartedFlow() {
   } = useSession();
   const isTrialUser = session?.isManagedTemplateTrialUser ?? false;
   const isGitHubReconnect = searchParams.get("step") === "github";
-  const redirectPath = sanitizeRedirectPath(searchParams.get("next"));
+  const redirectPath = sanitizeInternalRedirect(
+    searchParams.get("next"),
+    "/sessions",
+  );
   const [activeStep, setActiveStep] = useState<StepId>(
     isGitHubReconnect ? 2 : 1,
   );

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/sandbox-create-error-banner.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/sandbox-create-error-banner.tsx
@@ -1,18 +1,14 @@
 import { X } from "lucide-react";
 import Link from "next/link";
 import type { SandboxCreateErrorDetails } from "./sandbox-create";
+import { isSafeHttpUrl, sanitizeInternalRedirect } from "@/lib/redirect-safety";
 
 function isSafeActionUrl(url: string): boolean {
-  if (url.startsWith("/")) {
+  if (sanitizeInternalRedirect(url, "") === url) {
     return true;
   }
 
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "https:" || parsed.protocol === "http:";
-  } catch {
-    return false;
-  }
+  return isSafeHttpUrl(url);
 }
 
 export function SandboxCreateErrorBanner({

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -124,7 +124,7 @@ const convertMessages = async (
           const { filename, content } = part.data;
           return {
             type: "text",
-            text: `<snippet filename="${filename}">\n${content}\n</snippet>`,
+            text: JSON.stringify({ type: "snippet", filename, content }),
           };
         }
         return undefined;

--- a/apps/web/lib/admin/actions.ts
+++ b/apps/web/lib/admin/actions.ts
@@ -67,7 +67,7 @@ async function revokeVercelToken(token: string): Promise<boolean> {
   if (!clientId || !clientSecret) return false;
 
   try {
-    await fetch(VERCEL_REVOKE_URL, {
+    const res = await fetch(VERCEL_REVOKE_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -76,7 +76,7 @@ async function revokeVercelToken(token: string): Promise<boolean> {
         client_secret: clientSecret,
       }),
     });
-    return true;
+    return res.ok;
   } catch (err) {
     console.error("Vercel token revocation failed:", err);
     return false;
@@ -189,17 +189,18 @@ export async function revokeAllVercelTokens(): Promise<{
     let revokedTokens = 0;
     const revokeResults = await Promise.allSettled(
       vercelAccounts.map(async (acct) => {
-        try {
-          const result = await auth.api.getAccessToken({
-            body: { providerId: "vercel", userId: acct.userId },
-          });
-          if (result?.accessToken) {
-            const ok = await revokeVercelToken(result.accessToken);
-            if (ok) revokedTokens++;
+        const result = await auth.api.getAccessToken({
+          body: { providerId: "vercel", userId: acct.userId },
+        });
+        if (result?.accessToken) {
+          const ok = await revokeVercelToken(result.accessToken);
+          if (ok) {
+            revokedTokens++;
+            return;
           }
-        } catch {
-          // Token may already be expired/invalid — that's fine
         }
+
+        throw new Error("Token revocation failed");
       }),
     );
 

--- a/apps/web/lib/auth/actions.ts
+++ b/apps/web/lib/auth/actions.ts
@@ -24,15 +24,23 @@ async function revokeVercelToken(params: {
   });
 }
 
+async function getRevocableVercelToken(userId: string): Promise<string | null> {
+  try {
+    return await getUserVercelToken(userId);
+  } catch {
+    return null;
+  }
+}
+
 export async function signOut(): Promise<void> {
   const session = await getServerSession();
 
-  if (session?.user?.id && session.authProvider === "vercel") {
+  if (session?.user?.id) {
     try {
       const clientId = process.env.NEXT_PUBLIC_VERCEL_APP_CLIENT_ID;
       const clientSecret = process.env.VERCEL_APP_CLIENT_SECRET;
       if (clientId && clientSecret) {
-        const token = await getUserVercelToken(session.user.id);
+        const token = await getRevocableVercelToken(session.user.id);
         if (token) {
           await revokeVercelToken({ token, clientId, clientSecret });
         }

--- a/apps/web/lib/db/sessions.ts
+++ b/apps/web/lib/db/sessions.ts
@@ -704,6 +704,15 @@ export async function getChatMessageById(messageId: string) {
   });
 }
 
+export async function getChatMessageByIdForChat(
+  messageId: string,
+  chatId: string,
+) {
+  return db.query.chatMessages.findFirst({
+    where: and(eq(chatMessages.id, messageId), eq(chatMessages.chatId, chatId)),
+  });
+}
+
 export async function getChatMessages(chatId: string) {
   return db.query.chatMessages.findMany({
     where: eq(chatMessages.chatId, chatId),

--- a/apps/web/lib/github/pulls.ts
+++ b/apps/web/lib/github/pulls.ts
@@ -238,6 +238,21 @@ function extractVercelDeploymentUrl(commentBody: string): string | null {
   return extractVercelDeploymentUrlFromMetadata(commentBody);
 }
 
+function isTrustedVercelCommentAuthor(comment: {
+  author_association?: string | null;
+  user?: { login?: string | null; type?: string | null } | null;
+}): boolean {
+  const association = comment.author_association;
+  const login = comment.user?.login?.toLowerCase() ?? "";
+
+  return (
+    association === "OWNER" ||
+    association === "MEMBER" ||
+    login === "vercel[bot]" ||
+    login.endsWith("[bot]")
+  );
+}
+
 const SUCCESSFUL_CHECK_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
 
 const FAILED_CHECK_CONCLUSIONS = new Set([
@@ -1358,6 +1373,10 @@ export async function findDeploymentUrl(params: {
     for (let i = response.data.length - 1; i >= 0; i--) {
       const comment = response.data[i];
       if (!comment.body) {
+        continue;
+      }
+
+      if (!isTrustedVercelCommentAuthor(comment)) {
         continue;
       }
 

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -1,0 +1,47 @@
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+type RateLimitOptions = {
+  key: string;
+  limit: number;
+  windowMs: number;
+};
+
+const buckets = new Map<string, RateLimitBucket>();
+
+export function checkRateLimit(options: RateLimitOptions): Response | null {
+  const now = Date.now();
+  const existing = buckets.get(options.key);
+
+  if (!existing || existing.resetAt <= now) {
+    buckets.set(options.key, {
+      count: 1,
+      resetAt: now + options.windowMs,
+    });
+    return null;
+  }
+
+  if (existing.count >= options.limit) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((existing.resetAt - now) / 1000),
+    );
+
+    return Response.json(
+      { error: "Too many requests" },
+      {
+        status: 429,
+        headers: { "Retry-After": String(retryAfterSeconds) },
+      },
+    );
+  }
+
+  existing.count += 1;
+  return null;
+}
+
+export function rateLimitKey(parts: (number | string | null | undefined)[]) {
+  return parts.map((part) => String(part ?? "unknown")).join(":");
+}

--- a/apps/web/lib/redirect-safety.ts
+++ b/apps/web/lib/redirect-safety.ts
@@ -1,0 +1,44 @@
+const FALLBACK_BASE_URL = "https://open-agents.invalid";
+
+export function sanitizeInternalRedirect(
+  rawRedirectTo: string | null | undefined,
+  fallbackPath: string,
+  baseUrl = FALLBACK_BASE_URL,
+): string {
+  if (!rawRedirectTo || rawRedirectTo.includes("\\")) {
+    return fallbackPath;
+  }
+
+  let base: URL;
+  try {
+    base = new URL(baseUrl);
+  } catch {
+    base = new URL(FALLBACK_BASE_URL);
+  }
+
+  let candidate: URL;
+  try {
+    candidate = new URL(rawRedirectTo, base);
+  } catch {
+    return fallbackPath;
+  }
+
+  if (candidate.origin !== base.origin) {
+    return fallbackPath;
+  }
+
+  return `${candidate.pathname}${candidate.search}${candidate.hash}`;
+}
+
+export function isSafeHttpUrl(rawUrl: string): boolean {
+  if (rawUrl.includes("\\")) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}

--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -29,7 +29,18 @@ interface ToolOptions {
 }
 
 // Commands that should require approval
-const DANGEROUS_COMMAND_PATTERNS = [/\brm\s+-rf\b/];
+const DANGEROUS_COMMAND_PATTERNS = [
+  /\brm\s+(?:-[A-Za-z]*r[A-Za-z]*f|-{1,2}recursive\b.*-{1,2}force\b|-{1,2}force\b.*-{1,2}recursive\b)/,
+  /\b(?:shred|mkfs|dd)\b/,
+  /:\(\)\s*\{\s*:\|:/,
+];
+
+const SENSITIVE_FILE_PATTERNS = [
+  /\.\s*env/i,
+  /\$\([^)]*env[^)]*\)/i,
+  /`[^`]*env[^`]*`/i,
+  /\b(?:aws\/credentials|id_rsa|id_ed25519|\.ssh|proc\/self\/environ)\b/i,
+];
 
 /**
  * Check if a command should require approval.
@@ -45,7 +56,7 @@ export function commandNeedsApproval(command: string): boolean {
     }
   }
 
-  return lowerCommand.includes(".env");
+  return SENSITIVE_FILE_PATTERNS.some((pattern) => pattern.test(lowerCommand));
 }
 
 export const bashTool = (options?: ToolOptions) =>

--- a/packages/agent/tools/fetch.ts
+++ b/packages/agent/tools/fetch.ts
@@ -4,17 +4,171 @@ import { getSandbox, shellEscape } from "./utils";
 
 const TIMEOUT_MS = 30_000;
 export const MAX_BODY_LENGTH = 10_000;
-const PRIVATE_HOST_PATTERNS = [
-  /^localhost$/i,
-  /^127\./,
-  /^10\./,
-  /^192\.168\./,
-  /^172\.(1[6-9]|2\d|3[0-1])\./,
-  /^169\.254\./,
-  /^\[?::1\]?$/,
+
+type Ipv4Address = [number, number, number, number];
+type Ipv6Address = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
 ];
 
-function isAllowedWebUrl(value: string): boolean {
+function normalizeHostname(hostname: string): string {
+  const lowerHostname = hostname.toLowerCase();
+
+  if (lowerHostname.startsWith("[") && lowerHostname.endsWith("]")) {
+    return lowerHostname.slice(1, -1);
+  }
+
+  return lowerHostname;
+}
+
+function parseIpv4Address(hostname: string): Ipv4Address | null {
+  const octets = hostname.split(".");
+
+  if (octets.length !== 4) {
+    return null;
+  }
+
+  const parsed: number[] = [];
+
+  for (const octet of octets) {
+    if (!/^\d+$/.test(octet)) {
+      return null;
+    }
+
+    const value = Number(octet);
+    if (value < 0 || value > 255) {
+      return null;
+    }
+
+    parsed.push(value);
+  }
+
+  return [parsed[0] ?? 0, parsed[1] ?? 0, parsed[2] ?? 0, parsed[3] ?? 0];
+}
+
+function parseIpv6Address(hostname: string): Ipv6Address | null {
+  const [head = "", tail = "", ...extra] = hostname.split("::");
+
+  if (extra.length > 0) {
+    return null;
+  }
+
+  const headParts = head ? head.split(":") : [];
+  const tailParts = tail ? tail.split(":") : [];
+  const missingParts = hostname.includes("::")
+    ? 8 - headParts.length - tailParts.length
+    : 0;
+
+  if (missingParts < 0) {
+    return null;
+  }
+
+  const parts = [
+    ...headParts,
+    ...Array.from({ length: missingParts }, () => "0"),
+    ...tailParts,
+  ];
+
+  if (parts.length !== 8) {
+    return null;
+  }
+
+  const parsed: number[] = [];
+
+  for (const part of parts) {
+    if (!/^[\da-f]{1,4}$/i.test(part)) {
+      return null;
+    }
+
+    parsed.push(Number.parseInt(part, 16));
+  }
+
+  return [
+    parsed[0] ?? 0,
+    parsed[1] ?? 0,
+    parsed[2] ?? 0,
+    parsed[3] ?? 0,
+    parsed[4] ?? 0,
+    parsed[5] ?? 0,
+    parsed[6] ?? 0,
+    parsed[7] ?? 0,
+  ];
+}
+
+function isPrivateIpv4Address(hostname: string): boolean {
+  const octets = parseIpv4Address(hostname);
+
+  if (!octets) {
+    return false;
+  }
+
+  const [first, second] = octets;
+
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+function getIpv4MappedIpv6Address(groups: Ipv6Address): string | null {
+  const isMappedIpv4 =
+    groups.slice(0, 5).every((group) => group === 0) && groups[5] === 0xffff;
+
+  if (!isMappedIpv4) {
+    return null;
+  }
+
+  return [
+    groups[6] >> 8,
+    groups[6] & 0xff,
+    groups[7] >> 8,
+    groups[7] & 0xff,
+  ].join(".");
+}
+
+function isPrivateIpv6Address(hostname: string): boolean {
+  const groups = parseIpv6Address(hostname);
+
+  if (!groups) {
+    return false;
+  }
+
+  const ipv4MappedAddress = getIpv4MappedIpv6Address(groups);
+
+  if (ipv4MappedAddress) {
+    return isPrivateIpv4Address(ipv4MappedAddress);
+  }
+
+  const isUnspecified = groups.every((group) => group === 0);
+  const isLoopback =
+    groups.slice(0, 7).every((group) => group === 0) && groups[7] === 1;
+  const isUniqueLocal = (groups[0] & 0xfe00) === 0xfc00;
+  const isLinkLocal = (groups[0] & 0xffc0) === 0xfe80;
+
+  return isUnspecified || isLoopback || isUniqueLocal || isLinkLocal;
+}
+
+function isPrivateHost(hostname: string): boolean {
+  const normalizedHostname = normalizeHostname(hostname);
+
+  return (
+    normalizedHostname === "localhost" ||
+    isPrivateIpv4Address(normalizedHostname) ||
+    isPrivateIpv6Address(normalizedHostname)
+  );
+}
+
+export function isAllowedWebUrl(value: string): boolean {
   let parsed: URL;
   try {
     parsed = new URL(value);
@@ -26,8 +180,7 @@ function isAllowedWebUrl(value: string): boolean {
     return false;
   }
 
-  const hostname = parsed.hostname.toLowerCase();
-  return !PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(hostname));
+  return !isPrivateHost(parsed.hostname);
 }
 
 const fetchInputSchema = z.object({

--- a/packages/agent/tools/fetch.ts
+++ b/packages/agent/tools/fetch.ts
@@ -4,9 +4,38 @@ import { getSandbox, shellEscape } from "./utils";
 
 const TIMEOUT_MS = 30_000;
 export const MAX_BODY_LENGTH = 10_000;
+const PRIVATE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[0-1])\./,
+  /^169\.254\./,
+  /^\[?::1\]?$/,
+];
+
+function isAllowedWebUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  return !PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(hostname));
+}
 
 const fetchInputSchema = z.object({
-  url: z.string().url().describe("The URL to fetch"),
+  url: z
+    .string()
+    .url({ protocol: /^https?$/ })
+    .refine(isAllowedWebUrl, "URL must use http(s) and a public host")
+    .describe("The URL to fetch"),
   method: z
     .enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
     .optional()
@@ -58,6 +87,10 @@ EXAMPLES:
     const args: string[] = [
       "curl",
       "-sS",
+      "--proto",
+      shellEscape("=http,https"),
+      "--proto-redir",
+      shellEscape("=http,https"),
       "-X",
       method,
       "--max-time",

--- a/packages/agent/tools/path-security.ts
+++ b/packages/agent/tools/path-security.ts
@@ -1,0 +1,60 @@
+import * as path from "path";
+import type { Sandbox } from "@open-agents/sandbox";
+import { isPathWithinDirectory, shellEscape } from "./utils";
+
+export function isDotEnvFilePath(filePath: string): boolean {
+  const basename = path.basename(filePath.replaceAll("\\", "/")).toLowerCase();
+  return basename.startsWith(".env");
+}
+
+export function resolveWorkspacePath(
+  filePath: string,
+  workingDirectory: string,
+): string | null {
+  const absolutePath = path.isAbsolute(filePath)
+    ? path.resolve(filePath)
+    : path.resolve(workingDirectory, filePath);
+
+  return isPathWithinDirectory(absolutePath, workingDirectory)
+    ? absolutePath
+    : null;
+}
+
+export async function resolveSandboxRealPath(params: {
+  sandbox: Sandbox;
+  absolutePath: string;
+  workingDirectory: string;
+}): Promise<string | null> {
+  if (typeof params.sandbox.exec !== "function") {
+    return null;
+  }
+
+  const result = await params.sandbox.exec(
+    `realpath -- ${shellEscape(params.absolutePath)}`,
+    params.workingDirectory,
+    5000,
+  );
+
+  if (!result.success) {
+    return null;
+  }
+
+  const realPath = result.stdout.trim();
+  if (!realPath) {
+    return null;
+  }
+
+  return realPath;
+}
+
+export function isSensitiveDotEnvPath(params: {
+  requestedPath: string;
+  absolutePath: string;
+  realPath?: string | null;
+}): boolean {
+  return (
+    isDotEnvFilePath(params.requestedPath) ||
+    isDotEnvFilePath(params.absolutePath) ||
+    (params.realPath ? isDotEnvFilePath(params.realPath) : false)
+  );
+}

--- a/packages/agent/tools/read.ts
+++ b/packages/agent/tools/read.ts
@@ -1,13 +1,12 @@
 import { tool } from "ai";
 import { z } from "zod";
-import * as path from "path";
-import * as fs from "fs";
 import { getSandbox, toDisplayPath } from "./utils";
-
-function isDotEnvFilePath(filePath: string): boolean {
-  const basename = path.basename(filePath.replaceAll("\\", "/")).toLowerCase();
-  return basename.startsWith(".env");
-}
+import {
+  isDotEnvFilePath,
+  isSensitiveDotEnvPath,
+  resolveSandboxRealPath,
+  resolveWorkspacePath,
+} from "./path-security";
 
 const readInputSchema = z.object({
   filePath: z
@@ -25,41 +24,37 @@ const readInputSchema = z.object({
     .describe("Maximum number of lines to read. Default: 2000"),
 });
 
-/**
- * Resolve file path with fallback for root-like paths.
- * If a path like "/README.md" doesn't exist, try resolving it relative to workingDirectory.
- */
-function resolveFilePath(filePath: string, workingDirectory: string): string {
-  let absolutePath = path.isAbsolute(filePath)
-    ? filePath
-    : path.resolve(workingDirectory, filePath);
-
-  // If path doesn't exist and looks like a root-relative path (e.g., /README.md),
-  // try resolving it relative to the working directory
-  try {
-    fs.accessSync(absolutePath);
-  } catch {
-    if (
-      filePath.startsWith("/") &&
-      !filePath.startsWith("/Users/") &&
-      !filePath.startsWith("/home/")
-    ) {
-      const workspaceRelativePath = path.join(workingDirectory, filePath);
-      try {
-        fs.accessSync(workspaceRelativePath);
-        absolutePath = workspaceRelativePath;
-      } catch {
-        // Neither path exists - return original
-      }
-    }
-  }
-
-  return absolutePath;
-}
-
 export const readFileTool = () =>
   tool({
-    needsApproval: ({ filePath }) => isDotEnvFilePath(filePath),
+    needsApproval: async ({ filePath }, { experimental_context }) => {
+      if (isDotEnvFilePath(filePath)) {
+        return true;
+      }
+
+      let sandbox;
+      try {
+        sandbox = await getSandbox(experimental_context, "read");
+      } catch {
+        return false;
+      }
+      const workingDirectory = sandbox.workingDirectory;
+      const absolutePath = resolveWorkspacePath(filePath, workingDirectory);
+      if (!absolutePath) {
+        return false;
+      }
+
+      const realPath = await resolveSandboxRealPath({
+        sandbox,
+        absolutePath,
+        workingDirectory,
+      });
+
+      return isSensitiveDotEnvPath({
+        requestedPath: filePath,
+        absolutePath,
+        realPath,
+      });
+    },
     description: `Read a file from the filesystem.
 
 USAGE:
@@ -86,7 +81,25 @@ EXAMPLES:
       const workingDirectory = sandbox.workingDirectory;
 
       try {
-        const absolutePath = resolveFilePath(filePath, workingDirectory);
+        const absolutePath = resolveWorkspacePath(filePath, workingDirectory);
+        if (!absolutePath) {
+          return {
+            success: false,
+            error: "Path must stay within the workspace.",
+          };
+        }
+
+        const realPath = await resolveSandboxRealPath({
+          sandbox,
+          absolutePath,
+          workingDirectory,
+        });
+        if (realPath && !resolveWorkspacePath(realPath, workingDirectory)) {
+          return {
+            success: false,
+            error: "Path resolves outside the workspace.",
+          };
+        }
 
         const stats = await sandbox.stat(absolutePath);
         if (stats.isDirectory()) {

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -66,7 +66,8 @@ mock.module("@open-agents/sandbox", () => ({
 
 const { askUserQuestionTool } = await import("./ask-user-question");
 const { bashTool, commandNeedsApproval } = await import("./bash");
-const { MAX_BODY_LENGTH, webFetchTool } = await import("./fetch");
+const { MAX_BODY_LENGTH, isAllowedWebUrl, webFetchTool } =
+  await import("./fetch");
 const { globTool } = await import("./glob");
 const { grepTool } = await import("./grep");
 const { readFileTool } = await import("./read");
@@ -502,6 +503,43 @@ describe("tools execute behavior", () => {
         ? (result.body as string)
         : "";
     expect(body.length).toBe(MAX_BODY_LENGTH);
+  });
+
+  test("webFetchTool rejects private and internal URL hosts", () => {
+    const blockedUrls = [
+      "http://localhost",
+      "http://127.0.0.1",
+      "http://10.0.0.1",
+      "http://172.16.0.1",
+      "http://192.168.0.1",
+      "http://169.254.169.254",
+      "http://0.0.0.0",
+      "http://[::]",
+      "http://[::1]",
+      "http://[fc00::1]",
+      "http://[fe80::1]",
+      "http://[::ffff:127.0.0.1]",
+      "http://[::ffff:0a00:0001]",
+      "http://[::ffff:c0a8:0001]",
+      "http://[::ffff:ac10:0001]",
+    ];
+
+    for (const url of blockedUrls) {
+      expect(isAllowedWebUrl(url)).toBe(false);
+    }
+  });
+
+  test("webFetchTool allows public http and https URL hosts", () => {
+    const allowedUrls = [
+      "https://example.com",
+      "http://93.184.216.34",
+      "https://[2606:2800:220:1:248:1893:25c8:1946]",
+      "https://[::ffff:5db8:d822]",
+    ];
+
+    for (const url of allowedUrls) {
+      expect(isAllowedWebUrl(url)).toBe(true);
+    }
   });
 
   test("askUserQuestionTool formats structured answers", () => {

--- a/packages/agent/tools/utils.ts
+++ b/packages/agent/tools/utils.ts
@@ -24,8 +24,10 @@ export function isPathWithinDirectory(
   filePath: string,
   directory: string,
 ): boolean {
-  const resolvedPath = path.resolve(filePath);
   const resolvedDir = path.resolve(directory);
+  const resolvedPath = path.isAbsolute(filePath)
+    ? path.resolve(filePath)
+    : path.resolve(resolvedDir, filePath);
   return (
     resolvedPath.startsWith(resolvedDir + path.sep) ||
     resolvedPath === resolvedDir

--- a/packages/agent/tools/write.ts
+++ b/packages/agent/tools/write.ts
@@ -2,6 +2,12 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as path from "path";
 import { getSandbox, toDisplayPath } from "./utils";
+import {
+  isDotEnvFilePath,
+  isSensitiveDotEnvPath,
+  resolveSandboxRealPath,
+  resolveWorkspacePath,
+} from "./path-security";
 
 const writeInputSchema = z.object({
   filePath: z
@@ -34,6 +40,35 @@ const editInputSchema = z.object({
 
 export const writeFileTool = () =>
   tool({
+    needsApproval: async ({ filePath }, { experimental_context }) => {
+      if (isDotEnvFilePath(filePath)) {
+        return true;
+      }
+
+      let sandbox;
+      try {
+        sandbox = await getSandbox(experimental_context, "write");
+      } catch {
+        return false;
+      }
+      const workingDirectory = sandbox.workingDirectory;
+      const absolutePath = resolveWorkspacePath(filePath, workingDirectory);
+      if (!absolutePath) {
+        return false;
+      }
+
+      const realPath = await resolveSandboxRealPath({
+        sandbox,
+        absolutePath,
+        workingDirectory,
+      });
+
+      return isSensitiveDotEnvPath({
+        requestedPath: filePath,
+        absolutePath,
+        realPath,
+      });
+    },
     description: `Write content to a file on the filesystem.
 
 WHEN TO USE:
@@ -66,9 +101,25 @@ EXAMPLES:
       const workingDirectory = sandbox.workingDirectory;
 
       try {
-        const absolutePath = path.isAbsolute(filePath)
-          ? filePath
-          : path.resolve(workingDirectory, filePath);
+        const absolutePath = resolveWorkspacePath(filePath, workingDirectory);
+        if (!absolutePath) {
+          return {
+            success: false,
+            error: "Path must stay within the workspace.",
+          };
+        }
+
+        const realPath = await resolveSandboxRealPath({
+          sandbox,
+          absolutePath,
+          workingDirectory,
+        });
+        if (realPath && !resolveWorkspacePath(realPath, workingDirectory)) {
+          return {
+            success: false,
+            error: "Path resolves outside the workspace.",
+          };
+        }
 
         const dir = path.dirname(absolutePath);
         await sandbox.mkdir(dir, { recursive: true });
@@ -93,6 +144,35 @@ EXAMPLES:
 
 export const editFileTool = () =>
   tool({
+    needsApproval: async ({ filePath }, { experimental_context }) => {
+      if (isDotEnvFilePath(filePath)) {
+        return true;
+      }
+
+      let sandbox;
+      try {
+        sandbox = await getSandbox(experimental_context, "edit");
+      } catch {
+        return false;
+      }
+      const workingDirectory = sandbox.workingDirectory;
+      const absolutePath = resolveWorkspacePath(filePath, workingDirectory);
+      if (!absolutePath) {
+        return false;
+      }
+
+      const realPath = await resolveSandboxRealPath({
+        sandbox,
+        absolutePath,
+        workingDirectory,
+      });
+
+      return isSensitiveDotEnvPath({
+        requestedPath: filePath,
+        absolutePath,
+        realPath,
+      });
+    },
     description: `Perform exact string replacement in a file.
 
 WHEN TO USE:
@@ -137,9 +217,25 @@ EXAMPLES:
           };
         }
 
-        const absolutePath = path.isAbsolute(filePath)
-          ? filePath
-          : path.resolve(workingDirectory, filePath);
+        const absolutePath = resolveWorkspacePath(filePath, workingDirectory);
+        if (!absolutePath) {
+          return {
+            success: false,
+            error: "Path must stay within the workspace.",
+          };
+        }
+
+        const realPath = await resolveSandboxRealPath({
+          sandbox,
+          absolutePath,
+          workingDirectory,
+        });
+        if (realPath && !resolveWorkspacePath(realPath, workingDirectory)) {
+          return {
+            success: false,
+            error: "Path resolves outside the workspace.",
+          };
+        }
 
         const content = await sandbox.readFile(absolutePath, "utf-8");
 


### PR DESCRIPTION
## Summary

  Fixes the DeepSec report findings across agent tools and web API routes.

  ## Changes

  - Harden agent tools against local file reads through `webFetch`, workspace path
  traversal, symlinked `.env` access, unsafe `.env` writes, and weak bash approval
  detection.
  - Fix hosted demo bypasses for repository-backed sessions and trial message
  limits.
  - Add shared redirect sanitization for GitHub OAuth/App flows and related client
  redirect paths.
  - Add lightweight per-user rate limiting and bot checks to expensive endpoints.
  - Require session ownership for sandbox creation and remove the orphan ephemeral
  sandbox path.
  - Mask internal error details in client responses.
  - Fix code-editor launch races with a sandbox lock.
  - Fix preference mass assignment, Vercel token revocation reporting, prompt
  snippet escaping, and trusted deployment URL extraction.
  - Add/update tests for trial message replay, sandbox creation, and code-editor
  launch locking.

  ## Validation

  - `bun run ci`