### PR TITLE
Harden DeepSec follow-up findings

### DIFF
--- a/apps/web/app/api/generate-pr/route.ts
+++ b/apps/web/app/api/generate-pr/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["generate-pr", session.user.id]),
     limit: 5,
     windowMs: 60_000,

--- a/apps/web/app/api/generate-title/route.ts
+++ b/apps/web/app/api/generate-title/route.ts
@@ -51,7 +51,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["generate-title", session.user.id]),
     limit: 10,
     windowMs: 60_000,

--- a/apps/web/app/api/sandbox/extend/route.ts
+++ b/apps/web/app/api/sandbox/extend/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["sandbox-extend", authResult.userId]),
     limit: 3,
     windowMs: 60_000,

--- a/apps/web/app/api/sandbox/route.test.ts
+++ b/apps/web/app/api/sandbox/route.test.ts
@@ -84,9 +84,18 @@ mock.module("@/lib/github/users", () => ({
   }),
 }));
 
-mock.module("@/lib/github/client", () => ({
-  parseGitHubUrl: (repoUrl: string) => {
-    const match = repoUrl.match(/github\.com\/([^/]+)\/([^/]+?)(\.git)?$/);
+mock.module("@/lib/github/urls", () => ({
+  parseGitHubHttpsUrl: (repoUrl: string) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(repoUrl);
+    } catch {
+      return null;
+    }
+    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
+      return null;
+    }
+    const match = parsed.pathname.match(/^\/([^/]+)\/([^/]+?)(\.git)?$/);
     if (!match?.[1] || !match[2]) {
       return null;
     }
@@ -329,6 +338,28 @@ describe("/api/sandbox lifecycle kicks", () => {
       },
     });
     expect(connectConfigs[0]?.state.source).not.toHaveProperty("token");
+  });
+
+  test("rejects repo URLs that only contain github.com in the path", async () => {
+    const { POST } = await routeModulePromise;
+
+    const response = await POST(
+      new Request("http://localhost/api/sandbox", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: "session-1",
+          repoUrl: "https://attacker.example/github.com/acme/private-repo",
+          branch: "main",
+          sandboxType: "vercel",
+        }),
+      }),
+    );
+
+    const payload = (await response.json()) as { error: string };
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("Invalid GitHub repository URL");
+    expect(connectConfigs).toHaveLength(0);
   });
 
   test("new vercel sandbox does not sync linked Development env vars while code is commented out", async () => {

--- a/apps/web/app/api/sandbox/route.ts
+++ b/apps/web/app/api/sandbox/route.ts
@@ -7,7 +7,7 @@ import {
 import { checkBotProtection } from "@/lib/botid";
 import { getGitHubUserProfile } from "@/lib/github/users";
 import { updateSession } from "@/lib/db/sessions";
-import { parseGitHubUrl } from "@/lib/github/client";
+import { parseGitHubHttpsUrl } from "@/lib/github/urls";
 import {
   verifyRepoAccess,
   getRepoAccessErrorMessage,
@@ -121,7 +121,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["sandbox-create", session.user.id]),
     limit: 20,
     windowMs: 60_000,
@@ -157,7 +157,7 @@ export async function POST(req: Request) {
   let setupToken: ScopedInstallationToken | undefined;
 
   if (repoUrl) {
-    const parsedRepo = parseGitHubUrl(repoUrl);
+    const parsedRepo = parseGitHubHttpsUrl(repoUrl);
     if (!parsedRepo) {
       return Response.json(
         { error: "Invalid GitHub repository URL" },
@@ -297,7 +297,7 @@ export async function DELETE(req: Request) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["sandbox-delete", authResult.userId]),
     limit: 10,
     windowMs: 60_000,

--- a/apps/web/app/api/sessions/[sessionId]/checks/fix/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/checks/fix/route.ts
@@ -200,7 +200,7 @@ export async function POST(req: Request, context: RouteContext) {
     return sessionContext.response;
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["fix-checks", authResult.userId, sessionId]),
     limit: 5,
     windowMs: 60_000,

--- a/apps/web/app/api/sessions/[sessionId]/generate-commit-message/route.ts
+++ b/apps/web/app/api/sessions/[sessionId]/generate-commit-message/route.ts
@@ -22,7 +22,7 @@ export async function POST(
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["generate-commit-message", session.user.id]),
     limit: 10,
     windowMs: 60_000,

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -16,6 +16,7 @@ import { sanitizeUserPreferencesForSession } from "@/lib/model-access";
 import {
   isValidGitHubRepoName,
   isValidGitHubRepoOwner,
+  parseGitHubHttpsUrl,
 } from "@/lib/github/urls";
 import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
 import { getRandomCityName } from "@/lib/random-city";
@@ -183,7 +184,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["sessions-create", session.user.id]),
     limit: 10,
     windowMs: 60_000,
@@ -264,31 +265,11 @@ export async function POST(req: Request) {
       return Response.json({ error: "Invalid clone URL" }, { status: 400 });
     }
 
-    let parsedCloneUrl: URL;
-    try {
-      parsedCloneUrl = new URL(body.cloneUrl);
-    } catch {
-      return Response.json({ error: "Invalid clone URL" }, { status: 400 });
-    }
-
+    const parsedCloneUrl = parseGitHubHttpsUrl(body.cloneUrl);
     if (
-      parsedCloneUrl.protocol !== "https:" ||
-      parsedCloneUrl.hostname.toLowerCase() !== "github.com"
-    ) {
-      return Response.json({ error: "Invalid clone URL" }, { status: 400 });
-    }
-
-    const clonePathParts = parsedCloneUrl.pathname
-      .replace(/^\/+/, "")
-      .split("/");
-    const [cloneOwner, cloneRepoWithSuffix] = clonePathParts;
-    const cloneRepo = cloneRepoWithSuffix?.replace(/\.git$/, "");
-    if (
-      clonePathParts.length !== 2 ||
-      !cloneOwner ||
-      !cloneRepo ||
-      cloneOwner !== body.repoOwner ||
-      cloneRepo !== body.repoName
+      !parsedCloneUrl ||
+      parsedCloneUrl.owner !== body.repoOwner ||
+      parsedCloneUrl.repo !== body.repoName
     ) {
       return Response.json(
         { error: "Clone URL must match repository owner and name" },

--- a/apps/web/app/api/transcribe/route.ts
+++ b/apps/web/app/api/transcribe/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
-  const limited = checkRateLimit({
+  const limited = await checkRateLimit({
     key: rateLimitKey(["transcribe", session.user.id]),
     limit: 5,
     windowMs: 60_000,

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -1,6 +1,8 @@
 import { Octokit } from "@octokit/rest";
+import { parseGitHubHttpsUrl, parseGitHubUrl } from "./urls";
 
 export type { Octokit } from "@octokit/rest";
+export { parseGitHubHttpsUrl, parseGitHubUrl };
 
 type OctokitResult =
   | { octokit: Octokit; authenticated: true }
@@ -32,18 +34,4 @@ export async function getUserOctokit(userId: string): Promise<Octokit | null> {
   const token = await getUserGitHubToken(userId);
   if (!token) return null;
   return new Octokit({ auth: token });
-}
-
-/**
- * Parse a GitHub URL into owner/repo.
- * Supports https://github.com/owner/repo and git@github.com:owner/repo.git
- */
-export function parseGitHubUrl(
-  repoUrl: string,
-): { owner: string; repo: string } | null {
-  const match = repoUrl.match(/github\.com[/:]([.\w-]+)\/([.\w-]+?)(\.git)?$/);
-  if (match && match[1] && match[2]) {
-    return { owner: match[1], repo: match[2] };
-  }
-  return null;
 }

--- a/apps/web/lib/github/pulls.ts
+++ b/apps/web/lib/github/pulls.ts
@@ -239,18 +239,12 @@ function extractVercelDeploymentUrl(commentBody: string): string | null {
 }
 
 function isTrustedVercelCommentAuthor(comment: {
-  author_association?: string | null;
   user?: { login?: string | null; type?: string | null } | null;
 }): boolean {
-  const association = comment.author_association;
   const login = comment.user?.login?.toLowerCase() ?? "";
+  const type = comment.user?.type;
 
-  return (
-    association === "OWNER" ||
-    association === "MEMBER" ||
-    login === "vercel[bot]" ||
-    login.endsWith("[bot]")
-  );
+  return login === "vercel[bot]" && type === "Bot";
 }
 
 const SUCCESSFUL_CHECK_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);

--- a/apps/web/lib/github/repo-identifiers.test.ts
+++ b/apps/web/lib/github/repo-identifiers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { isValidGitHubRepoName, isValidGitHubRepoOwner } from "./urls";
+import {
+  isValidGitHubRepoName,
+  isValidGitHubRepoOwner,
+  parseGitHubHttpsUrl,
+  parseGitHubUrl,
+} from "./urls";
 
 describe("repo-identifiers", () => {
   test("accepts safe GitHub owner and repo segments", () => {
@@ -13,5 +18,28 @@ describe("repo-identifiers", () => {
   test("rejects unsafe GitHub owner and repo segments", () => {
     expect(isValidGitHubRepoOwner('vercel" && echo nope && "')).toBe(false);
     expect(isValidGitHubRepoName("open harness")).toBe(false);
+  });
+
+  test("parses only real github.com HTTPS repo URLs", () => {
+    expect(
+      parseGitHubHttpsUrl("https://github.com/vercel/open-agents.git"),
+    ).toEqual({ owner: "vercel", repo: "open-agents" });
+    expect(
+      parseGitHubHttpsUrl("https://attacker.example/github.com/vercel/repo"),
+    ).toBeNull();
+    expect(parseGitHubHttpsUrl("http://github.com/vercel/repo")).toBeNull();
+    expect(
+      parseGitHubHttpsUrl("https://github.com/vercel/repo/extra"),
+    ).toBeNull();
+  });
+
+  test("parses SSH GitHub URLs without accepting arbitrary hosts", () => {
+    expect(parseGitHubUrl("git@github.com:vercel/open-agents.git")).toEqual({
+      owner: "vercel",
+      repo: "open-agents",
+    });
+    expect(
+      parseGitHubUrl("git@attacker.example:github.com/vercel/repo.git"),
+    ).toBeNull();
   });
 });

--- a/apps/web/lib/github/urls.ts
+++ b/apps/web/lib/github/urls.ts
@@ -8,6 +8,64 @@ export function isValidGitHubRepoName(repoName: string): boolean {
   return GITHUB_REPO_PATH_SEGMENT_PATTERN.test(repoName);
 }
 
+export function parseGitHubHttpsUrl(
+  repoUrl: string,
+): { owner: string; repo: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(repoUrl);
+  } catch {
+    return null;
+  }
+
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.hostname.toLowerCase() !== "github.com" ||
+    parsed.username ||
+    parsed.password
+  ) {
+    return null;
+  }
+
+  const pathParts = parsed.pathname.replace(/^\/+/, "").split("/");
+  const [owner, repoWithSuffix] = pathParts;
+  const repo = repoWithSuffix?.replace(/\.git$/, "");
+  if (
+    pathParts.length !== 2 ||
+    !owner ||
+    !repo ||
+    !isValidGitHubRepoOwner(owner) ||
+    !isValidGitHubRepoName(repo)
+  ) {
+    return null;
+  }
+
+  return { owner, repo };
+}
+
+export function parseGitHubUrl(
+  repoUrl: string,
+): { owner: string; repo: string } | null {
+  const httpsUrl = parseGitHubHttpsUrl(repoUrl);
+  if (httpsUrl) {
+    return httpsUrl;
+  }
+
+  const sshMatch = repoUrl.match(
+    /^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/,
+  );
+  if (
+    sshMatch?.[1] &&
+    sshMatch[2] &&
+    isValidGitHubRepoOwner(sshMatch[1]) &&
+    isValidGitHubRepoName(sshMatch[2])
+  ) {
+    return { owner: sshMatch[1], repo: sshMatch[2] };
+  }
+
+  return null;
+}
+
 export function getInstallationManageUrl(
   installationId: number,
   fallbackUrl?: string | null,

--- a/apps/web/lib/rate-limit.test.ts
+++ b/apps/web/lib/rate-limit.test.ts
@@ -2,10 +2,11 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 type RedisOptions = Record<string, unknown>;
 type RedisTransactionResult = [Error | null, unknown];
+type RedisExecResults = RedisTransactionResult[] | null;
 
 const redisInstances: MockRedis[] = [];
 const redisState: {
-  execResults: RedisTransactionResult[] | null;
+  execResults: RedisExecResults | Promise<RedisExecResults>;
   ttl: number;
 } = {
   execResults: [
@@ -45,6 +46,7 @@ mock.module("ioredis", () => ({
 const originalRedisUrl = process.env.REDIS_URL;
 const originalKvUrl = process.env.KV_URL;
 const originalNodeEnv = process.env.NODE_ENV;
+const originalRateLimitTimeoutMs = process.env.RATE_LIMIT_TIMEOUT_MS;
 const nodeEnvKey = "NODE_ENV" as keyof NodeJS.ProcessEnv;
 let moduleVersion = 0;
 
@@ -73,6 +75,12 @@ afterEach(() => {
     delete process.env.KV_URL;
   } else {
     process.env.KV_URL = originalKvUrl;
+  }
+
+  if (originalRateLimitTimeoutMs === undefined) {
+    delete process.env.RATE_LIMIT_TIMEOUT_MS;
+  } else {
+    process.env.RATE_LIMIT_TIMEOUT_MS = originalRateLimitTimeoutMs;
   }
 
   process.env[nodeEnvKey] = originalNodeEnv;
@@ -140,6 +148,50 @@ describe("checkRateLimit", () => {
         [null, 1],
         [new Error("ERR syntax error"), null],
       ];
+      const { checkRateLimit } = await loadRateLimitModule();
+
+      const response = await checkRateLimit({
+        key: `test:${crypto.randomUUID()}`,
+        limit: 2,
+        windowMs: 60_000,
+      });
+
+      expect(response?.status).toBe(503);
+      expect(response?.headers.get("Retry-After")).toBe("30");
+      expect(redisInstances[0]?.disconnect).toHaveBeenCalledTimes(1);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  test("returns a retry response when the Redis count exceeds the limit", async () => {
+    process.env.REDIS_URL = "redis://localhost:6379";
+    process.env[nodeEnvKey] = "production";
+    redisState.execResults = [
+      [null, 3],
+      [null, 0],
+    ];
+    redisState.ttl = 12_345;
+    const { checkRateLimit } = await loadRateLimitModule();
+
+    const response = await checkRateLimit({
+      key: `test:${crypto.randomUUID()}`,
+      limit: 2,
+      windowMs: 60_000,
+    });
+
+    expect(response?.status).toBe(429);
+    expect(response?.headers.get("Retry-After")).toBe("13");
+  });
+
+  test("fails closed when the Redis check times out", async () => {
+    const originalConsoleError = console.error;
+    console.error = mock(() => undefined) as unknown as typeof console.error;
+    try {
+      process.env.REDIS_URL = "redis://localhost:6379";
+      process.env.RATE_LIMIT_TIMEOUT_MS = "1";
+      process.env[nodeEnvKey] = "production";
+      redisState.execResults = new Promise<RedisExecResults>(() => undefined);
       const { checkRateLimit } = await loadRateLimitModule();
 
       const response = await checkRateLimit({

--- a/apps/web/lib/rate-limit.test.ts
+++ b/apps/web/lib/rate-limit.test.ts
@@ -1,10 +1,66 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { checkRateLimit } from "./rate-limit";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type RedisOptions = Record<string, unknown>;
+type RedisTransactionResult = [Error | null, unknown];
+
+const redisInstances: MockRedis[] = [];
+const redisState: {
+  execResults: RedisTransactionResult[] | null;
+  ttl: number;
+} = {
+  execResults: [
+    [null, 1],
+    [null, 1],
+  ],
+  ttl: 60_000,
+};
+
+function createMockPipeline() {
+  const pipeline = {
+    incr: mock((_key: string) => pipeline),
+    pexpire: mock((_key: string, _windowMs: number, _mode: string) => pipeline),
+    exec: mock(async () => redisState.execResults),
+  };
+
+  return pipeline;
+}
+
+class MockRedis {
+  options: RedisOptions;
+  on = mock((_event: string, _handler: (error: Error) => void) => this);
+  disconnect = mock(() => undefined);
+  pttl = mock(async (_key: string) => redisState.ttl);
+  multi = mock(() => createMockPipeline());
+
+  constructor(options: RedisOptions) {
+    this.options = options;
+    redisInstances.push(this);
+  }
+}
+
+mock.module("ioredis", () => ({
+  default: MockRedis,
+}));
 
 const originalRedisUrl = process.env.REDIS_URL;
 const originalKvUrl = process.env.KV_URL;
 const originalNodeEnv = process.env.NODE_ENV;
 const nodeEnvKey = "NODE_ENV" as keyof NodeJS.ProcessEnv;
+let moduleVersion = 0;
+
+async function loadRateLimitModule() {
+  moduleVersion += 1;
+  return import(`./rate-limit?test=${moduleVersion}`);
+}
+
+beforeEach(() => {
+  redisInstances.length = 0;
+  redisState.execResults = [
+    [null, 1],
+    [null, 1],
+  ];
+  redisState.ttl = 60_000;
+});
 
 afterEach(() => {
   if (originalRedisUrl === undefined) {
@@ -27,6 +83,7 @@ describe("checkRateLimit", () => {
     delete process.env.REDIS_URL;
     delete process.env.KV_URL;
     process.env[nodeEnvKey] = "test";
+    const { checkRateLimit } = await loadRateLimitModule();
 
     const key = `test:${crypto.randomUUID()}`;
     expect(
@@ -44,6 +101,7 @@ describe("checkRateLimit", () => {
     delete process.env.REDIS_URL;
     delete process.env.KV_URL;
     process.env[nodeEnvKey] = "production";
+    const { checkRateLimit } = await loadRateLimitModule();
 
     const response = await checkRateLimit({
       key: `test:${crypto.randomUUID()}`,
@@ -53,5 +111,48 @@ describe("checkRateLimit", () => {
 
     expect(response?.status).toBe(503);
     expect(response?.headers.get("Retry-After")).toBe("30");
+  });
+
+  test("allows Redis commands to queue during initial connection", async () => {
+    process.env.REDIS_URL = "redis://localhost:6379";
+    process.env[nodeEnvKey] = "production";
+    const { checkRateLimit } = await loadRateLimitModule();
+
+    await expect(
+      checkRateLimit({
+        key: `test:${crypto.randomUUID()}`,
+        limit: 2,
+        windowMs: 60_000,
+      }),
+    ).resolves.toBeNull();
+
+    expect(redisInstances).toHaveLength(1);
+    expect(redisInstances[0]?.options.enableOfflineQueue).toBeUndefined();
+  });
+
+  test("fails closed when the Redis expiry command fails", async () => {
+    const originalConsoleError = console.error;
+    console.error = mock(() => undefined) as unknown as typeof console.error;
+    try {
+      process.env.REDIS_URL = "redis://localhost:6379";
+      process.env[nodeEnvKey] = "production";
+      redisState.execResults = [
+        [null, 1],
+        [new Error("ERR syntax error"), null],
+      ];
+      const { checkRateLimit } = await loadRateLimitModule();
+
+      const response = await checkRateLimit({
+        key: `test:${crypto.randomUUID()}`,
+        limit: 2,
+        windowMs: 60_000,
+      });
+
+      expect(response?.status).toBe(503);
+      expect(response?.headers.get("Retry-After")).toBe("30");
+      expect(redisInstances[0]?.disconnect).toHaveBeenCalledTimes(1);
+    } finally {
+      console.error = originalConsoleError;
+    }
   });
 });

--- a/apps/web/lib/rate-limit.test.ts
+++ b/apps/web/lib/rate-limit.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { checkRateLimit } from "./rate-limit";
+
+const originalRedisUrl = process.env.REDIS_URL;
+const originalKvUrl = process.env.KV_URL;
+const originalNodeEnv = process.env.NODE_ENV;
+const nodeEnvKey = "NODE_ENV" as keyof NodeJS.ProcessEnv;
+
+afterEach(() => {
+  if (originalRedisUrl === undefined) {
+    delete process.env.REDIS_URL;
+  } else {
+    process.env.REDIS_URL = originalRedisUrl;
+  }
+
+  if (originalKvUrl === undefined) {
+    delete process.env.KV_URL;
+  } else {
+    process.env.KV_URL = originalKvUrl;
+  }
+
+  process.env[nodeEnvKey] = originalNodeEnv;
+});
+
+describe("checkRateLimit", () => {
+  test("does not enforce limits locally when Redis is not configured", async () => {
+    delete process.env.REDIS_URL;
+    delete process.env.KV_URL;
+    process.env[nodeEnvKey] = "test";
+
+    const key = `test:${crypto.randomUUID()}`;
+    expect(
+      await checkRateLimit({ key, limit: 2, windowMs: 60_000 }),
+    ).toBeNull();
+    expect(
+      await checkRateLimit({ key, limit: 2, windowMs: 60_000 }),
+    ).toBeNull();
+
+    const response = await checkRateLimit({ key, limit: 2, windowMs: 60_000 });
+    expect(response).toBeNull();
+  });
+
+  test("fails closed in production when Redis is not configured", async () => {
+    delete process.env.REDIS_URL;
+    delete process.env.KV_URL;
+    process.env[nodeEnvKey] = "production";
+
+    const response = await checkRateLimit({
+      key: `test:${crypto.randomUUID()}`,
+      limit: 2,
+      windowMs: 60_000,
+    });
+
+    expect(response?.status).toBe(503);
+    expect(response?.headers.get("Retry-After")).toBe("30");
+  });
+});

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -54,11 +54,25 @@ async function checkRedisRateLimit(
   options: RateLimitOptions,
 ): Promise<Response | null> {
   const key = `rate-limit:${options.key}`;
-  const count = await client.incr(key);
+  const count = await client
+    .multi()
+    .incr(key)
+    .pexpire(key, options.windowMs, "NX")
+    .exec()
+    .then((results) => {
+      const [incrementResult] = results ?? [];
+      const [error, value] = incrementResult ?? [];
+      if (error) {
+        throw error;
+      }
 
-  if (count === 1) {
-    await client.pexpire(key, options.windowMs);
-  }
+      const count = typeof value === "number" ? value : Number(value);
+      if (!Number.isFinite(count)) {
+        throw new Error("Redis rate limit increment returned an invalid count");
+      }
+
+      return count;
+    });
 
   if (count <= options.limit) {
     return null;

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -23,7 +23,6 @@ function getSharedRedisClient(): Redis | null {
   sharedRedisClient = new Redis({
     ...(getRedisConnectionOptions(redisUrl) as RedisOptions),
     connectTimeout: 500,
-    enableOfflineQueue: false,
     maxRetriesPerRequest: 1,
   });
   sharedRedisClient.on("error", (error) => {
@@ -60,10 +59,15 @@ async function checkRedisRateLimit(
     .pexpire(key, options.windowMs, "NX")
     .exec()
     .then((results) => {
-      const [incrementResult] = results ?? [];
+      const [incrementResult, expireResult] = results ?? [];
       const [error, value] = incrementResult ?? [];
       if (error) {
         throw error;
+      }
+
+      const [expireError] = expireResult ?? [];
+      if (expireError) {
+        throw expireError;
       }
 
       const count = typeof value === "number" ? value : Number(value);

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -1,7 +1,5 @@
-type RateLimitBucket = {
-  count: number;
-  resetAt: number;
-};
+import Redis, { type RedisOptions } from "ioredis";
+import { getRedisConnectionOptions, getRedisUrl } from "./redis";
 
 type RateLimitOptions = {
   key: string;
@@ -9,37 +7,93 @@ type RateLimitOptions = {
   windowMs: number;
 };
 
-const buckets = new Map<string, RateLimitBucket>();
+let sharedRedisClient: Redis | null | undefined;
 
-export function checkRateLimit(options: RateLimitOptions): Response | null {
-  const now = Date.now();
-  const existing = buckets.get(options.key);
+function getSharedRedisClient(): Redis | null {
+  if (sharedRedisClient !== undefined) {
+    return sharedRedisClient;
+  }
 
-  if (!existing || existing.resetAt <= now) {
-    buckets.set(options.key, {
-      count: 1,
-      resetAt: now + options.windowMs,
-    });
+  const redisUrl = getRedisUrl();
+  if (!redisUrl) {
+    sharedRedisClient = null;
+    return sharedRedisClient;
+  }
+
+  sharedRedisClient = new Redis({
+    ...(getRedisConnectionOptions(redisUrl) as RedisOptions),
+    connectTimeout: 500,
+    enableOfflineQueue: false,
+    maxRetriesPerRequest: 1,
+  });
+  sharedRedisClient.on("error", (error) => {
+    console.error("[redis] rate-limit error:", error);
+  });
+  return sharedRedisClient;
+}
+
+function resetRedisClient(): void {
+  sharedRedisClient?.disconnect();
+  sharedRedisClient = undefined;
+}
+
+function rateLimitResponse(retryAfterMs: number): Response {
+  const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+
+  return Response.json(
+    { error: "Too many requests" },
+    {
+      status: 429,
+      headers: { "Retry-After": String(retryAfterSeconds) },
+    },
+  );
+}
+
+async function checkRedisRateLimit(
+  client: Redis,
+  options: RateLimitOptions,
+): Promise<Response | null> {
+  const key = `rate-limit:${options.key}`;
+  const count = await client.incr(key);
+
+  if (count === 1) {
+    await client.pexpire(key, options.windowMs);
+  }
+
+  if (count <= options.limit) {
     return null;
   }
 
-  if (existing.count >= options.limit) {
-    const retryAfterSeconds = Math.max(
-      1,
-      Math.ceil((existing.resetAt - now) / 1000),
-    );
+  const ttl = await client.pttl(key);
+  return rateLimitResponse(ttl > 0 ? ttl : options.windowMs);
+}
 
-    return Response.json(
-      { error: "Too many requests" },
-      {
-        status: 429,
-        headers: { "Retry-After": String(retryAfterSeconds) },
-      },
-    );
+function rateLimitUnavailableResponse(): Response | null {
+  if (process.env.NODE_ENV !== "production") {
+    return null;
   }
 
-  existing.count += 1;
-  return null;
+  return Response.json(
+    { error: "Rate limit unavailable" },
+    { status: 503, headers: { "Retry-After": "30" } },
+  );
+}
+
+export async function checkRateLimit(
+  options: RateLimitOptions,
+): Promise<Response | null> {
+  const redisClient = getSharedRedisClient();
+  if (!redisClient) {
+    return rateLimitUnavailableResponse();
+  }
+
+  try {
+    return await checkRedisRateLimit(redisClient, options);
+  } catch (error) {
+    resetRedisClient();
+    console.error("[rate-limit] Redis check failed:", error);
+    return rateLimitUnavailableResponse();
+  }
 }
 
 export function rateLimitKey(parts: (number | string | null | undefined)[]) {

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -7,7 +7,43 @@ type RateLimitOptions = {
   windowMs: number;
 };
 
+const DEFAULT_RATE_LIMIT_TIMEOUT_MS = 1000;
+
 let sharedRedisClient: Redis | null | undefined;
+
+function getRateLimitTimeoutMs(): number {
+  const configuredTimeoutMs = process.env.RATE_LIMIT_TIMEOUT_MS;
+  if (!configuredTimeoutMs) {
+    return DEFAULT_RATE_LIMIT_TIMEOUT_MS;
+  }
+
+  const timeoutMs = Number.parseInt(configuredTimeoutMs, 10);
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return DEFAULT_RATE_LIMIT_TIMEOUT_MS;
+  }
+
+  return timeoutMs;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      reject(
+        new Error(`Redis rate limit check timed out after ${timeoutMs}ms`),
+      );
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
 
 function getSharedRedisClient(): Redis | null {
   if (sharedRedisClient !== undefined) {
@@ -106,7 +142,10 @@ export async function checkRateLimit(
   }
 
   try {
-    return await checkRedisRateLimit(redisClient, options);
+    return await withTimeout(
+      checkRedisRateLimit(redisClient, options),
+      getRateLimitTimeoutMs(),
+    );
   } catch (error) {
     resetRedisClient();
     console.error("[rate-limit] Redis check failed:", error);

--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -30,13 +30,16 @@ interface ToolOptions {
 
 // Commands that should require approval
 const DANGEROUS_COMMAND_PATTERNS = [
-  /\brm\s+(?:-[A-Za-z]*r[A-Za-z]*f|-{1,2}recursive\b.*-{1,2}force\b|-{1,2}force\b.*-{1,2}recursive\b)/,
+  /\brm\s+(?:[^\n;&|]*\s)?(?:-[A-Za-z]*r[A-Za-z]*f|-[A-Za-z]*f[A-Za-z]*r|-r\s+-f|-f\s+-r|-{1,2}recursive\b.*-{1,2}force\b|-{1,2}force\b.*-{1,2}recursive\b)/,
+  /\bfind\b[^\n;&|]*(?:-delete|-exec\s+rm\b)/,
   /\b(?:shred|mkfs|dd)\b/,
   /:\(\)\s*\{\s*:\|:/,
 ];
 
 const SENSITIVE_FILE_PATTERNS = [
   /\.\s*env/i,
+  /\.e(?:['"]{2}|\\|\$\{[^}]*\}|\$\([^)]*\))?nv/i,
+  /\.e\$\([^)]*nv[^)]*\)/i,
   /\$\([^)]*env[^)]*\)/i,
   /`[^`]*env[^`]*`/i,
   /\b(?:aws\/credentials|id_rsa|id_ed25519|\.ssh|proc\/self\/environ)\b/i,

--- a/packages/agent/tools/fetch.ts
+++ b/packages/agent/tools/fetch.ts
@@ -183,6 +183,34 @@ export function isAllowedWebUrl(value: string): boolean {
   return !isPrivateHost(parsed.hostname);
 }
 
+async function resolvesToPrivateHost(params: {
+  hostname: string;
+  sandbox: Awaited<ReturnType<typeof getSandbox>>;
+  workingDirectory: string;
+  abortSignal?: AbortSignal;
+}): Promise<boolean> {
+  if (isPrivateHost(params.hostname)) {
+    return true;
+  }
+
+  const result = await params.sandbox.exec(
+    `getent ahosts ${shellEscape(params.hostname)} | awk '{print $1}' | sort -u`,
+    params.workingDirectory,
+    5000,
+    { signal: params.abortSignal },
+  );
+
+  if (!result.success) {
+    return false;
+  }
+
+  return result.stdout
+    .split("\n")
+    .map((address) => address.trim())
+    .filter(Boolean)
+    .some(isPrivateHost);
+}
+
 const fetchInputSchema = z.object({
   url: z
     .string()
@@ -236,6 +264,21 @@ EXAMPLES:
   ) => {
     const sandbox = await getSandbox(experimental_context, "web_fetch");
     const workingDirectory = sandbox.workingDirectory;
+
+    const parsedUrl = new URL(url);
+    if (
+      await resolvesToPrivateHost({
+        hostname: parsedUrl.hostname,
+        sandbox,
+        workingDirectory,
+        abortSignal,
+      })
+    ) {
+      return {
+        success: false,
+        error: "Fetch failed: URL resolves to a private or internal host",
+      };
+    }
 
     const args: string[] = [
       "curl",

--- a/packages/agent/tools/fetch.ts
+++ b/packages/agent/tools/fetch.ts
@@ -201,7 +201,7 @@ async function resolvesToPrivateHost(params: {
   );
 
   if (!result.success) {
-    return false;
+    return true;
   }
 
   return result.stdout

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -407,9 +407,13 @@ describe("tools execute behavior", () => {
     expect(commandNeedsApproval("bun install")).toBe(false);
     expect(commandNeedsApproval("custom-command --help")).toBe(false);
     expect(commandNeedsApproval("git reset --hard HEAD~1")).toBe(false);
-    expect(commandNeedsApproval("rm -fr tmp")).toBe(false);
+    expect(commandNeedsApproval("rm -fr tmp")).toBe(true);
+    expect(commandNeedsApproval("rm -r -f tmp")).toBe(true);
+    expect(commandNeedsApproval("find . -delete")).toBe(true);
     expect(commandNeedsApproval("rm -rf tmp")).toBe(true);
     expect(commandNeedsApproval("cat .env.local")).toBe(true);
+    expect(commandNeedsApproval("cat .e''nv.local")).toBe(true);
+    expect(commandNeedsApproval("cat .e$(printf nv).local")).toBe(true);
     expect(commandNeedsApproval("grep API_KEY apps/web/.env.example")).toBe(
       true,
     );
@@ -470,6 +474,17 @@ describe("tools execute behavior", () => {
       workingDirectory: "/repo",
       exec: async (command: string) => {
         executedCommand = command;
+
+        if (command.startsWith("getent ahosts")) {
+          return {
+            success: true,
+            exitCode: 0,
+            stdout: "93.184.216.34\n",
+            stderr: "",
+            truncated: false,
+          };
+        }
+
         return {
           success: false,
           exitCode: 23,
@@ -503,6 +518,38 @@ describe("tools execute behavior", () => {
         ? (result.body as string)
         : "";
     expect(body.length).toBe(MAX_BODY_LENGTH);
+  });
+
+  test("webFetchTool rejects public hostnames that resolve to private addresses", async () => {
+    const sandbox = {
+      workingDirectory: "/repo",
+      exec: async (command: string) => {
+        if (command.startsWith("getent ahosts")) {
+          return {
+            success: true,
+            exitCode: 0,
+            stdout: "127.0.0.1\n",
+            stderr: "",
+            truncated: false,
+          };
+        }
+
+        throw new Error("curl should not run for private DNS results");
+      },
+    };
+
+    const result = await webFetchTool.execute?.(
+      {
+        url: "https://internal.example",
+        method: "GET",
+      },
+      executionOptions(createContext(sandbox)),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Fetch failed: URL resolves to a private or internal host",
+    });
   });
 
   test("webFetchTool rejects private and internal URL hosts", () => {

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -552,6 +552,38 @@ describe("tools execute behavior", () => {
     });
   });
 
+  test("webFetchTool rejects when DNS resolution fails", async () => {
+    const sandbox = {
+      workingDirectory: "/repo",
+      exec: async (command: string) => {
+        if (command.startsWith("getent ahosts")) {
+          return {
+            success: false,
+            exitCode: 2,
+            stdout: "",
+            stderr: "resolution failed",
+            truncated: false,
+          };
+        }
+
+        throw new Error("curl should not run when DNS validation fails");
+      },
+    };
+
+    const result = await webFetchTool.execute?.(
+      {
+        url: "https://unresolved.example",
+        method: "GET",
+      },
+      executionOptions(createContext(sandbox)),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Fetch failed: URL resolves to a private or internal host",
+    });
+  });
+
   test("webFetchTool rejects private and internal URL hosts", () => {
     const blockedUrls = [
       "http://localhost",


### PR DESCRIPTION
## Summary
- harden GitHub repo URL parsing before sandbox/session clone flows
- make production rate limiting Redis/KV-backed and fail closed when unavailable
- tighten web_fetch SSRF checks, bash approval heuristics, and Vercel deployment URL provenance

## Validation
- bun run ci