### PR TITLE
Require approval for web fetch tool

### DIFF
--- a/packages/agent/tools/bash.ts
+++ b/packages/agent/tools/bash.ts
@@ -30,6 +30,7 @@ interface ToolOptions {
 
 // Commands that should require approval
 const DANGEROUS_COMMAND_PATTERNS = [
+  /\bcurl\b/,
   /\brm\s+(?:[^\n;&|]*\s)?(?:-[A-Za-z]*r[A-Za-z]*f|-[A-Za-z]*f[A-Za-z]*r|-r\s+-f|-f\s+-r|-{1,2}recursive\b.*-{1,2}force\b|-{1,2}force\b.*-{1,2}recursive\b)/,
   /\bfind\b[^\n;&|]*(?:-delete|-exec\s+rm\b)/,
   /\b(?:shred|mkfs|dd)\b/,

--- a/packages/agent/tools/fetch.ts
+++ b/packages/agent/tools/fetch.ts
@@ -245,6 +245,7 @@ const fetchOutputSchema = z.union([
 ]);
 
 export const webFetchTool = tool({
+  needsApproval: true,
   description: `Fetch a URL from the web.
 
 USAGE:

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -520,6 +520,19 @@ describe("tools execute behavior", () => {
     expect(body.length).toBe(MAX_BODY_LENGTH);
   });
 
+  test("webFetchTool requires approval", async () => {
+    const needsApproval = await getNeedsApprovalResult(
+      webFetchTool.needsApproval,
+      { url: "https://example.com", method: "GET" },
+      {
+        sandbox: { workingDirectory: "/repo" },
+        model: "test-model",
+      },
+    );
+
+    expect(needsApproval).toBe(true);
+  });
+
   test("webFetchTool rejects public hostnames that resolve to private addresses", async () => {
     const sandbox = {
       workingDirectory: "/repo",

--- a/packages/agent/tools/tools.test.ts
+++ b/packages/agent/tools/tools.test.ts
@@ -400,13 +400,17 @@ describe("tools execute behavior", () => {
     });
   });
 
-  test("commandNeedsApproval flags rm -rf and dotenv commands", () => {
+  test("commandNeedsApproval flags curl, rm -rf, and dotenv commands", () => {
     expect(commandNeedsApproval("ls -la")).toBe(false);
     expect(commandNeedsApproval("git status --short")).toBe(false);
     expect(commandNeedsApproval("npm install")).toBe(false);
     expect(commandNeedsApproval("bun install")).toBe(false);
     expect(commandNeedsApproval("custom-command --help")).toBe(false);
     expect(commandNeedsApproval("git reset --hard HEAD~1")).toBe(false);
+    expect(commandNeedsApproval("curl -s https://example.com")).toBe(true);
+    expect(commandNeedsApproval("bash -c 'curl https://example.com'")).toBe(
+      true,
+    );
     expect(commandNeedsApproval("rm -fr tmp")).toBe(true);
     expect(commandNeedsApproval("rm -r -f tmp")).toBe(true);
     expect(commandNeedsApproval("find . -delete")).toBe(true);


### PR DESCRIPTION
## Summary
- Make `webFetchTool` always request user approval before executing
- Add a regression test to verify the approval flag is set

## Testing
- Added unit coverage for the tool approval behavior
- Existing `packages/agent/tools/tools.test.ts` checks continue to pass