### PR TITLE
Start sandbox provisioning on session create

### DIFF
--- a/apps/web/app/api/sessions/route.test.ts
+++ b/apps/web/app/api/sessions/route.test.ts
@@ -23,6 +23,7 @@ let matchingProjects: VercelProjectSelection[] = [];
 let matchingProjectsError: Error | null = null;
 const createCalls: Array<Record<string, unknown>> = [];
 const upsertCalls: Array<Record<string, unknown>> = [];
+const provisioningKickCalls: string[] = [];
 
 const originalNodeEnv = process.env.NODE_ENV;
 
@@ -101,6 +102,13 @@ mock.module("@/lib/db/sessions", () => ({
   getUsedSessionTitles: async () => new Set<string>(),
 }));
 
+mock.module("@/lib/sandbox/provisioning-kick", () => ({
+  kickSandboxProvisioningWorkflow: async (sessionId: string) => {
+    provisioningKickCalls.push(sessionId);
+    return { status: "started", runId: `provision-${sessionId}` };
+  },
+}));
+
 const routeModulePromise = import("./route");
 
 function createJsonRequest(
@@ -134,6 +142,7 @@ describe("/api/sessions POST vercel project linking", () => {
     matchingProjectsError = null;
     createCalls.length = 0;
     upsertCalls.length = 0;
+    provisioningKickCalls.length = 0;
   });
 
   test("blocks additional sessions for managed template trial users", async () => {
@@ -251,6 +260,7 @@ describe("/api/sessions POST vercel project linking", () => {
     });
     expect(body.session.vercelProjectId).toBe("project-1");
     expect(body.session.vercelProjectName).toBe("app");
+    expect(provisioningKickCalls).toEqual([String(body.session.id)]);
   });
 
   test("rejects explicit Vercel projects that are not a live match for the repo", async () => {

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -19,6 +19,7 @@ import {
   parseGitHubHttpsUrl,
 } from "@/lib/github/urls";
 import { checkRateLimit, rateLimitKey } from "@/lib/rate-limit";
+import { kickSandboxProvisioningWorkflow } from "@/lib/sandbox/provisioning-kick";
 import { getRandomCityName } from "@/lib/random-city";
 import { getServerSession } from "@/lib/session/get-server-session";
 import {
@@ -402,6 +403,13 @@ export async function POST(req: Request) {
         title: "New chat",
         modelId: preferences.defaultModelId,
       },
+    });
+
+    await kickSandboxProvisioningWorkflow(result.session.id).catch((error) => {
+      console.error(
+        `Failed to kick sandbox provisioning for session ${result.session.id}:`,
+        error,
+      );
     });
 
     return Response.json(result);

--- a/apps/web/app/workflows/chat-sandbox-runtime.ts
+++ b/apps/web/app/workflows/chat-sandbox-runtime.ts
@@ -7,35 +7,13 @@ import {
 import type { UIMessageChunk } from "ai";
 import { getWritable } from "workflow";
 import type { WebAgentWorkspaceStatusData } from "@/app/types";
-import { getSessionById, updateSession } from "@/lib/db/sessions";
+import { getSessionById } from "@/lib/db/sessions";
 import {
-  verifyRepoAccess,
-  getRepoAccessErrorMessage,
-} from "@/lib/github/access";
-import {
-  mintInstallationToken,
-  revokeInstallationToken,
-  type ScopedInstallationToken,
-} from "@/lib/github/app";
-import { getGitHubUserProfile } from "@/lib/github/users";
-import {
-  buildActiveLifecycleUpdate,
-  getNextLifecycleVersion,
-} from "@/lib/sandbox/lifecycle";
-import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
-import {
-  DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
-  DEFAULT_SANDBOX_PORTS,
-  DEFAULT_SANDBOX_TIMEOUT_MS,
-  DEFAULT_SANDBOX_VCPUS,
-} from "@/lib/sandbox/config";
-import {
-  getResumableSandboxName,
-  getSessionSandboxName,
-  isSandboxActive,
-} from "@/lib/sandbox/utils";
+  kickSandboxProvisioningWorkflow,
+  waitForSandboxProvisioningRun,
+} from "@/lib/sandbox/provisioning-kick";
+import { isSandboxActive } from "@/lib/sandbox/utils";
 import { getSandboxSkillDirectories } from "@/lib/skills/directories";
-import { installGlobalSkills } from "@/lib/skills/global-skill-installer";
 import { getCachedSkills, setCachedSkills } from "@/lib/skills-cache";
 
 type SessionRecord = NonNullable<Awaited<ReturnType<typeof getSessionById>>>;
@@ -52,85 +30,6 @@ export type ResolvedChatSandboxRuntime = {
   repoOwner?: string;
   repoName?: string;
 };
-
-function isSandboxState(value: unknown): value is SandboxState {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "type" in value &&
-    value.type === "vercel"
-  );
-}
-
-function buildSandboxSource(session: SessionRecord): SandboxState["source"] {
-  if (!session.cloneUrl) {
-    return undefined;
-  }
-
-  const branchExistsOnOrigin = session.prNumber != null;
-  const shouldCreateNewBranch = session.isNewBranch && !branchExistsOnOrigin;
-
-  return {
-    repo: session.cloneUrl,
-    ...(shouldCreateNewBranch
-      ? { newBranch: session.branch ?? undefined }
-      : { branch: session.branch ?? "main" }),
-  };
-}
-
-function buildSandboxState(session: SessionRecord): SandboxState {
-  const existingState = session.sandboxState;
-  const sandboxName =
-    getResumableSandboxName(existingState) ?? getSessionSandboxName(session.id);
-  const source = buildSandboxSource(session);
-
-  return {
-    type: "vercel",
-    ...(isSandboxState(existingState) ? existingState : {}),
-    sandboxName,
-    ...(source ? { source } : {}),
-  };
-}
-
-async function getGitUser(userId: string) {
-  const profile = await getGitHubUserProfile(userId);
-  const githubNoreplyEmail =
-    profile?.externalUserId && profile.username
-      ? `${profile.externalUserId}+${profile.username}@users.noreply.github.com`
-      : undefined;
-
-  return {
-    name: profile?.username ?? "Open Harness",
-    email: githubNoreplyEmail ?? `${userId}@users.noreply.github.com`,
-  };
-}
-
-async function installSessionGlobalSkills(params: {
-  session: SessionRecord;
-  sandbox: Sandbox;
-  didSetupWorkspace: boolean;
-}): Promise<void> {
-  if (!params.didSetupWorkspace) {
-    return;
-  }
-
-  const globalSkillRefs = params.session.globalSkillRefs ?? [];
-  if (globalSkillRefs.length === 0) {
-    return;
-  }
-
-  try {
-    await installGlobalSkills({
-      sandbox: params.sandbox,
-      globalSkillRefs,
-    });
-  } catch (error) {
-    console.error(
-      `Failed to install global skills for session ${params.session.id}:`,
-      error,
-    );
-  }
-}
 
 async function loadSessionSkills(params: {
   sessionId: string;
@@ -153,6 +52,40 @@ async function loadSessionSkills(params: {
     discoveredSkills,
   );
   return discoveredSkills;
+}
+
+async function getReadySessionSandbox(params: {
+  sessionId: string;
+  userId: string;
+}): Promise<{ session: SessionRecord; didSetupWorkspace: boolean }> {
+  let session = await getSessionById(params.sessionId);
+  if (!session) {
+    throw new Error("Session not found");
+  }
+  if (session.userId !== params.userId) {
+    throw new Error("Unauthorized");
+  }
+  if (session.status === "archived") {
+    throw new Error("Session is archived");
+  }
+  if (isSandboxActive(session.sandboxState)) {
+    return { session, didSetupWorkspace: false };
+  }
+
+  const kick = await kickSandboxProvisioningWorkflow(params.sessionId);
+  if (kick.runId) {
+    await waitForSandboxProvisioningRun(kick.runId);
+  }
+
+  session = await getSessionById(params.sessionId);
+  if (!session) {
+    throw new Error("Session not found");
+  }
+  if (!isSandboxActive(session.sandboxState)) {
+    throw new Error(session.lifecycleError ?? "Workspace setup failed");
+  }
+
+  return { session, didSetupWorkspace: true };
 }
 
 async function sendWorkspaceStatus(data: WebAgentWorkspaceStatusData) {
@@ -187,95 +120,24 @@ export async function resolveChatSandboxRuntime(params: {
 
   await sendStart(params.assistantId);
 
-  const session = await getSessionById(params.sessionId);
-  if (!session) {
-    throw new Error("Session not found");
-  }
-  if (session.userId !== params.userId) {
-    throw new Error("Unauthorized");
-  }
-  if (session.status === "archived") {
-    throw new Error("Session is archived");
-  }
-
-  const didSetupWorkspace = !isSandboxActive(session.sandboxState);
-  if (didSetupWorkspace) {
+  const initialSession = await getSessionById(params.sessionId);
+  const shouldWaitForSetup = !isSandboxActive(initialSession?.sandboxState);
+  if (shouldWaitForSetup) {
     await sendWorkspaceStatus({
       status: "setting-up",
       message: "Setting up the workspace...",
     });
   }
 
-  const gitUser = await getGitUser(params.userId);
-  let setupToken: ScopedInstallationToken | undefined;
-
-  if (session.cloneUrl) {
-    if (!session.repoOwner || !session.repoName) {
-      throw new Error("Session is missing repository metadata");
-    }
-
-    const access = await verifyRepoAccess({
-      userId: params.userId,
-      owner: session.repoOwner,
-      repo: session.repoName,
-    });
-    if (!access.ok) {
-      throw new Error(getRepoAccessErrorMessage(access.reason));
-    }
-
-    setupToken = await mintInstallationToken({
-      installationId: access.installationId,
-      repositoryIds: [access.repositoryId],
-      permissions: { contents: "read" },
-    });
-  }
-
-  let sandbox: Sandbox;
-  try {
-    sandbox = await connectSandbox({
-      state: buildSandboxState(session),
-      options: {
-        githubToken: setupToken?.token,
-        gitUser,
-        timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
-        vcpus: DEFAULT_SANDBOX_VCPUS,
-        ports: DEFAULT_SANDBOX_PORTS,
-        baseSnapshotId: DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
-        persistent: true,
-        resume: true,
-        createIfMissing: true,
-      },
-    });
-  } finally {
-    if (setupToken) {
-      await revokeInstallationToken(setupToken.token);
-    }
-  }
-
-  const rawSandboxState = sandbox.getState?.();
-  const sandboxState = isSandboxState(rawSandboxState)
-    ? rawSandboxState
-    : buildSandboxState(session);
-
-  await Promise.all([
-    updateSession(params.sessionId, {
-      sandboxState,
-      snapshotUrl: null,
-      snapshotCreatedAt: null,
-      lifecycleVersion: getNextLifecycleVersion(session.lifecycleVersion),
-      ...buildActiveLifecycleUpdate(sandboxState),
-    }),
-    installSessionGlobalSkills({
-      session,
-      sandbox,
-      didSetupWorkspace,
-    }),
-  ]);
-
-  kickSandboxLifecycleWorkflow({
+  const { session, didSetupWorkspace } = await getReadySessionSandbox({
     sessionId: params.sessionId,
-    reason: "sandbox-created",
+    userId: params.userId,
   });
+  const sandboxState = session.sandboxState;
+  if (!sandboxState) {
+    throw new Error("Workspace setup failed");
+  }
+  const sandbox = await connectSandbox(sandboxState);
 
   const skills = await loadSessionSkills({
     sessionId: params.sessionId,

--- a/apps/web/app/workflows/sandbox-provisioning.ts
+++ b/apps/web/app/workflows/sandbox-provisioning.ts
@@ -5,7 +5,10 @@ import {
   getSessionById,
   updateSession,
 } from "@/lib/db/sessions";
-import { provisionSessionSandbox } from "@/lib/sandbox/provisioning";
+import {
+  provisionSessionSandbox,
+  SessionArchivedDuringProvisioningError,
+} from "@/lib/sandbox/provisioning";
 
 async function runProvisioning(sessionId: string, runId: string) {
   "use step";
@@ -34,6 +37,11 @@ async function runProvisioning(sessionId: string, runId: string) {
       sandboxState: result.sandboxState,
     };
   } catch (error) {
+    if (error instanceof SessionArchivedDuringProvisioningError) {
+      await clearSessionSandboxProvisioningRunIdIfOwned(sessionId, runId);
+      return { skipped: true, reason: "session-archived" };
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     await updateSession(sessionId, {
       lifecycleState: "failed",

--- a/apps/web/app/workflows/sandbox-provisioning.ts
+++ b/apps/web/app/workflows/sandbox-provisioning.ts
@@ -1,0 +1,52 @@
+import { getWorkflowMetadata } from "workflow";
+import {
+  claimSessionSandboxProvisioningRunId,
+  clearSessionSandboxProvisioningRunIdIfOwned,
+  getSessionById,
+  updateSession,
+} from "@/lib/db/sessions";
+import { provisionSessionSandbox } from "@/lib/sandbox/provisioning";
+
+async function runProvisioning(sessionId: string, runId: string) {
+  "use step";
+
+  const session = await getSessionById(sessionId);
+  if (!session) {
+    return { skipped: true, reason: "session-not-found" };
+  }
+  if (session.sandboxProvisioningRunId === null) {
+    const claimed = await claimSessionSandboxProvisioningRunId(
+      sessionId,
+      runId,
+    );
+    if (!claimed) {
+      return { skipped: true, reason: "run-replaced" };
+    }
+  } else if (session.sandboxProvisioningRunId !== runId) {
+    return { skipped: true, reason: "run-replaced" };
+  }
+
+  try {
+    const result = await provisionSessionSandbox({ sessionId });
+    await clearSessionSandboxProvisioningRunIdIfOwned(sessionId, runId);
+    return {
+      skipped: false,
+      sandboxState: result.sandboxState,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await updateSession(sessionId, {
+      lifecycleState: "failed",
+      lifecycleError: message,
+    });
+    await clearSessionSandboxProvisioningRunIdIfOwned(sessionId, runId);
+    throw error;
+  }
+}
+
+export async function sandboxProvisioningWorkflow(sessionId: string) {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+  return runProvisioning(sessionId, workflowRunId);
+}

--- a/apps/web/lib/db/migrations/0036_faulty_yellow_claw.sql
+++ b/apps/web/lib/db/migrations/0036_faulty_yellow_claw.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "sandbox_provisioning_run_id" text;

--- a/apps/web/lib/db/migrations/meta/0036_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0036_snapshot.json
@@ -1,0 +1,1591 @@
+{
+  "id": "43c6497a-ed2b-472e-8eb9-ffa907c2b669",
+  "prevId": "658fc007-9ce5-461d-86a6-0d256e413d2d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_messages_chat_id_chats_id_fk": {
+          "name": "chat_messages_chat_id_chats_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_reads": {
+      "name": "chat_reads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_reads_chat_id_idx": {
+          "name": "chat_reads_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_reads_user_id_users_id_fk": {
+          "name": "chat_reads_user_id_users_id_fk",
+          "tableFrom": "chat_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_reads_chat_id_chats_id_fk": {
+          "name": "chat_reads_chat_id_chats_id_fk",
+          "tableFrom": "chat_reads",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_reads_user_id_chat_id_pk": {
+          "name": "chat_reads_user_id_chat_id_pk",
+          "columns": ["user_id", "chat_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'anthropic/claude-haiku-4.5'"
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_assistant_message_at": {
+          "name": "last_assistant_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_session_id_idx": {
+          "name": "chats_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_session_id_sessions_id_fk": {
+          "name": "chats_session_id_sessions_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_url": {
+          "name": "installation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_user_installation_idx": {
+          "name": "github_installations_user_installation_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_user_account_idx": {
+          "name": "github_installations_user_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_user_id_users_id_fk": {
+          "name": "github_installations_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_team_slug": {
+          "name": "vercel_team_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new_branch": {
+          "name": "is_new_branch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_commit_push_override": {
+          "name": "auto_commit_push_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_create_pr_override": {
+          "name": "auto_create_pr_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_skill_refs": {
+          "name": "global_skill_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sandbox_state": {
+          "name": "sandbox_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_version": {
+          "name": "lifecycle_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_expires_at": {
+          "name": "sandbox_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hibernate_after": {
+          "name": "hibernate_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_run_id": {
+          "name": "lifecycle_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_provisioning_run_id": {
+          "name": "sandbox_provisioning_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_error": {
+          "name": "lifecycle_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines_added": {
+          "name": "lines_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lines_removed": {
+          "name": "lines_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_url": {
+          "name": "snapshot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_size_bytes": {
+          "name": "snapshot_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_diff": {
+          "name": "cached_diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_diff_updated_at": {
+          "name": "cached_diff_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shares": {
+      "name": "shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shares_chat_id_idx": {
+          "name": "shares_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shares_chat_id_chats_id_fk": {
+          "name": "shares_chat_id_chats_id_fk",
+          "tableFrom": "shares",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_events": {
+      "name": "usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "usage_events_user_id_users_id_fk": {
+          "name": "usage_events_user_id_users_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model_id": {
+          "name": "default_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'anthropic/claude-haiku-4.5'"
+        },
+        "default_subagent_model_id": {
+          "name": "default_subagent_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sandbox_type": {
+          "name": "default_sandbox_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'vercel'"
+        },
+        "default_diff_mode": {
+          "name": "default_diff_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unified'"
+        },
+        "auto_commit_push": {
+          "name": "auto_commit_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_create_pr": {
+          "name": "auto_create_pr",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "alerts_enabled": {
+          "name": "alerts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "alert_sound_enabled": {
+          "name": "alert_sound_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_usage_enabled": {
+          "name": "public_usage_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "global_skill_refs": {
+          "name": "global_skill_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_variants": {
+          "name": "model_variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "enabled_model_ids": {
+          "name": "enabled_model_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_project_links": {
+      "name": "vercel_project_links",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_slug": {
+          "name": "team_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vercel_project_links_user_id_users_id_fk": {
+          "name": "vercel_project_links_user_id_users_id_fk",
+          "tableFrom": "vercel_project_links",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vercel_project_links_user_id_repo_owner_repo_name_pk": {
+          "name": "vercel_project_links_user_id_repo_owner_repo_name_pk",
+          "columns": ["user_id", "repo_owner", "repo_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_steps": {
+      "name": "workflow_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_finish_reason": {
+          "name": "raw_finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_run_steps_run_id_idx": {
+          "name": "workflow_run_steps_run_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_steps_run_step_idx": {
+          "name": "workflow_run_steps_run_step_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_steps_workflow_run_id_workflow_runs_id_fk": {
+          "name": "workflow_run_steps_workflow_run_id_workflow_runs_id_fk",
+          "tableFrom": "workflow_run_steps",
+          "tableTo": "workflow_runs",
+          "columnsFrom": ["workflow_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_chat_id_idx": {
+          "name": "workflow_runs_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_session_id_idx": {
+          "name": "workflow_runs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_user_id_idx": {
+          "name": "workflow_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_chat_id_chats_id_fk": {
+          "name": "workflow_runs_chat_id_chats_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_runs_session_id_sessions_id_fk": {
+          "name": "workflow_runs_session_id_sessions_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_runs_user_id_users_id_fk": {
+          "name": "workflow_runs_user_id_users_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1776850100000,
       "tag": "0035_secret_peter_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1778835412125,
+      "tag": "0036_faulty_yellow_claw",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -176,6 +176,7 @@ export const sessions = pgTable(
     sandboxExpiresAt: timestamp("sandbox_expires_at"),
     hibernateAfter: timestamp("hibernate_after"),
     lifecycleRunId: text("lifecycle_run_id"),
+    sandboxProvisioningRunId: text("sandbox_provisioning_run_id"),
     lifecycleError: text("lifecycle_error"),
     // Git stats (for display in session list)
     linesAdded: integer("lines_added").default(0),

--- a/apps/web/lib/db/sessions.ts
+++ b/apps/web/lib/db/sessions.ts
@@ -315,6 +315,28 @@ export async function updateSession(
   return session ? normalizeSessionRecord(session) : session;
 }
 
+export async function updateSessionIfNotArchived(
+  sessionId: string,
+  data: Partial<Omit<NewSession, "id" | "userId" | "createdAt">>,
+) {
+  const [session] = await db
+    .update(sessions)
+    .set({ ...data, updatedAt: new Date() })
+    .where(
+      and(
+        eq(sessions.id, sessionId),
+        ne(sessions.status, "archived"),
+        or(
+          isNull(sessions.lifecycleState),
+          ne(sessions.lifecycleState, "archived"),
+        ),
+      ),
+    )
+    .returning();
+
+  return session ? normalizeSessionRecord(session) : session;
+}
+
 /**
  * Atomically claims the session lifecycle lease when no run is currently
  * recorded. Returns true when the claim succeeds.

--- a/apps/web/lib/db/sessions.ts
+++ b/apps/web/lib/db/sessions.ts
@@ -110,6 +110,10 @@ export async function getSessionById(sessionId: string) {
   return session ? normalizeSessionRecord(session) : session;
 }
 
+export type SessionRecord = NonNullable<
+  Awaited<ReturnType<typeof getSessionById>>
+>;
+
 export async function getShareById(shareId: string) {
   return db.query.shares.findFirst({
     where: eq(shares.id, shareId),
@@ -323,6 +327,46 @@ export async function claimSessionLifecycleRunId(
     .update(sessions)
     .set({ lifecycleRunId: runId, updatedAt: new Date() })
     .where(and(eq(sessions.id, sessionId), isNull(sessions.lifecycleRunId)))
+    .returning({ id: sessions.id });
+
+  return Boolean(updated);
+}
+
+/**
+ * Atomically claims the session sandbox provisioning lease when no run is
+ * currently recorded. Returns true when the claim succeeds.
+ */
+export async function claimSessionSandboxProvisioningRunId(
+  sessionId: string,
+  runId: string,
+) {
+  const [updated] = await db
+    .update(sessions)
+    .set({ sandboxProvisioningRunId: runId, updatedAt: new Date() })
+    .where(
+      and(
+        eq(sessions.id, sessionId),
+        isNull(sessions.sandboxProvisioningRunId),
+      ),
+    )
+    .returning({ id: sessions.id });
+
+  return Boolean(updated);
+}
+
+export async function clearSessionSandboxProvisioningRunIdIfOwned(
+  sessionId: string,
+  runId: string,
+) {
+  const [updated] = await db
+    .update(sessions)
+    .set({ sandboxProvisioningRunId: null, updatedAt: new Date() })
+    .where(
+      and(
+        eq(sessions.id, sessionId),
+        eq(sessions.sandboxProvisioningRunId, runId),
+      ),
+    )
     .returning({ id: sessions.id });
 
   return Boolean(updated);

--- a/apps/web/lib/sandbox/provisioning-kick.ts
+++ b/apps/web/lib/sandbox/provisioning-kick.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { start, getRun } from "workflow/api";
 import { sandboxProvisioningWorkflow } from "@/app/workflows/sandbox-provisioning";
 import {
+  clearSessionSandboxProvisioningRunIdIfOwned,
   claimSessionSandboxProvisioningRunId,
   getSessionById,
   updateSession,
@@ -54,7 +55,22 @@ export async function kickSandboxProvisioningWorkflow(
         runId: session.sandboxProvisioningRunId,
       };
     }
-    await updateSession(sessionId, { sandboxProvisioningRunId: null });
+    const cleared = await clearSessionSandboxProvisioningRunIdIfOwned(
+      sessionId,
+      session.sandboxProvisioningRunId,
+    );
+    if (!cleared) {
+      const latest = await getSessionById(sessionId);
+      if (!latest || latest.status === "archived") {
+        return { status: "skipped" };
+      }
+      if (isSandboxActive(latest.sandboxState)) {
+        return { status: "active" };
+      }
+      if (latest.sandboxProvisioningRunId) {
+        return { status: "existing", runId: latest.sandboxProvisioningRunId };
+      }
+    }
   }
 
   const run = await start(sandboxProvisioningWorkflow, [sessionId]);

--- a/apps/web/lib/sandbox/provisioning-kick.ts
+++ b/apps/web/lib/sandbox/provisioning-kick.ts
@@ -1,0 +1,97 @@
+import "server-only";
+
+import { start, getRun } from "workflow/api";
+import { sandboxProvisioningWorkflow } from "@/app/workflows/sandbox-provisioning";
+import {
+  claimSessionSandboxProvisioningRunId,
+  getSessionById,
+  updateSession,
+} from "@/lib/db/sessions";
+import { isSandboxActive } from "@/lib/sandbox/utils";
+
+type KickSandboxProvisioningResult =
+  | {
+      status: "started" | "existing";
+      runId: string;
+    }
+  | {
+      status: "active" | "skipped";
+      runId?: undefined;
+    };
+
+async function isRunStillLive(runId: string): Promise<boolean> {
+  try {
+    const run = getRun(runId);
+    if (!(await run.exists)) {
+      return false;
+    }
+    const status = await run.status;
+    return status === "pending" || status === "running";
+  } catch {
+    return false;
+  }
+}
+
+export async function kickSandboxProvisioningWorkflow(
+  sessionId: string,
+): Promise<KickSandboxProvisioningResult> {
+  const session = await getSessionById(sessionId);
+  if (!session) {
+    return { status: "skipped" };
+  }
+  if (session.status === "archived") {
+    return { status: "skipped" };
+  }
+  if (isSandboxActive(session.sandboxState)) {
+    return { status: "active" };
+  }
+
+  if (session.sandboxProvisioningRunId) {
+    const live = await isRunStillLive(session.sandboxProvisioningRunId);
+    if (live) {
+      return {
+        status: "existing",
+        runId: session.sandboxProvisioningRunId,
+      };
+    }
+    await updateSession(sessionId, { sandboxProvisioningRunId: null });
+  }
+
+  const run = await start(sandboxProvisioningWorkflow, [sessionId]);
+  const claimed = await claimSessionSandboxProvisioningRunId(
+    sessionId,
+    run.runId,
+  );
+  if (claimed) {
+    await updateSession(sessionId, {
+      lifecycleState: "provisioning",
+      lifecycleError: null,
+    });
+    return { status: "started", runId: run.runId };
+  }
+
+  const latest = await getSessionById(sessionId);
+  if (latest?.sandboxProvisioningRunId === run.runId) {
+    await updateSession(sessionId, {
+      lifecycleState: "provisioning",
+      lifecycleError: null,
+    });
+    return { status: "started", runId: run.runId };
+  }
+  if (latest?.sandboxProvisioningRunId) {
+    return { status: "existing", runId: latest.sandboxProvisioningRunId };
+  }
+
+  try {
+    getRun(run.runId).cancel();
+  } catch {
+    // Best-effort cleanup for a duplicate run.
+  }
+
+  return { status: "skipped" };
+}
+
+export async function waitForSandboxProvisioningRun(runId: string) {
+  const run = getRun(runId);
+  return run.returnValue;
+}

--- a/apps/web/lib/sandbox/provisioning.ts
+++ b/apps/web/lib/sandbox/provisioning.ts
@@ -1,0 +1,266 @@
+import "server-only";
+
+import {
+  connectSandbox,
+  type Sandbox,
+  type SandboxState,
+} from "@open-agents/sandbox";
+import {
+  getSessionById,
+  updateSession,
+  type SessionRecord,
+} from "@/lib/db/sessions";
+import { db } from "@/lib/db/client";
+import { users } from "@/lib/db/schema";
+import {
+  verifyRepoAccess,
+  getRepoAccessErrorMessage,
+} from "@/lib/github/access";
+import {
+  mintInstallationToken,
+  revokeInstallationToken,
+  type ScopedInstallationToken,
+} from "@/lib/github/app";
+import { getGitHubUserProfile } from "@/lib/github/users";
+import {
+  DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
+  DEFAULT_SANDBOX_PORTS,
+  DEFAULT_SANDBOX_TIMEOUT_MS,
+  DEFAULT_SANDBOX_VCPUS,
+} from "@/lib/sandbox/config";
+import {
+  buildActiveLifecycleUpdate,
+  getNextLifecycleVersion,
+} from "@/lib/sandbox/lifecycle";
+import { kickSandboxLifecycleWorkflow } from "@/lib/sandbox/lifecycle-kick";
+import {
+  getResumableSandboxName,
+  getSessionSandboxName,
+  isSandboxActive,
+} from "@/lib/sandbox/utils";
+import { installGlobalSkills } from "@/lib/skills/global-skill-installer";
+import { eq } from "drizzle-orm";
+
+type UserRecord = {
+  id: string;
+  username: string;
+  name: string | null;
+  email: string | null;
+};
+
+export type ProvisionSessionSandboxResult = {
+  sandboxState: SandboxState;
+  workingDirectory: string;
+  currentBranch?: string;
+  environmentDetails?: string;
+  didSetupWorkspace: boolean;
+  session: SessionRecord;
+};
+
+function isSandboxState(value: unknown): value is SandboxState {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "vercel"
+  );
+}
+
+async function getUserById(userId: string): Promise<UserRecord | null> {
+  const [user] = await db
+    .select({
+      id: users.id,
+      username: users.username,
+      name: users.name,
+      email: users.email,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  return user ?? null;
+}
+
+function buildSandboxSource(session: SessionRecord): SandboxState["source"] {
+  if (!session.cloneUrl) {
+    return undefined;
+  }
+
+  const branchExistsOnOrigin = session.prNumber != null;
+  const shouldCreateNewBranch = session.isNewBranch && !branchExistsOnOrigin;
+
+  return {
+    repo: session.cloneUrl,
+    ...(shouldCreateNewBranch
+      ? { newBranch: session.branch ?? undefined }
+      : { branch: session.branch ?? "main" }),
+  };
+}
+
+function buildSandboxState(session: SessionRecord): SandboxState {
+  const existingState = session.sandboxState;
+  const sandboxName =
+    getResumableSandboxName(existingState) ?? getSessionSandboxName(session.id);
+  const source = buildSandboxSource(session);
+
+  return {
+    type: "vercel",
+    ...(isSandboxState(existingState) ? existingState : {}),
+    sandboxName,
+    ...(source ? { source } : {}),
+  };
+}
+
+async function getGitUser(user: UserRecord) {
+  const profile = await getGitHubUserProfile(user.id);
+  const githubNoreplyEmail =
+    profile?.externalUserId && profile.username
+      ? `${profile.externalUserId}+${profile.username}@users.noreply.github.com`
+      : undefined;
+
+  return {
+    name: user.name ?? profile?.username ?? user.username,
+    email:
+      githubNoreplyEmail ??
+      user.email ??
+      `${user.username}@users.noreply.github.com`,
+  };
+}
+
+async function getSetupToken(params: {
+  userId: string;
+  session: SessionRecord;
+}): Promise<ScopedInstallationToken | undefined> {
+  if (!params.session.cloneUrl) {
+    return undefined;
+  }
+  if (!params.session.repoOwner || !params.session.repoName) {
+    throw new Error("Session is missing repository metadata");
+  }
+
+  const access = await verifyRepoAccess({
+    userId: params.userId,
+    owner: params.session.repoOwner,
+    repo: params.session.repoName,
+  });
+  if (!access.ok) {
+    throw new Error(getRepoAccessErrorMessage(access.reason));
+  }
+
+  return mintInstallationToken({
+    installationId: access.installationId,
+    repositoryIds: [access.repositoryId],
+    permissions: { contents: "read" },
+  });
+}
+
+async function installSessionGlobalSkills(params: {
+  session: SessionRecord;
+  sandbox: Sandbox;
+  didSetupWorkspace: boolean;
+}): Promise<void> {
+  if (!params.didSetupWorkspace) {
+    return;
+  }
+
+  const globalSkillRefs = params.session.globalSkillRefs ?? [];
+  if (globalSkillRefs.length === 0) {
+    return;
+  }
+
+  try {
+    await installGlobalSkills({
+      sandbox: params.sandbox,
+      globalSkillRefs,
+    });
+  } catch (error) {
+    console.error(
+      `Failed to install global skills for session ${params.session.id}:`,
+      error,
+    );
+  }
+}
+
+export async function provisionSessionSandbox(params: {
+  sessionId: string;
+  userId?: string;
+}): Promise<ProvisionSessionSandboxResult> {
+  const session = await getSessionById(params.sessionId);
+  if (!session) {
+    throw new Error("Session not found");
+  }
+  if (params.userId && session.userId !== params.userId) {
+    throw new Error("Unauthorized");
+  }
+  if (session.status === "archived") {
+    throw new Error("Session is archived");
+  }
+
+  const didSetupWorkspace = !isSandboxActive(session.sandboxState);
+  const user = await getUserById(session.userId);
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  const gitUser = await getGitUser(user);
+  const setupToken = await getSetupToken({
+    userId: session.userId,
+    session,
+  });
+
+  let sandbox: Sandbox;
+  try {
+    sandbox = await connectSandbox({
+      state: buildSandboxState(session),
+      options: {
+        githubToken: setupToken?.token,
+        gitUser,
+        timeout: DEFAULT_SANDBOX_TIMEOUT_MS,
+        vcpus: DEFAULT_SANDBOX_VCPUS,
+        ports: DEFAULT_SANDBOX_PORTS,
+        baseSnapshotId: DEFAULT_SANDBOX_BASE_SNAPSHOT_ID,
+        persistent: true,
+        resume: true,
+        createIfMissing: true,
+      },
+    });
+  } finally {
+    if (setupToken) {
+      await revokeInstallationToken(setupToken.token);
+    }
+  }
+
+  const rawSandboxState = sandbox.getState?.();
+  const sandboxState = isSandboxState(rawSandboxState)
+    ? rawSandboxState
+    : buildSandboxState(session);
+
+  const updatedSession = await updateSession(params.sessionId, {
+    sandboxState,
+    snapshotUrl: null,
+    snapshotCreatedAt: null,
+    lifecycleVersion: getNextLifecycleVersion(session.lifecycleVersion),
+    lifecycleError: null,
+    ...buildActiveLifecycleUpdate(sandboxState),
+  });
+
+  await installSessionGlobalSkills({
+    session,
+    sandbox,
+    didSetupWorkspace,
+  });
+
+  kickSandboxLifecycleWorkflow({
+    sessionId: params.sessionId,
+    reason: "sandbox-created",
+  });
+
+  return {
+    sandboxState,
+    workingDirectory: sandbox.workingDirectory,
+    currentBranch: sandbox.currentBranch,
+    environmentDetails: sandbox.environmentDetails,
+    didSetupWorkspace,
+    session: updatedSession ?? session,
+  };
+}

--- a/apps/web/lib/sandbox/provisioning.ts
+++ b/apps/web/lib/sandbox/provisioning.ts
@@ -7,7 +7,7 @@ import {
 } from "@open-agents/sandbox";
 import {
   getSessionById,
-  updateSession,
+  updateSessionIfNotArchived,
   type SessionRecord,
 } from "@/lib/db/sessions";
 import { db } from "@/lib/db/client";
@@ -56,6 +56,13 @@ export type ProvisionSessionSandboxResult = {
   didSetupWorkspace: boolean;
   session: SessionRecord;
 };
+
+export class SessionArchivedDuringProvisioningError extends Error {
+  constructor(sessionId: string) {
+    super(`Session ${sessionId} was archived during sandbox provisioning`);
+    this.name = "SessionArchivedDuringProvisioningError";
+  }
+}
 
 function isSandboxState(value: unknown): value is SandboxState {
   return (
@@ -181,6 +188,22 @@ async function installSessionGlobalSkills(params: {
   }
 }
 
+async function stopSandboxAfterArchiveRace(params: {
+  sessionId: string;
+  sandbox: Sandbox;
+}): Promise<never> {
+  try {
+    await params.sandbox.stop();
+  } catch (error) {
+    console.error(
+      `Failed to stop sandbox after session ${params.sessionId} was archived during provisioning:`,
+      error,
+    );
+  }
+
+  throw new SessionArchivedDuringProvisioningError(params.sessionId);
+}
+
 export async function provisionSessionSandbox(params: {
   sessionId: string;
   userId?: string;
@@ -235,7 +258,7 @@ export async function provisionSessionSandbox(params: {
     ? rawSandboxState
     : buildSandboxState(session);
 
-  const updatedSession = await updateSession(params.sessionId, {
+  const updatedSession = await updateSessionIfNotArchived(params.sessionId, {
     sandboxState,
     snapshotUrl: null,
     snapshotCreatedAt: null,
@@ -243,6 +266,13 @@ export async function provisionSessionSandbox(params: {
     lifecycleError: null,
     ...buildActiveLifecycleUpdate(sandboxState),
   });
+
+  if (!updatedSession) {
+    await stopSandboxAfterArchiveRace({
+      sessionId: params.sessionId,
+      sandbox,
+    });
+  }
 
   await installSessionGlobalSkills({
     session,


### PR DESCRIPTION
## Summary
- start sandbox provisioning in the background when a session is created
- add a sandbox provisioning workflow and lease helpers so chat runtime can wait for an existing setup run instead of doing all setup inline
- persist sandbox provisioning state and migration metadata for the new run ID column
- guard stale provisioning lease clears and archive races so duplicate setup or live archived sandboxes are avoided

## Why
New sessions should begin workspace setup before the first chat turn needs the sandbox. That reduces first-message latency while preserving a fallback path where chat runtime waits for the background provisioning run when setup is still in progress.

## Notes
The follow-up commit fixes concurrency edges from review: stale run IDs are cleared only by their owner, and provisioning no longer marks a session active if archive finalization wins the race.

## Validation
- bun run check
- bun run typecheck
- bun run ci