### PR TITLE
[codex] Fix stale sandbox head before broker commits

### DIFF
--- a/apps/web/lib/chat/auto-commit-direct.test.ts
+++ b/apps/web/lib/chat/auto-commit-direct.test.ts
@@ -37,6 +37,7 @@ let apiCommitResult:
   commitSha: "abc123def456",
 };
 let generateTextResult = { text: "feat: implement new feature" };
+let syncPreservingChangesCalls = 0;
 
 // ── module mocks ───────────────────────────────────────────────────
 
@@ -64,6 +65,9 @@ mock.module("@open-agents/sandbox", () => ({
   getHeadSha: async () => "base-sha",
   getCurrentBranch: async () => "feature-branch",
   syncToRemote: async () => {},
+  syncToRemotePreservingChanges: async () => {
+    syncPreservingChangesCalls += 1;
+  },
   withTemporaryGitHubAuth: async (
     _sandbox: unknown,
     _token: string | undefined,
@@ -156,6 +160,7 @@ beforeEach(() => {
   };
   apiCommitResult = { ok: true, commitSha: "abc123def456" };
   generateTextResult = { text: "feat: implement new feature" };
+  syncPreservingChangesCalls = 0;
 });
 
 describe("performAutoCommit", () => {
@@ -205,6 +210,7 @@ describe("performAutoCommit", () => {
     expect(result.commitMessage).toBeDefined();
     expect(result.commitSha).toBe("abc123def456");
     expect(result.error).toBeUndefined();
+    expect(syncPreservingChangesCalls).toBe(1);
   });
 
   test("uses fallback commit message when diff is empty", async () => {

--- a/apps/web/lib/chat/auto-commit-direct.ts
+++ b/apps/web/lib/chat/auto-commit-direct.ts
@@ -5,6 +5,7 @@ import {
   getCurrentBranch,
   getStagedDiff,
   syncToRemote,
+  syncToRemotePreservingChanges,
   withTemporaryGitHubAuth,
 } from "@open-agents/sandbox";
 import { generateText } from "ai";
@@ -62,21 +63,7 @@ export async function performAutoCommit(
     return { committed: false, pushed: false };
   }
 
-  // 2. stage all changes
-  try {
-    await stageAll(sandbox);
-  } catch {
-    return {
-      committed: false,
-      pushed: false,
-      error: "Failed to stage changes",
-    };
-  }
-
-  // 3. generate commit message from staged diff
-  const commitMessage = await generateCommitMessage(sandbox, sessionTitle);
-
-  // 4. verify repo access and get installation
+  // 2. verify repo access and get installation
   const access = await verifyRepoAccess({
     userId,
     owner: repoOwner,
@@ -119,6 +106,47 @@ export async function performAutoCommit(
     }
     await updateSession(sessionId, { branch }).catch(() => {});
   }
+
+  // Keep the sandbox parent aligned with broker-created remote commits before
+  // staging, while preserving the current uncommitted edits.
+  try {
+    const syncToken = await mintInstallationToken({
+      installationId: access.installationId,
+      repositoryIds: [access.repositoryId],
+      permissions: { contents: "read" },
+    });
+    try {
+      await withTemporaryGitHubAuth(sandbox, syncToken.token, () =>
+        syncToRemotePreservingChanges(sandbox, branch),
+      );
+    } finally {
+      await revokeInstallationToken(syncToken.token);
+    }
+  } catch (error) {
+    console.warn(
+      `[auto-commit] Pre-commit sandbox sync failed for session ${sessionId}:`,
+      error,
+    );
+    return {
+      committed: false,
+      pushed: false,
+      error: "Failed to sync latest remote changes before committing",
+    };
+  }
+
+  // 3. stage all changes after syncing the branch parent
+  try {
+    await stageAll(sandbox);
+  } catch {
+    return {
+      committed: false,
+      pushed: false,
+      error: "Failed to stage changes",
+    };
+  }
+
+  // 4. generate commit message from staged diff
+  const commitMessage = await generateCommitMessage(sandbox, sessionTitle);
 
   const coAuthor = await buildCoAuthor(userId);
 

--- a/apps/web/lib/github/actions/commit.ts
+++ b/apps/web/lib/github/actions/commit.ts
@@ -5,6 +5,7 @@ import {
   stageAll,
   getStagedDiff,
   syncToRemote,
+  syncToRemotePreservingChanges,
   withTemporaryGitHubAuth,
   hasUncommittedChanges as checkUncommitted,
 } from "@open-agents/sandbox";
@@ -200,6 +201,47 @@ export async function commitChanges(params: {
     await updateSession(sessionId, { branch: resolvedBranch }).catch(() => {});
   }
 
+  if (await checkUncommitted(sandbox)) {
+    const access = await verifyRepoAccess({
+      userId: session.user.id,
+      owner: sessionRecord.repoOwner,
+      repo: sessionRecord.repoName,
+      requiredUserPermission: "write",
+    });
+
+    if (!access.ok) {
+      return {
+        committed: false,
+        pushed: false,
+        branchName: resolvedBranch,
+        error: getRepoAccessErrorMessage(access.reason),
+      };
+    }
+
+    try {
+      const syncToken = await mintInstallationToken({
+        installationId: access.installationId,
+        repositoryIds: [access.repositoryId],
+        permissions: { contents: "read" },
+      });
+      try {
+        await withTemporaryGitHubAuth(sandbox, syncToken.token, () =>
+          syncToRemotePreservingChanges(sandbox, resolvedBranch),
+        );
+      } finally {
+        await revokeInstallationToken(syncToken.token);
+      }
+    } catch (error) {
+      console.warn("[commit] pre-commit sandbox sync failed:", error);
+      return {
+        committed: false,
+        pushed: false,
+        branchName: resolvedBranch,
+        error: "Failed to sync latest remote changes before committing",
+      };
+    }
+  }
+
   // check for changes
   if (!(await checkUncommitted(sandbox))) {
     if (!(await hasCommitsToPush({ sandbox, cwd }))) {
@@ -266,7 +308,6 @@ export async function commitChanges(params: {
     commitMessage = await generateCommitMessage(diff, sessionTitle);
   }
 
-  // verify access
   const access = await verifyRepoAccess({
     userId: session.user.id,
     owner: sessionRecord.repoOwner,

--- a/packages/sandbox/git.test.ts
+++ b/packages/sandbox/git.test.ts
@@ -46,6 +46,7 @@ describe("syncToRemotePreservingChanges", () => {
     const sandbox = createSandbox([
       result(),
       result({ stdout: " M file.ts\n" }),
+      result({ stdout: "original-head\n" }),
       result(),
       result(),
       result(),
@@ -57,6 +58,7 @@ describe("syncToRemotePreservingChanges", () => {
     expect(sandbox.commands).toEqual([
       "git fetch origin feature:refs/remotes/origin/feature",
       "git status --porcelain",
+      "git rev-parse HEAD",
       "git stash push --include-untracked -m open-agents-pre-commit-sync",
       "git reset --hard origin/feature",
       "git branch --set-upstream-to=origin/feature feature",
@@ -77,6 +79,44 @@ describe("syncToRemotePreservingChanges", () => {
 
     expect(sandbox.commands).toEqual([
       "git fetch origin feature:refs/remotes/origin/feature",
+    ]);
+  });
+
+  test("rolls back and restores local changes when stash restore conflicts after sync", async () => {
+    const sandbox = createSandbox([
+      result(),
+      result({ stdout: " M file.ts\n" }),
+      result({ stdout: "original-head\n" }),
+      result(),
+      result(),
+      result(),
+      result({
+        success: false,
+        exitCode: 1,
+        stderr: "CONFLICT (content): Merge conflict in file.ts\n",
+      }),
+      result(),
+      result(),
+      result(),
+    ]) as Sandbox & { commands: string[] };
+
+    await expect(
+      syncToRemotePreservingChanges(sandbox, "feature"),
+    ).rejects.toThrow(
+      "Failed to restore local changes after syncing remote branch",
+    );
+
+    expect(sandbox.commands).toEqual([
+      "git fetch origin feature:refs/remotes/origin/feature",
+      "git status --porcelain",
+      "git rev-parse HEAD",
+      "git stash push --include-untracked -m open-agents-pre-commit-sync",
+      "git reset --hard origin/feature",
+      "git branch --set-upstream-to=origin/feature feature",
+      "git stash pop",
+      "git reset --hard original-head",
+      "git clean -fd",
+      "git stash pop",
     ]);
   });
 });

--- a/packages/sandbox/git.test.ts
+++ b/packages/sandbox/git.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import type { ExecResult, Sandbox } from "./interface";
+import { syncToRemotePreservingChanges } from "./git";
+
+function result(params: Partial<ExecResult> = {}): ExecResult {
+  return {
+    success: true,
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    truncated: false,
+    ...params,
+  };
+}
+
+function createSandbox(results: ExecResult[]): Sandbox {
+  const commands: string[] = [];
+
+  return {
+    type: "cloud",
+    workingDirectory: "/repo",
+    exec: async (command) => {
+      commands.push(command);
+      return results.shift() ?? result();
+    },
+    readFile: async () => "",
+    writeFile: async () => {},
+    readFileBuffer: async () => Buffer.from(""),
+    access: async () => {},
+    stat: async () => ({
+      isDirectory: () => false,
+      isFile: () => true,
+      size: 0,
+      mtimeMs: 0,
+    }),
+    mkdir: async () => {},
+    readdir: async () => [],
+    exists: async () => true,
+    stop: async () => {},
+    commands,
+  } as Sandbox & { commands: string[] };
+}
+
+describe("syncToRemotePreservingChanges", () => {
+  test("stashes local changes, resets to remote, and restores changes", async () => {
+    const sandbox = createSandbox([
+      result(),
+      result({ stdout: " M file.ts\n" }),
+      result(),
+      result(),
+      result(),
+      result(),
+    ]) as Sandbox & { commands: string[] };
+
+    await syncToRemotePreservingChanges(sandbox, "feature");
+
+    expect(sandbox.commands).toEqual([
+      "git fetch origin feature:refs/remotes/origin/feature",
+      "git status --porcelain",
+      "git stash push --include-untracked -m open-agents-pre-commit-sync",
+      "git reset --hard origin/feature",
+      "git branch --set-upstream-to=origin/feature feature",
+      "git stash pop",
+    ]);
+  });
+
+  test("returns without touching local changes when the remote branch is missing", async () => {
+    const sandbox = createSandbox([
+      result({
+        success: false,
+        exitCode: 128,
+        stderr: "fatal: couldn't find remote ref feature\n",
+      }),
+    ]) as Sandbox & { commands: string[] };
+
+    await syncToRemotePreservingChanges(sandbox, "feature");
+
+    expect(sandbox.commands).toEqual([
+      "git fetch origin feature:refs/remotes/origin/feature",
+    ]);
+  });
+});

--- a/packages/sandbox/git.ts
+++ b/packages/sandbox/git.ts
@@ -36,6 +36,65 @@ function exec(
   return sandbox.exec(command, sandbox.workingDirectory, timeoutMs);
 }
 
+function commandOutput(result: ExecResult): string {
+  return result.stderr?.trim() || result.stdout?.trim() || "Git command failed";
+}
+
+function isMissingRemoteRef(result: ExecResult): boolean {
+  const output = `${result.stderr}\n${result.stdout}`;
+  return output.includes("couldn't find remote ref");
+}
+
+async function fetchRemoteBranch(
+  sandbox: Sandbox,
+  branch: string,
+): Promise<"fetched" | "missing"> {
+  const fetchResult = await exec(
+    sandbox,
+    `git fetch origin ${branch}:refs/remotes/origin/${branch}`,
+    30000,
+  );
+
+  if (fetchResult.success) {
+    return "fetched";
+  }
+
+  if (isMissingRemoteRef(fetchResult)) {
+    return "missing";
+  }
+
+  throw new Error(
+    `Failed to fetch remote branch: ${commandOutput(fetchResult)}`,
+  );
+}
+
+async function resetToFetchedRemoteBranch(
+  sandbox: Sandbox,
+  branch: string,
+): Promise<void> {
+  const resetResult = await exec(
+    sandbox,
+    `git reset --hard origin/${branch}`,
+    10000,
+  );
+  if (!resetResult.success) {
+    throw new Error(
+      `Failed to reset to remote branch: ${commandOutput(resetResult)}`,
+    );
+  }
+
+  const upstreamResult = await exec(
+    sandbox,
+    `git branch --set-upstream-to=origin/${branch} ${branch}`,
+    10000,
+  );
+  if (!upstreamResult.success) {
+    throw new Error(
+      `Failed to set upstream after remote sync: ${commandOutput(upstreamResult)}`,
+    );
+  }
+}
+
 // ---- public functions ----
 
 /**
@@ -245,32 +304,67 @@ export async function syncToRemote(
     throw new Error("Invalid branch name");
   }
 
-  const fetchResult = await exec(
+  const fetchStatus = await fetchRemoteBranch(sandbox, branch);
+  if (fetchStatus === "missing") {
+    throw new Error(`Remote branch '${branch}' not found`);
+  }
+
+  await resetToFetchedRemoteBranch(sandbox, branch);
+}
+
+/**
+ * Refresh the sandbox branch from remote before building an API commit.
+ * Local edits are stashed and restored so commits are based on the latest
+ * remote head even when a previous broker-created commit was not synced back.
+ */
+export async function syncToRemotePreservingChanges(
+  sandbox: Sandbox,
+  branch: string,
+): Promise<void> {
+  if (!isSafeBranchName(branch)) {
+    throw new Error("Invalid branch name");
+  }
+
+  const fetchStatus = await fetchRemoteBranch(sandbox, branch);
+  if (fetchStatus === "missing") {
+    return;
+  }
+
+  const statusResult = await exec(sandbox, "git status --porcelain", 10000);
+  if (!statusResult.success) {
+    throw new Error(
+      `Failed to inspect local changes: ${commandOutput(statusResult)}`,
+    );
+  }
+
+  const hasLocalChanges = statusResult.stdout.trim().length > 0;
+  if (!hasLocalChanges) {
+    await resetToFetchedRemoteBranch(sandbox, branch);
+    return;
+  }
+
+  const stashResult = await exec(
     sandbox,
-    `git fetch origin ${branch}:refs/remotes/origin/${branch}`,
+    "git stash push --include-untracked -m open-agents-pre-commit-sync",
     30000,
   );
-  if (!fetchResult.success) {
-    throw new Error(`Failed to fetch after commit: ${fetchResult.stdout}`);
-  }
-
-  const resetResult = await exec(
-    sandbox,
-    `git reset --hard origin/${branch}`,
-    10000,
-  );
-  if (!resetResult.success) {
-    throw new Error(`Failed to reset after API commit: ${resetResult.stdout}`);
-  }
-
-  const upstreamResult = await exec(
-    sandbox,
-    `git branch --set-upstream-to=origin/${branch} ${branch}`,
-    10000,
-  );
-  if (!upstreamResult.success) {
+  if (!stashResult.success) {
     throw new Error(
-      `Failed to set upstream after API commit: ${upstreamResult.stdout}`,
+      `Failed to stash local changes: ${commandOutput(stashResult)}`,
+    );
+  }
+
+  try {
+    await resetToFetchedRemoteBranch(sandbox, branch);
+  } catch (error) {
+    await exec(sandbox, "git stash pop", 30000).catch(() => {});
+    throw error;
+  }
+
+  const popResult = await exec(sandbox, "git stash pop", 30000);
+  if (!popResult.success) {
+    throw new Error(
+      `Failed to restore local changes after syncing remote branch: ${commandOutput(popResult)}`,
     );
   }
 }

--- a/packages/sandbox/git.ts
+++ b/packages/sandbox/git.ts
@@ -95,6 +95,33 @@ async function resetToFetchedRemoteBranch(
   }
 }
 
+async function getCurrentHead(sandbox: Sandbox): Promise<string> {
+  const headResult = await exec(sandbox, "git rev-parse HEAD", 10000);
+  if (!headResult.success) {
+    throw new Error(
+      `Failed to inspect current HEAD: ${commandOutput(headResult)}`,
+    );
+  }
+
+  return headResult.stdout.trim();
+}
+
+async function resetToCommit(sandbox: Sandbox, commit: string): Promise<void> {
+  const resetResult = await exec(sandbox, `git reset --hard ${commit}`, 10000);
+  if (!resetResult.success) {
+    throw new Error(
+      `Failed to restore original HEAD after sync failure: ${commandOutput(resetResult)}`,
+    );
+  }
+
+  const cleanResult = await exec(sandbox, "git clean -fd", 10000);
+  if (!cleanResult.success) {
+    throw new Error(
+      `Failed to clean worktree after sync failure: ${commandOutput(cleanResult)}`,
+    );
+  }
+}
+
 // ---- public functions ----
 
 /**
@@ -343,6 +370,8 @@ export async function syncToRemotePreservingChanges(
     return;
   }
 
+  const originalHead = await getCurrentHead(sandbox);
+
   const stashResult = await exec(
     sandbox,
     "git stash push --include-untracked -m open-agents-pre-commit-sync",
@@ -357,12 +386,21 @@ export async function syncToRemotePreservingChanges(
   try {
     await resetToFetchedRemoteBranch(sandbox, branch);
   } catch (error) {
+    await resetToCommit(sandbox, originalHead);
     await exec(sandbox, "git stash pop", 30000).catch(() => {});
     throw error;
   }
 
   const popResult = await exec(sandbox, "git stash pop", 30000);
   if (!popResult.success) {
+    await resetToCommit(sandbox, originalHead);
+    const restoreResult = await exec(sandbox, "git stash pop", 30000);
+    if (!restoreResult.success) {
+      throw new Error(
+        `Failed to restore local changes after rolling back sync failure: ${commandOutput(restoreResult)}`,
+      );
+    }
+
     throw new Error(
       `Failed to restore local changes after syncing remote branch: ${commandOutput(popResult)}`,
     );

--- a/packages/sandbox/index.ts
+++ b/packages/sandbox/index.ts
@@ -32,6 +32,7 @@ export {
   readFileContents,
   getFileModes,
   syncToRemote,
+  syncToRemotePreservingChanges,
   withTemporaryGitHubAuth,
   type FileChange,
   type FileChangeStatus,


### PR DESCRIPTION
## Summary

- sync the sandbox branch to the latest remote head before brokered commits while preserving local edits
- run the pre-sync before staging in auto-commit and manual commit paths
- add sandbox git helper coverage for stash/reset/pop and local-only branches

## Root Cause

Broker-created GitHub API commits could land on the remote branch while the sandbox stayed on the previous HEAD if the follow-up sync lagged or failed. The next broker commit then compared the stale sandbox HEAD with the remote branch HEAD and failed with "Remote branch changed before commit could be created".

## Validation

- bun run ci