### PR TITLE
Expose sandbox actions with lazy startup

### DIFF
--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/hooks/use-code-editor.ts
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/hooks/use-code-editor.ts
@@ -24,6 +24,8 @@ export interface CodeEditorControls {
   handleStop: () => Promise<void>;
 }
 
+type EnsureSandboxReady = () => Promise<boolean>;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -56,9 +58,11 @@ function parseLaunchResponse(body: unknown): CodeEditorLaunchResponse | null {
 export function useCodeEditor({
   sessionId,
   canRun,
+  ensureSandboxReady,
 }: {
   sessionId: string;
   canRun: boolean;
+  ensureSandboxReady?: EnsureSandboxReady;
 }): CodeEditorControls {
   const router = useRouter();
   const [state, setState] = useState<CodeEditorState>({ status: "idle" });
@@ -134,6 +138,11 @@ export function useCodeEditor({
       setState({ status: "starting" });
 
       try {
+        const sandboxReady = await ensureSandboxReady?.();
+        if (sandboxReady === false) {
+          throw new Error("Failed to start sandbox");
+        }
+
         const response = await fetch(`/api/sessions/${sessionId}/code-editor`, {
           method: "POST",
         });
@@ -167,17 +176,39 @@ export function useCodeEditor({
         });
         return null;
       }
-    }, [sessionId, state]);
+    }, [ensureSandboxReady, sessionId, state]);
 
   const handleOpen = useCallback(async () => {
+    if (state.status === "ready") {
+      const sandboxReady = await ensureSandboxReady?.();
+      if (sandboxReady === false) {
+        setState({ status: "error", message: "Failed to start sandbox" });
+        return;
+      }
+
+      openEditorPage();
+      return;
+    }
+
     const info = await ensureRunning();
     if (info) {
       openEditorPage();
     }
-  }, [ensureRunning, openEditorPage]);
+  }, [ensureRunning, ensureSandboxReady, openEditorPage, state]);
 
   const handleOpenFile = useCallback(
     async (_filePath: string) => {
+      if (state.status === "ready") {
+        const sandboxReady = await ensureSandboxReady?.();
+        if (sandboxReady === false) {
+          setState({ status: "error", message: "Failed to start sandbox" });
+          return;
+        }
+
+        openEditorPage();
+        return;
+      }
+
       const info = await ensureRunning();
       if (info) {
         // Open the codespace page; file-specific deep linking can be added
@@ -185,7 +216,7 @@ export function useCodeEditor({
         openEditorPage();
       }
     },
-    [ensureRunning, openEditorPage],
+    [ensureRunning, ensureSandboxReady, openEditorPage, state],
   );
 
   const handleStop = useCallback(async () => {

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/hooks/use-dev-server.ts
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/hooks/use-dev-server.ts
@@ -19,6 +19,8 @@ export interface DevServerControls {
   handleStopAction: () => Promise<void>;
 }
 
+type EnsureSandboxReady = () => Promise<boolean>;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -56,9 +58,11 @@ function parseLaunchResponse(body: unknown): DevServerLaunchResponse | null {
 export function useDevServer({
   sessionId,
   canRun,
+  ensureSandboxReady,
 }: {
   sessionId: string;
   canRun: boolean;
+  ensureSandboxReady?: EnsureSandboxReady;
 }): DevServerControls {
   const [state, setState] = useState<DevServerLaunchState>({ status: "idle" });
 
@@ -78,6 +82,12 @@ export function useDevServer({
 
   const handlePrimaryAction = useCallback(async () => {
     if (state.status === "ready") {
+      const sandboxReady = await ensureSandboxReady?.();
+      if (sandboxReady === false) {
+        setState({ status: "error", message: "Failed to start sandbox" });
+        return;
+      }
+
       openDevServerUrl(state.info.url);
       return;
     }
@@ -89,6 +99,11 @@ export function useDevServer({
     setState({ status: "starting" });
 
     try {
+      const sandboxReady = await ensureSandboxReady?.();
+      if (sandboxReady === false) {
+        throw new Error("Failed to start sandbox");
+      }
+
       const response = await fetch(`/api/sessions/${sessionId}/dev-server`, {
         method: "POST",
       });
@@ -117,7 +132,7 @@ export function useDevServer({
             : "Failed to launch dev server",
       });
     }
-  }, [openDevServerUrl, sessionId, state]);
+  }, [ensureSandboxReady, openDevServerUrl, sessionId, state]);
 
   const handleStopAction = useCallback(async () => {
     if (state.status !== "ready") {

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -198,6 +198,8 @@ type ReasoningMessagePart = Extract<
   { type: "reasoning" }
 >;
 
+type SandboxReadinessResult = "connected" | "no_sandbox" | "failed";
+
 type MessageRenderGroup =
   | {
       type: "part";
@@ -2152,6 +2154,17 @@ export function SessionChatContent({
     [attemptReconnection, syncSandboxStatus],
   );
 
+  const checkSandboxReadiness =
+    useCallback(async (): Promise<SandboxReadinessResult> => {
+      const result = await attemptReconnection();
+      if (result === "connected" || result === "no_sandbox") {
+        return result;
+      }
+
+      await syncSandboxStatus();
+      return "failed";
+    }, [attemptReconnection, syncSandboxStatus]);
+
   const refreshWorkspaceAfterRestore = useCallback(async () => {
     await requestStatusSync("force").catch(() => undefined);
     await Promise.all([
@@ -2709,8 +2722,18 @@ export function SessionChatContent({
       }
 
       const readyPromise = (async () => {
-        if (isCreatingSandbox || isRestoringSnapshot || isReconnectingSandbox) {
+        if (isCreatingSandbox || isRestoringSnapshot) {
           return waitForSandboxReady(12);
+        }
+
+        if (isReconnectingSandbox) {
+          const readiness = await checkSandboxReadiness();
+          if (readiness === "connected") {
+            return true;
+          }
+          if (readiness === "failed") {
+            return false;
+          }
         }
 
         if (hasSnapshot || hasRuntimeSandboxState || isHibernatingUi) {
@@ -2731,6 +2754,7 @@ export function SessionChatContent({
     }, [
       _handleCreateNewSandbox,
       _handleRestoreSnapshot,
+      checkSandboxReadiness,
       hasRuntimeSandboxState,
       hasSnapshot,
       isArchived,

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/session-chat-content.tsx
@@ -1631,6 +1631,7 @@ export function SessionChatContent({
     lastAt: 0,
   });
   const shouldSkipServerSnapshotOverwriteRef = useRef(false);
+  const sandboxActionReadyPromiseRef = useRef<Promise<boolean> | null>(null);
 
   const refreshCurrentChatSnapshot = useCallback(async (): Promise<void> => {
     if (shouldSkipServerSnapshotOverwriteRef.current) {
@@ -2691,14 +2692,64 @@ export function SessionChatContent({
     !isRestoringSnapshot &&
     !isReconnectingSandbox &&
     !isHibernatingUi;
+  const canUseSandboxActions = !isArchived;
   const canUseCodeEditor = codeEditorDisabledReason === null;
+  const ensureSandboxReadyForAction =
+    useCallback(async (): Promise<boolean> => {
+      if (isSandboxActive) {
+        return true;
+      }
+
+      if (isArchived) {
+        return false;
+      }
+
+      if (sandboxActionReadyPromiseRef.current) {
+        return sandboxActionReadyPromiseRef.current;
+      }
+
+      const readyPromise = (async () => {
+        if (isCreatingSandbox || isRestoringSnapshot || isReconnectingSandbox) {
+          return waitForSandboxReady(12);
+        }
+
+        if (hasSnapshot || hasRuntimeSandboxState || isHibernatingUi) {
+          await _handleRestoreSnapshot();
+        } else {
+          await _handleCreateNewSandbox();
+        }
+
+        return waitForSandboxReady(12);
+      })();
+
+      sandboxActionReadyPromiseRef.current = readyPromise;
+      try {
+        return await readyPromise;
+      } finally {
+        sandboxActionReadyPromiseRef.current = null;
+      }
+    }, [
+      _handleCreateNewSandbox,
+      _handleRestoreSnapshot,
+      hasRuntimeSandboxState,
+      hasSnapshot,
+      isArchived,
+      isCreatingSandbox,
+      isHibernatingUi,
+      isReconnectingSandbox,
+      isRestoringSnapshot,
+      isSandboxActive,
+      waitForSandboxReady,
+    ]);
   const devServer = useDevServer({
     sessionId: session.id,
     canRun: canRunDevServer,
+    ensureSandboxReady: ensureSandboxReadyForAction,
   });
   const codeEditor = useCodeEditor({
     sessionId: session.id,
     canRun: canRunDevServer && canUseCodeEditor,
+    ensureSandboxReady: ensureSandboxReadyForAction,
   });
   const isCodeEditorActionDisabled =
     !canUseCodeEditor ||
@@ -2792,7 +2843,7 @@ export function SessionChatContent({
     prDeploymentUrl ??
     (isDeploymentFailed ? failedDeploymentUrl : null);
   const showHeaderActions =
-    canRunDevServer || Boolean(previewDeploymentTargetUrl);
+    canUseSandboxActions || Boolean(previewDeploymentTargetUrl);
 
   // When auto-commit lands (transitions from committing to clean), mark the
   // current preview deployment as stale so the UI shows "Deploying…" until
@@ -2988,7 +3039,7 @@ export function SessionChatContent({
         showHeaderActions &&
         createPortal(
           <div className="flex items-center gap-1">
-            {canRunDevServer && (
+            {canUseSandboxActions && (
               <>
                 <Tooltip>
                   <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- keep the dev-server and code-editor actions visible whenever the session is not archived
- add a shared readiness path that creates, restores, or reconnects the sandbox before launching those actions
- coalesce concurrent action clicks so only one sandbox startup path runs at a time
- let the first click continue into create or restore when the initial reconnect probe reports no sandbox

## Why
Previously these actions were hidden until the sandbox was already active. That made paused, hibernated, or not-yet-created sessions require a separate sandbox resume/create step before users could launch the dev server or editor.

This change makes those actions self-starting: clicking one handles the needed sandbox lifecycle work first, then proceeds with the requested action.

## Validation
- bun run ci