### PR TITLE
Fix commit sync failures in sandbox fetch path

### DIFF
--- a/packages/sandbox/git.test.ts
+++ b/packages/sandbox/git.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import type { ExecResult, Sandbox } from "./interface";
 import { syncToRemotePreservingChanges } from "./git";
 
+const fetchFeatureCommand =
+  "GIT_TERMINAL_PROMPT=0 git fetch --force origin feature:refs/remotes/origin/feature";
+
 function result(params: Partial<ExecResult> = {}): ExecResult {
   return {
     success: true,
@@ -56,7 +59,7 @@ describe("syncToRemotePreservingChanges", () => {
     await syncToRemotePreservingChanges(sandbox, "feature");
 
     expect(sandbox.commands).toEqual([
-      "git fetch origin feature:refs/remotes/origin/feature",
+      fetchFeatureCommand,
       "git status --porcelain",
       "git rev-parse HEAD",
       "git stash push --include-untracked -m open-agents-pre-commit-sync",
@@ -77,9 +80,7 @@ describe("syncToRemotePreservingChanges", () => {
 
     await syncToRemotePreservingChanges(sandbox, "feature");
 
-    expect(sandbox.commands).toEqual([
-      "git fetch origin feature:refs/remotes/origin/feature",
-    ]);
+    expect(sandbox.commands).toEqual([fetchFeatureCommand]);
   });
 
   test("rolls back and restores local changes when stash restore conflicts after sync", async () => {
@@ -107,7 +108,7 @@ describe("syncToRemotePreservingChanges", () => {
     );
 
     expect(sandbox.commands).toEqual([
-      "git fetch origin feature:refs/remotes/origin/feature",
+      fetchFeatureCommand,
       "git status --porcelain",
       "git rev-parse HEAD",
       "git stash push --include-untracked -m open-agents-pre-commit-sync",

--- a/packages/sandbox/git.ts
+++ b/packages/sandbox/git.ts
@@ -51,7 +51,7 @@ async function fetchRemoteBranch(
 ): Promise<"fetched" | "missing"> {
   const fetchResult = await exec(
     sandbox,
-    `git fetch origin ${branch}:refs/remotes/origin/${branch}`,
+    `GIT_TERMINAL_PROMPT=0 git fetch --force origin ${branch}:refs/remotes/origin/${branch}`,
     30000,
   );
 

--- a/packages/sandbox/vercel/sandbox.test.ts
+++ b/packages/sandbox/vercel/sandbox.test.ts
@@ -11,7 +11,7 @@ type MockRunCommandResult = {
   exitCode?: number;
   cmdId: string;
   stdout: () => Promise<string>;
-  stderr?: () => Promise<string>;
+  stderr: () => Promise<string>;
   wait?: (params?: { signal?: AbortSignal }) => Promise<MockWaitResult>;
 };
 type MockRunCommandParams = {
@@ -48,6 +48,7 @@ let runCommandMock = async (
   exitCode: 0,
   cmdId: "cmd-1",
   stdout: async () => "",
+  stderr: async () => "",
 });
 let lastRunCommandEnv: Record<string, string> | undefined;
 let currentSessionStateFactory = (_name: string): MockSessionState => ({});
@@ -167,6 +168,7 @@ beforeEach(() => {
     exitCode: 0,
     cmdId: "cmd-1",
     stdout: async () => "",
+    stderr: async () => "",
   });
   lastRunCommandEnv = undefined;
   currentSessionStateFactory = () => ({});
@@ -246,6 +248,36 @@ describe("VercelSandbox.environmentDetails", () => {
     expect(lastRunCommandEnv?.SANDBOX_URL_3000).toBe(
       "https://sbx-3000.vercel.run",
     );
+  });
+});
+
+describe("VercelSandbox.exec", () => {
+  test("preserves stderr output from failed commands", async () => {
+    runCommandMock = async () => ({
+      exitCode: 128,
+      cmdId: "cmd-fetch-failed",
+      stdout: async () => "",
+      stderr: async () => "fatal: couldn't find remote ref feature\n",
+    });
+
+    const sandbox = await sandboxModule.VercelSandbox.connect("sbx-test", {
+      ports: [3000],
+      remainingTimeout: 0,
+    });
+
+    const result = await sandbox.exec(
+      "git fetch origin feature",
+      "/vercel/sandbox",
+      5_000,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      exitCode: 128,
+      stdout: "",
+      stderr: "fatal: couldn't find remote ref feature\n",
+      truncated: false,
+    });
   });
 });
 
@@ -472,6 +504,7 @@ describe("VercelSandbox.execDetached", () => {
     runCommandMock = async () => ({
       cmdId: "cmd-detached-running",
       stdout: async () => "",
+      stderr: async () => "",
       wait: async () => await new Promise<MockWaitResult>(() => {}),
     });
 
@@ -508,6 +541,7 @@ describe("VercelSandbox.execDetached", () => {
     runCommandMock = async () => ({
       cmdId: "cmd-detached-error",
       stdout: async () => "",
+      stderr: async () => "",
       wait: async () => {
         throw new Error("wait failed");
       },
@@ -527,6 +561,7 @@ describe("VercelSandbox.execDetached", () => {
     runCommandMock = async () => ({
       cmdId: "cmd-detached-fail",
       stdout: async () => "",
+      stderr: async () => "",
       wait: async () => ({
         exitCode: 1,
         stdout: async () => "",

--- a/packages/sandbox/vercel/sandbox.ts
+++ b/packages/sandbox/vercel/sandbox.ts
@@ -156,6 +156,20 @@ function getRemainingTimeoutFromSession(
   return remaining > 10_000 ? remaining : undefined;
 }
 
+function truncateCommandOutput(output: string): {
+  output: string;
+  truncated: boolean;
+} {
+  if (output.length <= MAX_OUTPUT_LENGTH) {
+    return { output, truncated: false };
+  }
+
+  return {
+    output: output.slice(0, MAX_OUTPUT_LENGTH),
+    truncated: true,
+  };
+}
+
 /**
  * Vercel Sandbox implementation using the @vercel/sandbox SDK.
  * Runs code in isolated Firecracker MicroVMs.
@@ -901,20 +915,19 @@ ${hostLine}${portLines}${runtimeEnvLine}`;
         signal,
       });
 
-      let stdout = await result.stdout();
-      let truncated = false;
-
-      if (stdout.length > MAX_OUTPUT_LENGTH) {
-        stdout = stdout.slice(0, MAX_OUTPUT_LENGTH);
-        truncated = true;
-      }
+      const [rawStdout, rawStderr] = await Promise.all([
+        result.stdout(),
+        result.stderr(),
+      ]);
+      const stdout = truncateCommandOutput(rawStdout);
+      const stderr = truncateCommandOutput(rawStderr);
 
       return {
         success: result.exitCode === 0,
         exitCode: result.exitCode,
-        stdout,
-        stderr: "", // Vercel SDK combines stdout/stderr
-        truncated,
+        stdout: stdout.output,
+        stderr: stderr.output,
+        truncated: stdout.truncated || stderr.truncated,
       };
     } catch (error) {
       if (error instanceof Error && error.name === "TimeoutError") {


### PR DESCRIPTION
## Summary
- Preserve `stderr` from sandbox command execution so Git failures surface their real cause instead of `Git command failed`
- Force-refresh the remote tracking ref during pre-commit sync and disable interactive Git prompts
- Add regression coverage for fetch failures and stderr preservation

## Testing
- Added targeted unit coverage for sandbox git sync and Vercel sandbox command output handling
- `bun run check` passed
- `bun run ci` passed