### PR TITLE
Update Workflow beta stream handling

### DIFF
--- a/apps/web/app/api/chat/[chatId]/stream/route.test.ts
+++ b/apps/web/app/api/chat/[chatId]/stream/route.test.ts
@@ -24,6 +24,7 @@ let sessionRecord: {
 
 let workflowRunStatus: string = "running";
 let getRunShouldThrow = false;
+let lastStartIndex: number | undefined;
 
 const spies = {
   updateChatActiveStreamId: mock(() => Promise.resolve()),
@@ -39,21 +40,36 @@ globalThis.fetch = (async () =>
   })) as unknown as typeof fetch;
 
 mock.module("ai", () => ({
-  createUIMessageStreamResponse: ({ stream }: { stream: ReadableStream }) =>
-    new Response(stream, { status: 200 }),
+  createUIMessageStreamResponse: ({
+    stream,
+    headers,
+  }: {
+    stream: ReadableStream;
+    headers?: HeadersInit;
+  }) => new Response(stream, { status: 200, headers }),
 }));
+
+function createWorkflowReadableStream(startIndex?: number) {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+  return Object.assign(stream, {
+    getTailIndex: () => Promise.resolve(12),
+    startIndex,
+  });
+}
 
 mock.module("workflow/api", () => ({
   getRun: () => {
     if (getRunShouldThrow) throw new Error("Run not found");
     return {
       status: Promise.resolve(workflowRunStatus),
-      getReadable: () =>
-        new ReadableStream({
-          start(controller) {
-            controller.close();
-          },
-        }),
+      getReadable: (options?: { startIndex?: number }) => {
+        lastStartIndex = options?.startIndex;
+        return createWorkflowReadableStream(options?.startIndex);
+      },
     };
   },
 }));
@@ -87,6 +103,16 @@ function createStreamRequest() {
   });
 }
 
+function createStreamRequestWithStartIndex(startIndex: string) {
+  return new Request(
+    `http://localhost/api/chat/chat-1/stream?startIndex=${startIndex}`,
+    {
+      method: "GET",
+      headers: { cookie: "session=abc" },
+    },
+  );
+}
+
 const routeContext = {
   params: Promise.resolve({ chatId: "chat-1" }),
 };
@@ -102,6 +128,7 @@ beforeEach(() => {
   };
   workflowRunStatus = "running";
   getRunShouldThrow = false;
+  lastStartIndex = undefined;
   Object.values(spies).forEach((s) => s.mockClear());
 });
 
@@ -145,7 +172,35 @@ describe("GET /api/chat/[chatId]/stream", () => {
 
     const response = await GET(createStreamRequest(), routeContext);
     expect(response.status).toBe(200);
+    expect(response.headers.get("x-workflow-stream-tail-index")).toBe("12");
+    expect(lastStartIndex).toBeUndefined();
     expect(spies.updateChatActiveStreamId).not.toHaveBeenCalled();
+  });
+
+  test("passes startIndex to workflow stream when reconnecting", async () => {
+    workflowRunStatus = "running";
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(
+      createStreamRequestWithStartIndex("8"),
+      routeContext,
+    );
+
+    expect(response.status).toBe(200);
+    expect(lastStartIndex).toBe(8);
+    expect(response.headers.get("x-workflow-stream-tail-index")).toBe("12");
+  });
+
+  test("rejects invalid startIndex", async () => {
+    const { GET } = await routeModulePromise;
+
+    const response = await GET(
+      createStreamRequestWithStartIndex("invalid"),
+      routeContext,
+    );
+
+    expect(response.status).toBe(400);
+    expect(lastStartIndex).toBeUndefined();
   });
 
   test("returns stream response when workflow is pending", async () => {

--- a/apps/web/app/api/chat/[chatId]/stream/route.ts
+++ b/apps/web/app/api/chat/[chatId]/stream/route.ts
@@ -14,10 +14,42 @@ type RouteContext = {
 
 type WebAgentUIMessageChunk = InferUIMessageChunk<WebAgentUIMessage>;
 
-export async function GET(_request: Request, context: RouteContext) {
+type ParseStartIndexResult =
+  | {
+      ok: true;
+      startIndex: number | undefined;
+    }
+  | {
+      ok: false;
+      response: Response;
+    };
+
+function parseStartIndex(request: Request): ParseStartIndexResult {
+  const startIndexParam = new URL(request.url).searchParams.get("startIndex");
+  if (startIndexParam === null) {
+    return { ok: true, startIndex: undefined };
+  }
+
+  const startIndex = Number.parseInt(startIndexParam, 10);
+  if (Number.isNaN(startIndex)) {
+    return {
+      ok: false,
+      response: new Response("Invalid startIndex", { status: 400 }),
+    };
+  }
+
+  return { ok: true, startIndex };
+}
+
+export async function GET(request: Request, context: RouteContext) {
   const authResult = await requireAuthenticatedUser("text");
   if (!authResult.ok) {
     return authResult.response;
+  }
+
+  const parsedStartIndex = parseStartIndex(request);
+  if (!parsedStartIndex.ok) {
+    return parsedStartIndex.response;
   }
 
   const { chatId } = await context.params;
@@ -53,11 +85,18 @@ export async function GET(_request: Request, context: RouteContext) {
       return new Response(null, { status: 204 });
     }
 
-    const stream = createCancelableReadableStream(
-      run.getReadable<WebAgentUIMessageChunk>(),
-    );
+    const readable = run.getReadable<WebAgentUIMessageChunk>({
+      startIndex: parsedStartIndex.startIndex,
+    });
+    const tailIndex = await readable.getTailIndex();
+    const stream = createCancelableReadableStream(readable);
 
-    return createUIMessageStreamResponse({ stream });
+    return createUIMessageStreamResponse({
+      stream,
+      headers: {
+        "x-workflow-stream-tail-index": String(tailIndex),
+      },
+    });
   } catch {
     // Workflow run not found or inaccessible — clear stale ID.
     await updateChatActiveStreamId(chatId, null);

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/stream-recovery-policy.test.ts
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/stream-recovery-policy.test.ts
@@ -89,7 +89,7 @@ describe("getStreamRecoveryDecision", () => {
     expect(decision).toBe("none");
   });
 
-  test("probes when submitted stream appears stalled", () => {
+  test("does not probe while a submitted stream appears stalled", () => {
     const decision = getStreamRecoveryDecision({
       now,
       lastRecoveryAt: now - STREAM_RECOVERY_MIN_INTERVAL_MS,
@@ -99,7 +99,7 @@ describe("getStreamRecoveryDecision", () => {
       isProbeInFlight: false,
     });
 
-    expect(decision).toBe("probe");
+    expect(decision).toBe("none");
   });
 
   test("probes on visibility recovery when chat is ready", () => {
@@ -146,7 +146,7 @@ describe("getStreamRecoveryDecision", () => {
 });
 
 describe("shouldScheduleStallRecovery", () => {
-  test("requires in-flight status, no content, and visible document", () => {
+  test("does not schedule stall recovery during an active request", () => {
     expect(
       shouldScheduleStallRecovery({
         isChatInFlight: false,
@@ -177,7 +177,7 @@ describe("shouldScheduleStallRecovery", () => {
         hasAssistantRenderableContent: false,
         isDocumentVisible: true,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 

--- a/apps/web/app/sessions/[sessionId]/chats/[chatId]/stream-recovery-policy.ts
+++ b/apps/web/app/sessions/[sessionId]/chats/[chatId]/stream-recovery-policy.ts
@@ -31,12 +31,9 @@ export function getStreamRecoveryDecision(options: {
     now,
     lastRecoveryAt,
     status,
-    hasAssistantRenderableContent,
-    inFlightStartedAt,
     isProbeInFlight,
     isVisibilityRecovery = false,
     minIntervalMs = STREAM_RECOVERY_MIN_INTERVAL_MS,
-    stallMs = STREAM_RECOVERY_STALL_MS,
   } = options;
 
   if (now - lastRecoveryAt < minIntervalMs) {
@@ -57,19 +54,7 @@ export function getStreamRecoveryDecision(options: {
     return "probe";
   }
 
-  if (status !== "submitted" || hasAssistantRenderableContent) {
-    return "none";
-  }
-
-  if (inFlightStartedAt === null || now - inFlightStartedAt < stallMs) {
-    return "none";
-  }
-
-  if (isProbeInFlight) {
-    return "none";
-  }
-
-  return "probe";
+  return "none";
 }
 
 export function shouldScheduleStallRecovery(options: {
@@ -77,10 +62,9 @@ export function shouldScheduleStallRecovery(options: {
   hasAssistantRenderableContent: boolean;
   isDocumentVisible: boolean;
 }): boolean {
-  const { isChatInFlight, hasAssistantRenderableContent, isDocumentVisible } =
-    options;
+  void options;
 
-  return isChatInFlight && !hasAssistantRenderableContent && isDocumentVisible;
+  return false;
 }
 
 export function getStreamRecoveryDelayMs(options: {

--- a/apps/web/lib/abortable-chat-transport.ts
+++ b/apps/web/lib/abortable-chat-transport.ts
@@ -1,16 +1,47 @@
 import type { UIMessage } from "ai";
-import { DefaultChatTransport } from "ai";
+import {
+  WorkflowChatTransport,
+  type WorkflowChatTransportOptions,
+} from "@workflow/ai";
+
+type RequestBody = Record<string, unknown>;
+type RequestBodyFactory = () => RequestBody;
 
 type FetchFunction = typeof globalThis.fetch;
+type AbortableWorkflowChatTransportOptions<UI_MESSAGE extends UIMessage> =
+  WorkflowChatTransportOptions<UI_MESSAGE> & {
+    body?: RequestBody | RequestBodyFactory;
+  };
+
+function resolveBody(body: RequestBody | RequestBodyFactory | undefined) {
+  return typeof body === "function" ? body() : body;
+}
+
+function mergeHeaders(...headerInits: Array<HeadersInit | undefined>) {
+  const headers = new Headers();
+  for (const headerInit of headerInits) {
+    if (!headerInit) continue;
+
+    new Headers(headerInit).forEach((value, key) => {
+      headers.set(key, value);
+    });
+  }
+
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  return headers;
+}
 
 /**
  * A chat transport that allows aborting ALL active fetch connections,
  * including `reconnectToStream` requests.
  *
- * The AI SDK's `reconnectToStream` does not pass an abort signal to its
- * internal fetch call, so `chatInstance.stop()` cannot cancel resumed
- * streams. This transport wraps every fetch with a transport-level abort
- * signal so that `abort()` reliably tears down any active connection.
+ * The Workflow transport tracks stream chunk indexes across reconnects so the
+ * client resumes from the last received chunk instead of replaying the stream
+ * from the beginning. This wrapper keeps that behavior while adding a
+ * transport-level abort signal for route cleanup and explicit stops.
  *
  * After `abort()` the transport is immediately reusable — a fresh controller
  * is created so that subsequent fetches are not affected. This makes it safe
@@ -18,29 +49,70 @@ type FetchFunction = typeof globalThis.fetch;
  */
 export class AbortableChatTransport<
   UI_MESSAGE extends UIMessage = UIMessage,
-> extends DefaultChatTransport<UI_MESSAGE> {
+> extends WorkflowChatTransport<UI_MESSAGE> {
   private _state: { controller: AbortController };
 
-  constructor(
-    options: ConstructorParameters<typeof DefaultChatTransport<UI_MESSAGE>>[0],
-  ) {
+  constructor(options: AbortableWorkflowChatTransportOptions<UI_MESSAGE>) {
     // Mutable ref so the fetch wrapper always reads the *current* controller,
     // even after abort() swaps it out.
     const state = { controller: new AbortController() };
     const outerFetch: FetchFunction = options?.fetch ?? globalThis.fetch;
 
-    super({
-      ...options,
-      fetch: ((input: RequestInfo | URL, init?: RequestInit) =>
+    const fetchWithAbort: FetchFunction = Object.assign(
+      (
+        input: Parameters<FetchFunction>[0],
+        init?: Parameters<FetchFunction>[1],
+      ) =>
         outerFetch(input, {
           ...init,
           signal: init?.signal
             ? AbortSignal.any([state.controller.signal, init.signal])
             : state.controller.signal,
-        })) as FetchFunction,
+        }),
+      {
+        preconnect: outerFetch.preconnect,
+      },
+    );
+
+    super({
+      ...options,
+      fetch: fetchWithAbort,
+      prepareSendMessagesRequest: async (request) => {
+        const prepared = await options.prepareSendMessagesRequest?.(request);
+        const configuredBody = resolveBody(options.body);
+        return {
+          ...prepared,
+          headers: mergeHeaders(request.headers, prepared?.headers),
+          body: {
+            ...configuredBody,
+            ...request.body,
+            messages: request.messages,
+            ...prepared?.body,
+          },
+        };
+      },
     });
 
     this._state = state;
+  }
+
+  override async reconnectToStream(
+    options: Parameters<
+      WorkflowChatTransport<UI_MESSAGE>["reconnectToStream"]
+    >[0],
+  ) {
+    try {
+      return await super.reconnectToStream(options);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.startsWith("Failed to fetch chat: 204")
+      ) {
+        return null;
+      }
+
+      throw error;
+    }
   }
 
   /**

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@streamdown/code": "^1.1.1",
     "@vercel/analytics": "^1.4.1",
     "@vercel/oidc": "^2.0.0",
+    "@workflow/ai": "^5.0.0-beta.4",
     "ai": "catalog:",
     "arctic": "^3.7.0",
     "better-auth": "^1.6.5",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,7 +63,7 @@
     "swr": "^2.3.8",
     "tailwind-merge": "^3.4.0",
     "vaul": "^1.1.2",
-    "workflow": "^4.2.0-beta.72",
+    "workflow": "^5.0.0-beta.5",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "@streamdown/code": "^1.1.1",
         "@vercel/analytics": "^1.4.1",
         "@vercel/oidc": "^2.0.0",
+        "@workflow/ai": "^5.0.0-beta.4",
         "ai": "catalog:",
         "arctic": "^3.7.0",
         "better-auth": "^1.6.5",
@@ -157,13 +158,19 @@
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.104", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA=="],
 
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.75", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XAm31ftiOrzlb8NjDzT7kw0xw+4lmgFdGFn1QKM73nXFFKyN1kWLESBV75UGNfjXP8X1YJ0YydnMVqO0jaPghw=="],
+
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ=="],
+
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.47", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Enm5UlL0zUCrW3792opk5h7hRWxZOZzDe6eQYVFqX9LUOGGCe1h8MZWAGim765nwzgnjlpeYOsuzZmLtRsTPlg=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
 
     "@ai-sdk/react": ["@ai-sdk/react@3.0.170", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.23", "ai": "6.0.168", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-YUDn+mK0c8iUz14rCBf1A0zg6SV5b5aSVUz+azF1bdBd1SFXVI19dKYR+PQSpZY+0+z+zs252AAsacUqiO98Kw=="],
+
+    "@ai-sdk/xai": ["@ai-sdk/xai@3.0.91", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.47", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7zhOCe7hoLfJ5VMTLejzAjBuhaBWIakfd6ZBeQBveshP+DKAPTbl08wTVqnjRLqP1Dw2zN2oT3eyz1EtiFzyBg=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -982,6 +989,8 @@
     "@vercel/queue": ["@vercel/queue@0.1.4", "", { "dependencies": { "@vercel/oidc": "^3.0.5", "minimatch": "^10.2.4", "mixpart": "0.0.5", "picocolors": "^1.1.1" } }, "sha512-wo+jCycmCX078vQSbkX+RcLvySONDCK0f9aQp5UMKQD1+B+xKt3YVbIYbZukvoHQpbm5nnk6If+ADSeK/PmCgQ=="],
 
     "@vercel/sandbox": ["@vercel/sandbox@2.0.0-beta.11", "", { "dependencies": { "@vercel/oidc": "3.2.0", "async-retry": "1.3.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.16.0", "xdg-app-paths": "5.1.0", "zod": "3.24.4" } }, "sha512-92B4b3cgUIR9CTGsGlIgy7UIrdyqIqQQom8U8YD10m5lXbjbZrf/tU7Rt+S+Vy0hlI94hKVjPkx7U+fPyBtpNA=="],
+
+    "@workflow/ai": ["@workflow/ai@5.0.0-beta.4", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@workflow/serde": "^5.0.0-beta.1", "zod": "4.3.6" }, "optionalDependencies": { "@ai-sdk/anthropic": "^3.0.0", "@ai-sdk/gateway": "^3.0.0", "@ai-sdk/google": "^3.0.0", "@ai-sdk/openai": "^3.0.0", "@ai-sdk/xai": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "ai": "^6", "workflow": "^5.0.0-beta.5" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-Wp/X7gwkURC+Y80TRoBs6bucrRK7x2f83wkyeuDaTfPpgsSQsuhLhXNDM33TqsvlHvLkwV9JkfF4+GTGxql4SQ=="],
 
     "@workflow/astro": ["@workflow/astro@5.0.0-beta.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "5.0.0-beta.5", "@workflow/rollup": "5.0.0-beta.5", "@workflow/swc-plugin": "5.0.0-beta.4", "@workflow/vite": "5.0.0-beta.5", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-XFal3AbvyMaw2EFcBr6G8sRZN6vn8Kacrc6nQ38Px1C9K4NMdrLn4MidUiAhwIhb2m+iz8BrheFUOaxPitwxAA=="],
 
@@ -2208,6 +2217,18 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
+    "@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
+
+    "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "open-agents",
@@ -64,7 +63,7 @@
         "swr": "^2.3.8",
         "tailwind-merge": "^3.4.0",
         "vaul": "^1.1.2",
-        "workflow": "^4.2.0-beta.72",
+        "workflow": "^5.0.0-beta.5",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -984,45 +983,45 @@
 
     "@vercel/sandbox": ["@vercel/sandbox@2.0.0-beta.11", "", { "dependencies": { "@vercel/oidc": "3.2.0", "async-retry": "1.3.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.16.0", "xdg-app-paths": "5.1.0", "zod": "3.24.4" } }, "sha512-92B4b3cgUIR9CTGsGlIgy7UIrdyqIqQQom8U8YD10m5lXbjbZrf/tU7Rt+S+Vy0hlI94hKVjPkx7U+fPyBtpNA=="],
 
-    "@workflow/astro": ["@workflow/astro@4.0.4", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "4.0.5", "@workflow/rollup": "4.0.4", "@workflow/swc-plugin": "4.1.0", "@workflow/vite": "4.0.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-TVx1SY4KoYSkHS/nkhXP7wz10rYBKJ0o9oQGahS+kCBkGkD5kyKdAc4QR2IpynG/u/vVg599XJj2Bsh9m2Jsrw=="],
+    "@workflow/astro": ["@workflow/astro@5.0.0-beta.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "5.0.0-beta.5", "@workflow/rollup": "5.0.0-beta.5", "@workflow/swc-plugin": "5.0.0-beta.4", "@workflow/vite": "5.0.0-beta.5", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-XFal3AbvyMaw2EFcBr6G8sRZN6vn8Kacrc6nQ38Px1C9K4NMdrLn4MidUiAhwIhb2m+iz8BrheFUOaxPitwxAA=="],
 
-    "@workflow/builders": ["@workflow/builders@4.0.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/core": "4.2.4", "@workflow/errors": "4.1.1", "@workflow/swc-plugin": "4.1.0", "@workflow/utils": "4.1.1", "builtin-modules": "5.0.0", "chalk": "5.6.2", "enhanced-resolve": "5.19.0", "esbuild": "^0.27.3", "find-up": "7.0.0", "json5": "2.2.3", "tinyglobby": "0.2.15" } }, "sha512-UmlZOjkiDqb37NZjxpJ56zwg0MFAdv/XSfRJgU8a0JQOGdTiEhJ1pWdg0pAD96pcoDwNqGphSTBhf/QoRdXgnw=="],
+    "@workflow/builders": ["@workflow/builders@5.0.0-beta.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/core": "5.0.0-beta.5", "@workflow/errors": "5.0.0-beta.2", "@workflow/swc-plugin": "5.0.0-beta.4", "@workflow/utils": "5.0.0-beta.2", "builtin-modules": "5.0.0", "chalk": "5.6.2", "enhanced-resolve": "5.19.0", "esbuild": "^0.27.3", "find-up": "7.0.0", "json5": "2.2.3", "tinyglobby": "0.2.15" } }, "sha512-giugSd8gBxiUmb1zbaMkpFcXyzp+VZ7vHjtcE04tRdXv72glxAtJ4DRQuIk0PYxOKxdJ3onQzp4y5UFceDJLKQ=="],
 
-    "@workflow/cli": ["@workflow/cli@4.2.4", "", { "dependencies": { "@oclif/core": "4.8.1", "@oclif/plugin-help": "6.2.37", "@swc/core": "1.15.3", "@vercel/cli-auth": "0.0.1", "@workflow/builders": "4.0.5", "@workflow/core": "4.2.4", "@workflow/errors": "4.1.1", "@workflow/swc-plugin": "4.1.0", "@workflow/utils": "4.1.1", "@workflow/web": "4.1.5", "@workflow/world": "4.1.1", "@workflow/world-local": "4.1.1", "@workflow/world-vercel": "4.1.2", "boxen": "8.0.1", "builtin-modules": "5.0.0", "chalk": "5.6.2", "chokidar": "4.0.3", "date-fns": "4.1.0", "dotenv": "^17.3.1", "easy-table": "1.2.0", "enhanced-resolve": "5.19.0", "esbuild": "^0.27.3", "find-up": "7.0.0", "mixpart": "0.0.4", "open": "10.2.0", "ora": "8.2.0", "terminal-link": "5.0.0", "tinyglobby": "0.2.15", "xdg-app-paths": "5.1.0", "zod": "4.3.6" }, "bin": { "wf": "bin/run.js", "workflow": "bin/run.js" } }, "sha512-NtVZNCt9CY2KtpT3FOSpQXIaj/zt8sCFfaNNzOIVCQLwfkGc6Dfi1nFtI6BELY0cWWAmCf3+ZlHOecluEx0Ynw=="],
+    "@workflow/cli": ["@workflow/cli@5.0.0-beta.5", "", { "dependencies": { "@oclif/core": "4.8.1", "@oclif/plugin-help": "6.2.37", "@swc/core": "1.15.3", "@vercel/cli-auth": "0.0.1", "@workflow/builders": "5.0.0-beta.5", "@workflow/core": "5.0.0-beta.5", "@workflow/errors": "5.0.0-beta.2", "@workflow/swc-plugin": "5.0.0-beta.4", "@workflow/utils": "5.0.0-beta.2", "@workflow/web": "5.0.0-beta.5", "@workflow/world": "5.0.0-beta.2", "@workflow/world-local": "5.0.0-beta.4", "@workflow/world-vercel": "5.0.0-beta.4", "boxen": "8.0.1", "builtin-modules": "5.0.0", "chalk": "5.6.2", "chokidar": "4.0.3", "date-fns": "4.1.0", "dotenv": "^17.3.1", "easy-table": "1.2.0", "enhanced-resolve": "5.19.0", "esbuild": "^0.27.3", "find-up": "7.0.0", "mixpart": "0.0.4", "open": "10.2.0", "ora": "8.2.0", "terminal-link": "5.0.0", "tinyglobby": "0.2.15", "xdg-app-paths": "5.1.0", "zod": "4.3.6" }, "bin": { "workflow": "bin/run.js", "wf": "bin/run.js" } }, "sha512-dIP2IQ6wrWpdCmMNByyQnmAi94g+7IvJq+eOlmVvG0+eo1BtVl2AcRcc5hwm/RMrLevTtLHUIWZmevNed8iqaw=="],
 
-    "@workflow/core": ["@workflow/core@4.2.4", "", { "dependencies": { "@aws-sdk/credential-provider-web-identity": "3.972.13", "@jridgewell/trace-mapping": "0.3.31", "@standard-schema/spec": "1.0.0", "@types/ms": "2.1.0", "@vercel/functions": "^3.4.3", "@workflow/errors": "4.1.1", "@workflow/serde": "4.1.1", "@workflow/utils": "4.1.1", "@workflow/world": "4.1.1", "@workflow/world-local": "4.1.1", "@workflow/world-vercel": "4.1.2", "debug": "4.4.3", "devalue": "5.6.3", "ms": "2.1.3", "nanoid": "5.1.6", "seedrandom": "3.0.5", "semver": "7.7.4", "ulid": "~3.0.1", "zod": "4.3.6" }, "peerDependencies": { "@opentelemetry/api": "1" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uORE+d8KPwf5vTvpq/gcynFl4gmls8m6ESHvsR+AOERlQAXRgEysCBpUAFczCFWU1P16CTEBJvH5S+qpnTWQIA=="],
+    "@workflow/core": ["@workflow/core@5.0.0-beta.5", "", { "dependencies": { "@aws-sdk/credential-provider-web-identity": "3.972.13", "@jridgewell/trace-mapping": "0.3.31", "@standard-schema/spec": "1.0.0", "@types/ms": "2.1.0", "@vercel/functions": "^3.4.3", "@workflow/errors": "5.0.0-beta.2", "@workflow/serde": "5.0.0-beta.1", "@workflow/utils": "5.0.0-beta.2", "@workflow/world": "5.0.0-beta.2", "@workflow/world-local": "5.0.0-beta.4", "@workflow/world-vercel": "5.0.0-beta.4", "debug": "4.4.3", "devalue": "5.6.3", "ms": "2.1.3", "nanoid": "5.1.6", "seedrandom": "3.0.5", "semver": "7.7.4", "ulid": "~3.0.1", "zod": "4.3.6" }, "peerDependencies": { "@opentelemetry/api": "1" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-MruKLhDj+6FRnNFeikbcGgfW1Ayf0AjJs+sYrKQb6g8ppLiqOZEL61nKzjyWFAh1ORCJpLHQrt3ZJK/qoen7/g=="],
 
-    "@workflow/errors": ["@workflow/errors@4.1.1", "", { "dependencies": { "@workflow/utils": "4.1.1", "ms": "2.1.3" } }, "sha512-T9x1MNKhoL9uMLP6KJNg2VyNz/Hf3cEB2WUaMU8fCEihDtHdHQ7q8J3sHIzFcHRg1FTnYFmVTk57Ycgfv8lZ5w=="],
+    "@workflow/errors": ["@workflow/errors@5.0.0-beta.2", "", { "dependencies": { "@workflow/utils": "5.0.0-beta.2", "ms": "2.1.3" } }, "sha512-I8Atj9nUwQ292388jbWjBTIQMBA9oc95EzjHjkNm1qbdv+Kt2JkdSl2OCQgpO46lvK4XGSiqsOBeBZ6tvo+h6w=="],
 
-    "@workflow/nest": ["@workflow/nest@0.0.4", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "4.0.5", "@workflow/swc-plugin": "4.1.0", "pathe": "2.0.3" }, "peerDependencies": { "@nestjs/common": ">=10.0.0", "@nestjs/core": ">=10.0.0", "@swc/cli": ">=0.4.0" }, "bin": { "workflow-nest": "dist/cli.js" } }, "sha512-dW2vg3178toaLqPHMtpXJEGQ/EufBPez1Ew0NhMpuo0+IVA7bqNDylK7g0ScMtsCX7CL5GOziW9I2mUVvpYUng=="],
+    "@workflow/nest": ["@workflow/nest@5.0.0-beta.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "5.0.0-beta.5", "@workflow/swc-plugin": "5.0.0-beta.4", "pathe": "2.0.3" }, "peerDependencies": { "@nestjs/common": ">=10.0.0", "@nestjs/core": ">=10.0.0", "@swc/cli": ">=0.4.0" }, "bin": { "workflow-nest": "dist/cli.js" } }, "sha512-HQQdAc7R0LJcioKJUObm0N37y0CdUWvrSISfLoOOU1WlewtEVskTxbtdy4556X9juPWZabHRB3p5Oe1NOehjqg=="],
 
-    "@workflow/next": ["@workflow/next@4.0.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "4.0.5", "@workflow/core": "4.2.4", "@workflow/swc-plugin": "4.1.0", "semver": "7.7.4", "watchpack": "2.5.1" }, "peerDependencies": { "next": ">13" }, "optionalPeers": ["next"] }, "sha512-Nos/vWpVj9uHK0w05AFVEULaWQs8R3AQZoJtGCxvjHCUWAI3Od8iQIzC9IeugKaDuufkkzLcZOeWaGV9p+Ey0w=="],
+    "@workflow/next": ["@workflow/next@5.0.0-beta.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "5.0.0-beta.5", "@workflow/core": "5.0.0-beta.5", "@workflow/swc-plugin": "5.0.0-beta.4", "semver": "7.7.4", "watchpack": "2.5.1" }, "peerDependencies": { "next": ">13" }, "optionalPeers": ["next"] }, "sha512-qi91RmpQgdAKWU8gAi2+yfy1KVlg9ckaZIpcgnmxGP2Jg18KqSYinZLGphGex1ANhNlCywTMC6fF5lqmKvZ3Pg=="],
 
-    "@workflow/nitro": ["@workflow/nitro@4.0.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "4.0.5", "@workflow/core": "4.2.4", "@workflow/rollup": "4.0.4", "@workflow/swc-plugin": "4.1.0", "@workflow/vite": "4.0.4", "exsolve": "1.0.8", "pathe": "2.0.3" } }, "sha512-M/jm+to+QiJI8/8r8tfz/4iayK0/vfsgu1703ec+ifPS8AYY0+LRWLIweb860vnEtydLuZgydIqts5CIgPsZcw=="],
+    "@workflow/nitro": ["@workflow/nitro@5.0.0-beta.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "5.0.0-beta.5", "@workflow/core": "5.0.0-beta.5", "@workflow/rollup": "5.0.0-beta.5", "@workflow/swc-plugin": "5.0.0-beta.4", "@workflow/vite": "5.0.0-beta.5", "exsolve": "1.0.8", "pathe": "2.0.3" } }, "sha512-6nDUOaOWkQ2Z46P7xEnGG8jdLytPVkEhcGBGCy3lssOU9xD/9waIMkDnZ62O1Mt4EmW4ZB4h4npQ1qg6hAagaQ=="],
 
-    "@workflow/nuxt": ["@workflow/nuxt@4.0.5", "", { "dependencies": { "@nuxt/kit": "4.4.2", "@workflow/nitro": "4.0.5" } }, "sha512-Q7fv0VqhZ8NXrgUOhd+YSc3j1ZVlDratVOcJ8Omxd0j2Mn0feC3CGeglFjaYfuvY/B2t7xG9SCcCXBV74CrEdQ=="],
+    "@workflow/nuxt": ["@workflow/nuxt@5.0.0-beta.5", "", { "dependencies": { "@nuxt/kit": "4.4.2", "@workflow/nitro": "5.0.0-beta.5" } }, "sha512-QAb3J1UtQFoBtFTzObBITM/tb9LiCuCt6p5bA/zx1IZ2popZsSNfDncz7zYAOwgqpNnkh80TmoZzBIVqjkwXmw=="],
 
-    "@workflow/rollup": ["@workflow/rollup@4.0.4", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "4.0.5", "@workflow/swc-plugin": "4.1.0", "exsolve": "1.0.7" } }, "sha512-DqmSp89Y4WVoMkBWkiNll0b5mZ2WA9uwNsRuO4QOU0XHytuCnvTRGMf0ZV6fXAa3KyeXlgS1r0V8SHwt1ZQ7jg=="],
+    "@workflow/rollup": ["@workflow/rollup@5.0.0-beta.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "5.0.0-beta.5", "@workflow/swc-plugin": "5.0.0-beta.4", "exsolve": "1.0.7" } }, "sha512-LQrb61SN25ts2fu/U8d2ByM9XCgGJ1YfiUXtfB8QPuv9gO/oF9El6UDkXaZEDg4y0k6+OutpgJtJJiLRp++O7g=="],
 
-    "@workflow/serde": ["@workflow/serde@4.1.1", "", {}, "sha512-191/N2w3WlrapuAvtAT1knONuqJ9auOqM8c7yMMM7c6rqXAZQKkNJrOuuj/j0vp7x43rg0+fy90bqT/xQ5ki4w=="],
+    "@workflow/serde": ["@workflow/serde@5.0.0-beta.1", "", {}, "sha512-rHBq0a0q1OAgo6DpwquPYyz994Qevd2bWzfg0DV6Z/I8Dn+TrRupzsdePsW9wEvO4b5R7f6plcYrn19nApKjzw=="],
 
-    "@workflow/sveltekit": ["@workflow/sveltekit@4.0.4", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "4.0.5", "@workflow/rollup": "4.0.4", "@workflow/swc-plugin": "4.1.0", "@workflow/vite": "4.0.4", "exsolve": "^1.0.8", "fs-extra": "^11.3.2", "pathe": "^2.0.3" } }, "sha512-aqBJKSHhBUzZnJ08A0aSmimPXIk9o/ayS6zBpQESt6HgX3vrX7MbpklWKP9x0+3NzUDNN368O+Iahp+mJb5E9A=="],
+    "@workflow/sveltekit": ["@workflow/sveltekit@5.0.0-beta.5", "", { "dependencies": { "@swc/core": "1.15.3", "@workflow/builders": "5.0.0-beta.5", "@workflow/rollup": "5.0.0-beta.5", "@workflow/swc-plugin": "5.0.0-beta.4", "@workflow/vite": "5.0.0-beta.5", "exsolve": "^1.0.8", "fs-extra": "^11.3.2", "pathe": "^2.0.3" } }, "sha512-ubF3tWG0+VcgSiqH0jnWKETr/S8zgg4aZj1fBI8nSqZ/neeIfexV8hFPwRz12aTDxpND1QbtzxhBY5svY2ieuw=="],
 
-    "@workflow/swc-plugin": ["@workflow/swc-plugin@4.1.0", "", { "peerDependencies": { "@swc/core": "1.15.3" } }, "sha512-FcWKJwzkRqf0u08/WCyg2n1H3932JQpFk3g6edE7trXKFW06a8o4F22k/xgPFsbxAq8UpywcIN7f46H0/uH5Tw=="],
+    "@workflow/swc-plugin": ["@workflow/swc-plugin@5.0.0-beta.4", "", { "peerDependencies": { "@swc/core": "1.15.3" } }, "sha512-XJbdhjaXC1JHYYaEBNqvh7TEyPFRY2VddtF9uwSy8M7119H3agxc+77iCgGAXjS16niqZ1Z/72UMhkaQSm8uoQ=="],
 
-    "@workflow/typescript-plugin": ["@workflow/typescript-plugin@4.0.2", "", { "peerDependencies": { "typescript": ">=5.0.0" } }, "sha512-7bw6aEl+QMZWWZmhJS5bydrSgmxQrG8Kyo5Zhdb7klu+/pBUyNMVTUZmnfe1xRjWborqvOevqYbSDh0a0gwnAw=="],
+    "@workflow/typescript-plugin": ["@workflow/typescript-plugin@5.0.0-beta.3", "", { "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-b9UWZjytb9joiiEAJiOafFnwWZzhLhFU0n1OrhTTE0XboXw3fYCjjgBPoAclYKBnkm71y0AKsmgU+fAZi8x+Rw=="],
 
-    "@workflow/utils": ["@workflow/utils@4.1.1", "", { "dependencies": { "ms": "2.1.3" } }, "sha512-4+yJxzyeOBZsVRG8npvLsafCPt9E4bsFi/oUBBT2yLM5X4v+KUBLMwZOubShwcBix2/VOGau7mumvh12JSKjaA=="],
+    "@workflow/utils": ["@workflow/utils@5.0.0-beta.2", "", { "dependencies": { "ms": "2.1.3" } }, "sha512-r8L97VL12cI62S2U6kdtrqwBHwCwU+4k6dzuRGwFX1hAFP0G41uefQuMHMTcf11Z1b1u2IGiP76B9Lb109TmsQ=="],
 
-    "@workflow/vite": ["@workflow/vite@4.0.4", "", { "dependencies": { "@workflow/builders": "4.0.5" } }, "sha512-dEw5Dg6zdlsBwwEFYYqRIXApZ4kgqN/vMzZEyEbisJEofKNPDIYP1/nAh22DkYW55Nxa0YOKdqnhxQq+kdvX2A=="],
+    "@workflow/vite": ["@workflow/vite@5.0.0-beta.5", "", { "dependencies": { "@workflow/builders": "5.0.0-beta.5" } }, "sha512-On9DsoRFyEhIwzG/ypbhGhBqi3pJv9XKJ5a0rNHq5MeR4UUvEReN5bshSu7y9O6kwwF89v8rhj9XoLsM9mzACw=="],
 
-    "@workflow/web": ["@workflow/web@4.1.5", "", { "dependencies": { "express": "^4.21.0" } }, "sha512-VBdRdOBIs/TsS79TxhnjnYcmXKIOwR57gWL+n/0GSvd7aaMHcvKBybmRUTMYOe0q110KXs31eJ4aLjWLYLQxGA=="],
+    "@workflow/web": ["@workflow/web@5.0.0-beta.5", "", { "dependencies": { "express": "^4.21.0" } }, "sha512-+d2chu5KF+qd+JHVonUWzMQI+7bDK/dE7W/0bAOzsRijYpeCVX9J7P5C4r2b+57J7TvwrsMOOiW7iESAaC1LPA=="],
 
-    "@workflow/world": ["@workflow/world@4.1.1", "", { "dependencies": { "ulid": "~3.0.1" }, "peerDependencies": { "zod": "4.3.6" } }, "sha512-OVfswz2SCt1NKSihAIPlPx/ygGdkA8si69xTAZtAZQACphuhmcg5mm28aNPo0/7oxcUVD/tO/AF1uSUF4BGpRw=="],
+    "@workflow/world": ["@workflow/world@5.0.0-beta.2", "", { "dependencies": { "ulid": "~3.0.1" }, "peerDependencies": { "zod": "4.3.6" } }, "sha512-FBbX+Nw0i8ywE0YeVip6qCW2DResvyUgkqCg3+BPM3PYKDvZacSrGZKM1vhcaePpwEKgH6p+G2d5kGOPH2d6dQ=="],
 
-    "@workflow/world-local": ["@workflow/world-local@4.1.1", "", { "dependencies": { "@vercel/queue": "0.1.4", "@workflow/errors": "4.1.1", "@workflow/utils": "4.1.1", "@workflow/world": "4.1.1", "async-sema": "3.1.1", "ulid": "~3.0.1", "undici": "7.22.0", "zod": "4.3.6" }, "peerDependencies": { "@opentelemetry/api": "1" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-qQznGPy15nPD+CO0THxMDwozIrvEOkZuAkpI2S3/+hrvUF07mSHGsGCVp6eVaECSTi3dGseep9rKUXZhU/HGYw=="],
+    "@workflow/world-local": ["@workflow/world-local@5.0.0-beta.4", "", { "dependencies": { "@vercel/queue": "0.1.4", "@workflow/errors": "5.0.0-beta.2", "@workflow/utils": "5.0.0-beta.2", "@workflow/world": "5.0.0-beta.2", "async-sema": "3.1.1", "ulid": "~3.0.1", "undici": "7.22.0", "zod": "4.3.6" }, "peerDependencies": { "@opentelemetry/api": "1" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UD+mgtDrox9pJs3AVGWDkytKQEY01HhDI/G27NSfOrGECf2K0+mu+GmdcFiEiVL2pab0tZ7pJSdPsqJmOGu8Gg=="],
 
-    "@workflow/world-vercel": ["@workflow/world-vercel@4.1.2", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@vercel/queue": "0.1.4", "@workflow/errors": "4.1.1", "@workflow/world": "4.1.1", "cbor-x": "1.6.0", "undici": "7.22.0", "zod": "4.3.6" }, "peerDependencies": { "@opentelemetry/api": "1" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-GR0l0Hhm8JpILQgHn1gMGKNAlU6ioZEFDtyrM4haxz6JdcUE42JMNRGtw4IeHzsCXcXOZ7+SbVNFnEIVtG5faw=="],
+    "@workflow/world-vercel": ["@workflow/world-vercel@5.0.0-beta.4", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@vercel/queue": "0.1.4", "@workflow/errors": "5.0.0-beta.2", "@workflow/world": "5.0.0-beta.2", "cbor-x": "1.6.0", "undici": "7.22.0", "zod": "4.3.6" }, "peerDependencies": { "@opentelemetry/api": "1" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-gMkKWsls+7uDzObGajGqdIrdhbbJwNB0eNeklQRmXBuOZ1mtPhVwGWEc3u6+/2VLtkx2kfIKnlrVGd3Bmi3BHQ=="],
 
     "@xhmikosr/archive-type": ["@xhmikosr/archive-type@8.0.1", "", { "dependencies": { "file-type": "^21.3.0" } }, "sha512-toXuiWChyfOpEiCPsIw6HGHaNji5LVkvB6EREL548vGWr+hGaehwxG4LzN20vm9aGFXwnA/Jty8yW2/SmV+1zQ=="],
 
@@ -2188,7 +2187,7 @@
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
-    "workflow": ["workflow@4.2.4", "", { "dependencies": { "@workflow/astro": "4.0.4", "@workflow/cli": "4.2.4", "@workflow/core": "4.2.4", "@workflow/errors": "4.1.1", "@workflow/nest": "0.0.4", "@workflow/next": "4.0.5", "@workflow/nitro": "4.0.5", "@workflow/nuxt": "4.0.5", "@workflow/rollup": "4.0.4", "@workflow/sveltekit": "4.0.4", "@workflow/typescript-plugin": "4.0.2", "@workflow/utils": "4.1.1", "ms": "2.1.3" }, "peerDependencies": { "@opentelemetry/api": "1" }, "optionalPeers": ["@opentelemetry/api"], "bin": { "wf": "bin/run.js", "workflow": "bin/run.js" } }, "sha512-F7HT6uXIF0YaERtfK9kdXgebeXOUtSuCvQElIJYh5cjYmUS7JcRLsAsQSUeQ4Dcjvnml4t1efHypTR7gk/2d3g=="],
+    "workflow": ["workflow@5.0.0-beta.5", "", { "dependencies": { "@workflow/astro": "5.0.0-beta.5", "@workflow/cli": "5.0.0-beta.5", "@workflow/core": "5.0.0-beta.5", "@workflow/errors": "5.0.0-beta.2", "@workflow/nest": "5.0.0-beta.5", "@workflow/next": "5.0.0-beta.5", "@workflow/nitro": "5.0.0-beta.5", "@workflow/nuxt": "5.0.0-beta.5", "@workflow/rollup": "5.0.0-beta.5", "@workflow/sveltekit": "5.0.0-beta.5", "@workflow/typescript-plugin": "5.0.0-beta.3", "@workflow/utils": "5.0.0-beta.2", "ms": "2.1.3" }, "peerDependencies": { "@opentelemetry/api": "1" }, "optionalPeers": ["@opentelemetry/api"], "bin": { "wf": "bin/run.js", "workflow": "bin/run.js" } }, "sha512-RnDgshX9Sme6pL7BufSH7WMudeO6bvgIi0LKdZVWCa8TjKjZBxQltObIVFdlMxtCzXOnpOdXiez3TCU6wmVI5g=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 


### PR DESCRIPTION
## Summary
- update Workflow to 5.0.0-beta.5 and add @workflow/ai for the beta chat transport
- switch the abortable chat transport to wrap WorkflowChatTransport so reconnects resume from the last received workflow stream chunk
- update the chat stream reconnect endpoint to accept startIndex and return x-workflow-stream-tail-index
- disable stall recovery during an already active chat request to avoid overlapping resumeStream calls creating duplicate live assistant messages

## Why
The Workflow beta changes the streaming path enough that the app needs the Workflow-aware AI transport, not only the workflow package bump. Without chunk-index-aware reconnects, stream recovery can replay chunks. Separately, the existing stall recovery could start a second resumeStream while the original POST stream was still active, which polluted the live AI SDK chat state with repeated assistant messages. Refresh looked fine because persistence still collapsed back to the final stored assistant message.

## Validation
- bun install --frozen-lockfile
- bun run check
- turbo typecheck --filter=web
- bun test apps/web/app/workflows/chat.test.ts
- bun test apps/web/app/api/chat/route.test.ts
- bun test apps/web/app/api/chat/[chatId]/stream/route.test.ts
- bun test apps/web/app/api/chat/[chatId]/stop/route.test.ts
- bun test apps/web/lib/sandbox/lifecycle-kick.test.ts
- bun test apps/web/app/sessions/[sessionId]/chats/[chatId]/stream-recovery-policy.test.ts