### PR TITLE
Parallelize chat workflow startup

### DIFF
--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -107,6 +107,7 @@ mock.module("ai", () => ({
     stream: ReadableStream;
     headers?: Record<string, string>;
   }) => new Response(stream, { status: 200, headers }),
+  generateId: () => "gen-id-1",
   isToolUIPart: (part: { type: string }) =>
     part.type === "tool-invocation" || part.type.startsWith("tool-"),
 }));
@@ -429,6 +430,8 @@ describe("/api/chat route", () => {
     expect(startCalls).toHaveLength(1);
     expect(startCalls[0]?.[1]).toEqual([
       expect.objectContaining({
+        assistantId: "gen-id-1",
+        inputMessagesPersisted: true,
         maxSteps: 500,
         requestUrl: "http://localhost/api/chat",
         authSession: currentAuthSession,

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -431,7 +431,6 @@ describe("/api/chat route", () => {
     expect(startCalls[0]?.[1]).toEqual([
       expect.objectContaining({
         assistantId: "gen-id-1",
-        inputMessagesPersisted: true,
         maxSteps: 500,
         requestUrl: "http://localhost/api/chat",
         authSession: currentAuthSession,

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -148,7 +148,6 @@ export async function POST(req: Request) {
       requestUrl: req.url,
       authSession: session ?? null,
       assistantId: generateId(),
-      inputMessagesPersisted: true,
       maxSteps: 500,
     },
   ]);

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,4 +1,8 @@
-import { createUIMessageStreamResponse, type InferUIMessageChunk } from "ai";
+import {
+  createUIMessageStreamResponse,
+  generateId,
+  type InferUIMessageChunk,
+} from "ai";
 import { checkBotProtection } from "@/lib/botid";
 import { start } from "workflow/api";
 import type { WebAgentUIMessage } from "@/app/types";
@@ -143,6 +147,8 @@ export async function POST(req: Request) {
       userId,
       requestUrl: req.url,
       authSession: session ?? null,
+      assistantId: generateId(),
+      inputMessagesPersisted: true,
       maxSteps: 500,
     },
   ]);

--- a/apps/web/app/workflows/chat-post-finish.ts
+++ b/apps/web/app/workflows/chat-post-finish.ts
@@ -294,6 +294,8 @@ export type ClaimActiveStreamResult = "claimed" | "conflict" | "error";
 export async function claimActiveStream(
   chatId: string,
   workflowRunId: string,
+  writable?: WritableStream<UIMessageChunk>,
+  messageId?: string,
 ): Promise<ClaimActiveStreamResult> {
   "use step";
 
@@ -311,10 +313,26 @@ export async function claimActiveStream(
         );
         return "conflict";
       }
+      if (writable && messageId) {
+        const writer = writable.getWriter();
+        try {
+          await writer.write({ type: "start", messageId });
+        } finally {
+          writer.releaseLock();
+        }
+      }
       return "claimed";
     } catch (error) {
       if (attempt === ACTIVE_STREAM_CLAIM_MAX_ATTEMPTS) {
         console.error("[workflow] Failed to claim activeStreamId:", error);
+        if (writable && messageId) {
+          const writer = writable.getWriter();
+          try {
+            await writer.write({ type: "start", messageId });
+          } finally {
+            writer.releaseLock();
+          }
+        }
         // Non-fatal: workflow can still run, just won't be resumable.
         return "error";
       }

--- a/apps/web/app/workflows/chat-sandbox-runtime.ts
+++ b/apps/web/app/workflows/chat-sandbox-runtime.ts
@@ -4,9 +4,6 @@ import {
   type Sandbox,
   type SandboxState,
 } from "@open-agents/sandbox";
-import type { UIMessageChunk } from "ai";
-import { getWritable } from "workflow";
-import type { WebAgentWorkspaceStatusData } from "@/app/types";
 import { getSessionById } from "@/lib/db/sessions";
 import {
   kickSandboxProvisioningWorkflow,
@@ -88,46 +85,11 @@ async function getReadySessionSandbox(params: {
   return { session, didSetupWorkspace: true };
 }
 
-async function sendWorkspaceStatus(data: WebAgentWorkspaceStatusData) {
-  const writer = getWritable<UIMessageChunk>().getWriter();
-  try {
-    await writer.write({
-      type: "data-workspace-status",
-      id: "workspace-status",
-      data,
-      transient: true,
-    });
-  } finally {
-    writer.releaseLock();
-  }
-}
-
-async function sendStart(messageId: string) {
-  const writer = getWritable<UIMessageChunk>().getWriter();
-  try {
-    await writer.write({ type: "start", messageId });
-  } finally {
-    writer.releaseLock();
-  }
-}
-
 export async function resolveChatSandboxRuntime(params: {
   userId: string;
   sessionId: string;
-  assistantId: string;
 }): Promise<ResolvedChatSandboxRuntime> {
   "use step";
-
-  await sendStart(params.assistantId);
-
-  const initialSession = await getSessionById(params.sessionId);
-  const shouldWaitForSetup = !isSandboxActive(initialSession?.sandboxState);
-  if (shouldWaitForSetup) {
-    await sendWorkspaceStatus({
-      status: "setting-up",
-      message: "Setting up the workspace...",
-    });
-  }
 
   const { session, didSetupWorkspace } = await getReadySessionSandbox({
     sessionId: params.sessionId,

--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -52,11 +52,27 @@ const spies = {
   persistSandboxState: mock((_sessionId?: unknown, _sandboxState?: unknown) =>
     Promise.resolve(),
   ),
-  resolveChatSandboxRuntime: mock((params: { assistantId: string }) => {
-    writtenChunks.push({ type: "start", messageId: params.assistantId });
+  resolveChatSandboxRuntime: mock((_params: { assistantId?: string }) => {
     return Promise.resolve(createResolvedChatSandboxRuntime());
   }),
-  claimActiveStream: mock(() => Promise.resolve("claimed")),
+  claimActiveStream: mock(
+    async (
+      _chatId?: unknown,
+      _workflowRunId?: unknown,
+      writable?: WritableStream<UIMessageChunk>,
+      messageId?: string,
+    ) => {
+      if (writable && messageId) {
+        const writer = writable.getWriter();
+        try {
+          await writer.write({ type: "start", messageId });
+        } finally {
+          writer.releaseLock();
+        }
+      }
+      return "claimed";
+    },
+  ),
   closeStream: mock((writable: WritableStream<UIMessageChunk>) =>
     writable.close(),
   ),
@@ -443,8 +459,23 @@ describe("runAgentWorkflow", () => {
   });
 
   test("continues when claiming the stream errors", async () => {
-    spies.claimActiveStream.mockImplementationOnce(() =>
-      Promise.resolve("error"),
+    spies.claimActiveStream.mockImplementationOnce(
+      async (
+        _chatId?: unknown,
+        _workflowRunId?: unknown,
+        writable?: WritableStream<UIMessageChunk>,
+        messageId?: string,
+      ) => {
+        if (writable && messageId) {
+          const writer = writable.getWriter();
+          try {
+            await writer.write({ type: "start", messageId });
+          } finally {
+            writer.releaseLock();
+          }
+        }
+        return "error";
+      },
     );
 
     await runAgentWorkflow(makeOptions());
@@ -463,18 +494,8 @@ describe("runAgentWorkflow", () => {
     expect(types[types.length - 1]).toBe("finish");
   });
 
-  test("streams transient workspace setup status from runtime prep", async () => {
-    spies.resolveChatSandboxRuntime.mockImplementationOnce(async (params) => {
-      writtenChunks.push({ type: "start", messageId: params.assistantId });
-      writtenChunks.push({
-        type: "data-workspace-status",
-        id: "workspace-status",
-        data: {
-          status: "setting-up",
-          message: "Setting up the workspace...",
-        },
-        transient: true,
-      });
+  test("does not stream transient workspace setup status from runtime prep", async () => {
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(async () => {
       return createResolvedChatSandboxRuntime({
         didSetupWorkspace: true,
       });
@@ -483,20 +504,13 @@ describe("runAgentWorkflow", () => {
     await runAgentWorkflow(makeOptions());
 
     expect(writtenChunks[0]).toEqual({ type: "start", messageId: "gen-id-1" });
-    expect(writtenChunks[1]).toEqual({
-      type: "data-workspace-status",
-      id: "workspace-status",
-      data: {
-        status: "setting-up",
-        message: "Setting up the workspace...",
-      },
-      transient: true,
-    });
+    expect(
+      writtenChunks.some((chunk) => chunk.type === "data-workspace-status"),
+    ).toBe(false);
   });
 
   test("streams a user-visible message when workspace setup fails", async () => {
-    spies.resolveChatSandboxRuntime.mockImplementationOnce(async (params) => {
-      writtenChunks.push({ type: "start", messageId: params.assistantId });
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(async () => {
       throw new Error("Connect GitHub to access repositories");
     });
 
@@ -532,8 +546,7 @@ describe("runAgentWorkflow", () => {
   });
 
   test("streams an archived-session setup message when runtime rejects", async () => {
-    spies.resolveChatSandboxRuntime.mockImplementationOnce(async (params) => {
-      writtenChunks.push({ type: "start", messageId: params.assistantId });
+    spies.resolveChatSandboxRuntime.mockImplementationOnce(async () => {
       throw new Error("Session is archived");
     });
 

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -69,6 +69,8 @@ type Options = {
   selectedModelId?: string;
   modelId?: string;
   agentOptions?: Omit<OpenAgentCallOptions, "sandbox" | "skills">;
+  assistantId?: string;
+  inputMessagesPersisted?: boolean;
   maxSteps?: number;
   autoCommitEnabled?: boolean;
   autoCreatePrEnabled?: boolean;
@@ -227,11 +229,6 @@ async function resolveChatModelRuntime(params: {
     autoCreatePrEnabled,
   };
 }
-
-const generateId = async () => {
-  "use step";
-  return generateIdAi();
-};
 
 async function persistInputMessages(
   chatId: string,
@@ -605,6 +602,27 @@ export async function runAgentWorkflow(options: Options) {
     throw new Error("runAgentWorkflow requires at least one message");
   }
 
+  const assistantId =
+    latestMessage.role === "assistant"
+      ? latestMessage.id
+      : (options.assistantId ?? generateIdAi());
+
+  const modelMessagesPromise = convertMessages(options.messages);
+  let inputMessagesPersistPromise = options.inputMessagesPersisted
+    ? Promise.resolve()
+    : undefined;
+  const modelRuntimePromise = resolveChatModelRuntime({
+    userId: options.userId,
+    sessionId: options.sessionId,
+    chatId: options.chatId,
+    requestUrl: options.requestUrl,
+    authSession: options.authSession,
+  });
+  const runtimePromise = resolveChatSandboxRuntime({
+    userId: options.userId,
+    sessionId: options.sessionId,
+  });
+
   // Self-register this workflow's runId onto the chat as the very first step.
   // The HTTP POST handler also writes this (via compareAndSetChatActiveStreamId
   // after `start()` returns), but that write is best-effort and can be lost
@@ -612,25 +630,32 @@ export async function runAgentWorkflow(options: Options) {
   // it runs. Persisting from inside the workflow guarantees that as long as
   // the workflow is running, the chat row points at it and the client can
   // resume on refresh.
-  const activeStreamClaim = await claimActiveStream(
+  const activeStreamClaimPromise = claimActiveStream(
     options.chatId,
     workflowRunId,
+    writable,
+    assistantId,
   );
+  const activeStreamClaim = await activeStreamClaimPromise;
   if (activeStreamClaim === "conflict") {
     // Another workflow claimed the slot while this run was queued or starting.
     // Exit before emitting chunks or persisting messages so only the owning
     // workflow can mutate this chat.
+    await Promise.allSettled([
+      runtimePromise,
+      modelMessagesPromise,
+      ...(inputMessagesPersistPromise ? [inputMessagesPersistPromise] : []),
+      modelRuntimePromise,
+    ]);
     await closeStream(writable);
     return;
   }
 
-  const modelMessagesPromise = convertMessages(options.messages);
-  const inputMessagesPersistPromise = persistInputMessages(
+  inputMessagesPersistPromise ??= persistInputMessages(
     options.chatId,
     options.messages,
   );
-  const assistantId =
-    latestMessage.role === "assistant" ? latestMessage.id : await generateId();
+
   let selectedModelId = APP_DEFAULT_MODEL_ID;
   let modelId = APP_DEFAULT_MODEL_ID;
 
@@ -669,19 +694,10 @@ export async function runAgentWorkflow(options: Options) {
   let shouldRefreshCachedDiff = false;
 
   try {
-    const [runtime, modelRuntime, modelMessages] = await Promise.all([
-      resolveChatSandboxRuntime({
-        userId: options.userId,
-        sessionId: options.sessionId,
-        assistantId,
-      }),
-      resolveChatModelRuntime({
-        userId: options.userId,
-        sessionId: options.sessionId,
-        chatId: options.chatId,
-        requestUrl: options.requestUrl,
-        authSession: options.authSession,
-      }),
+    const [, runtime, modelRuntime, modelMessages] = await Promise.all([
+      activeStreamClaimPromise,
+      runtimePromise,
+      modelRuntimePromise,
       modelMessagesPromise,
       inputMessagesPersistPromise,
     ]);

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -608,9 +608,9 @@ export async function runAgentWorkflow(options: Options) {
       : (options.assistantId ?? generateIdAi());
 
   const modelMessagesPromise = convertMessages(options.messages);
-  let inputMessagesPersistPromise = options.inputMessagesPersisted
+  const inputMessagesPersistPromise = options.inputMessagesPersisted
     ? Promise.resolve()
-    : undefined;
+    : persistInputMessages(options.chatId, options.messages);
   const modelRuntimePromise = resolveChatModelRuntime({
     userId: options.userId,
     sessionId: options.sessionId,
@@ -644,17 +644,12 @@ export async function runAgentWorkflow(options: Options) {
     await Promise.allSettled([
       runtimePromise,
       modelMessagesPromise,
-      ...(inputMessagesPersistPromise ? [inputMessagesPersistPromise] : []),
+      inputMessagesPersistPromise,
       modelRuntimePromise,
     ]);
     await closeStream(writable);
     return;
   }
-
-  inputMessagesPersistPromise ??= persistInputMessages(
-    options.chatId,
-    options.messages,
-  );
 
   let selectedModelId = APP_DEFAULT_MODEL_ID;
   let modelId = APP_DEFAULT_MODEL_ID;


### PR DESCRIPTION
## Summary

Parallelizes chat workflow startup so the workflow can prepare model messages, model runtime, sandbox runtime, input persistence, and active stream claiming concurrently.

This also moves the initial assistant `start` chunk into the active-stream claim step so clients receive a stable assistant message ID earlier, while keeping the durable workflow's input-message persistence fallback active.

## Changes

- Generate and pass the assistant message ID from the chat route when starting the workflow.
- Start chat workflow startup tasks concurrently before awaiting the active-stream claim.
- Stop streaming transient workspace setup status from runtime preparation.
- Keep workflow-side input persistence running as an idempotent fallback instead of trusting route-side eager persistence.
- Update route and workflow tests for the new startup behavior.

## Validation

- `bun test "apps/web/app/workflows/chat.test.ts"`
- `bun test "apps/web/app/api/chat/route.test.ts"`
