### PR TITLE
[codex] fix session creation BotID protection

### DIFF
--- a/apps/web/instrumentation-client.test.ts
+++ b/apps/web/instrumentation-client.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const initBotIdCalls: unknown[] = [];
+
+mock.module("botid/client/core", () => ({
+  initBotId: (config: unknown) => {
+    initBotIdCalls.push(config);
+  },
+}));
+
+describe("BotID client instrumentation", () => {
+  test("protects session creation to match the server-side BotID gate", async () => {
+    const { botIdProtectedRoutes } = await import("./instrumentation-client");
+
+    expect(botIdProtectedRoutes).toContainEqual({
+      path: "/api/sessions",
+      method: "POST",
+    });
+    expect(initBotIdCalls).toContainEqual({
+      protect: botIdProtectedRoutes,
+    });
+  });
+});

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,5 +1,18 @@
 import { initBotId } from "botid/client/core";
 
+export const botIdProtectedRoutes = [
+  // AI text-generation endpoints
+  { path: "/api/chat", method: "POST" },
+  { path: "/api/generate-pr", method: "POST" },
+  { path: "/api/generate-title", method: "POST" },
+  { path: "/api/sessions/*/generate-commit-message", method: "POST" },
+
+  // Resource-intensive endpoints
+  { path: "/api/sandbox", method: "POST" },
+  { path: "/api/sessions", method: "POST" },
+  { path: "/api/transcribe", method: "POST" },
+];
+
 /**
  * Vercel BotID client-side initialization.
  *
@@ -9,15 +22,5 @@ import { initBotId } from "botid/client/core";
  * @see https://vercel.com/docs/botid/get-started
  */
 initBotId({
-  protect: [
-    // AI text-generation endpoints
-    { path: "/api/chat", method: "POST" },
-    { path: "/api/generate-pr", method: "POST" },
-    { path: "/api/generate-title", method: "POST" },
-    { path: "/api/sessions/*/generate-commit-message", method: "POST" },
-
-    // Resource-intensive endpoints
-    { path: "/api/sandbox", method: "POST" },
-    { path: "/api/transcribe", method: "POST" },
-  ],
+  protect: botIdProtectedRoutes,
 });


### PR DESCRIPTION
## Summary

- Add POST /api/sessions to the BotID client protected route list.
- Export the BotID protected route config and add a regression test for session creation protection.

## Root cause

The server enforced BotID on POST /api/sessions, but the browser BotID initialization did not include that route. New chat creation could therefore reach the server without BotID verification and be rejected with 403 Access denied before trial or rate-limit checks ran.

## Validation

- bun test apps/web/instrumentation-client.test.ts
- bun run ci