### PR TITLE
[codex] Disable OpenAI GPT pro models

### DIFF
--- a/apps/web/lib/model-availability.test.ts
+++ b/apps/web/lib/model-availability.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  filterDisabledModels,
+  isModelDisabled,
+  resolveAvailableModelId,
+} from "./model-availability";
+import { APP_DEFAULT_MODEL_ID } from "./models";
+
+describe("model availability", () => {
+  test("disables OpenAI GPT pro models", () => {
+    expect(isModelDisabled("openai/gpt-5.4-pro")).toBe(true);
+    expect(isModelDisabled("openai/gpt-5.5-pro")).toBe(true);
+    expect(isModelDisabled("openai/gpt-5.5-pro-preview")).toBe(false);
+    expect(isModelDisabled("openai/gpt-5.5")).toBe(false);
+    expect(isModelDisabled("openai/o1-pro")).toBe(false);
+  });
+
+  test("filters disabled models from available model lists", () => {
+    const models = [
+      { id: "openai/gpt-5.5", name: "GPT 5.5" },
+      { id: "openai/gpt-5.5-pro", name: "GPT 5.5 Pro" },
+      { id: "anthropic/claude-opus-4.6", name: "Claude Opus 4.6" },
+    ];
+
+    expect(filterDisabledModels(models)).toEqual([
+      { id: "openai/gpt-5.5", name: "GPT 5.5" },
+      { id: "anthropic/claude-opus-4.6", name: "Claude Opus 4.6" },
+    ]);
+  });
+
+  test("resolves disabled model selections to the app default", () => {
+    expect(resolveAvailableModelId("openai/gpt-5.5-pro")).toBe(
+      APP_DEFAULT_MODEL_ID,
+    );
+    expect(resolveAvailableModelId("openai/gpt-5.5")).toBe("openai/gpt-5.5");
+  });
+});

--- a/apps/web/lib/model-availability.ts
+++ b/apps/web/lib/model-availability.ts
@@ -1,9 +1,13 @@
 import { APP_DEFAULT_MODEL_ID } from "@/lib/models";
 
-const DISABLED_MODEL_IDS = new Set(["openai/gpt-5.4-pro"]);
+const DISABLED_OPENAI_GPT_PREFIX = "openai/gpt-";
+const DISABLED_OPENAI_PRO_SUFFIX = "-pro";
 
 export function isModelDisabled(modelId: string): boolean {
-  return DISABLED_MODEL_IDS.has(modelId);
+  return (
+    modelId.startsWith(DISABLED_OPENAI_GPT_PREFIX) &&
+    modelId.endsWith(DISABLED_OPENAI_PRO_SUFFIX)
+  );
 }
 
 export function filterDisabledModels<T extends { id: string }>(


### PR DESCRIPTION
## Summary
- Disable any model ID that starts with `openai/gpt-` and ends with `-pro`.
- Add model availability tests for the new rule and fallback behavior.

## Validation
- `bun test apps/web/lib/model-availability.test.ts`
- `bun run ci`