### PR TITLE
Document self-hosting setup and fix rollout deployment defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ ELEVENLABS_API_KEY=
    https://YOUR_DOMAIN/api/auth/callback/vercel
    ```
 
+   Enable the `openid`, `email`, `profile`, and `offline_access` scopes on the OAuth app.
+
 7. Add these env vars and redeploy:
 
    ```env
@@ -181,6 +183,8 @@ For local development, use:
 http://localhost:3000/api/auth/callback/vercel
 ```
 
+Make sure the OAuth app has the following scopes enabled: `openid`, `email`, `profile`, and `offline_access`.
+
 Then set:
 
 ```env
@@ -200,6 +204,21 @@ Create a GitHub App for installation-based repo access and configure:
 - make the app public if you want org installs to work cleanly
 
 For local development, use `http://localhost:3000` as the homepage URL, `http://localhost:3000/api/auth/callback/github` as the callback URL, and `http://localhost:3000/api/github/app/callback` as the setup URL.
+
+#### Repository permissions
+
+Under **Permissions & events → Repository permissions**, enable the following. These are derived from the GitHub API calls the app actually makes:
+
+| Permission       | Level                       | Used by                                                                                   |
+| ---------------- | --------------------------- | ----------------------------------------------------------------------------------------- |
+| Contents         | Read and write              | committing changes — `git.createBlob`/`createTree`/`createCommit`/`createRef`/`updateRef`/`deleteRef` |
+| Pull requests    | Read and write              | `pulls.create`/`update`/`merge`/`list`/`get`                                               |
+| Metadata         | Read-only (mandatory)       | `repos.get`                                                                                |
+| Commit statuses  | Read-only                   | `repos.getCombinedStatusForRef`                                                            |
+| Checks           | Read-only                   | `checks.listForRef`                                                                        |
+| Issues           | Read-only                   | `issues.listComments` (PR conversation comments)                                           |
+| Administration   | Read-only                   | `repos.getStatusChecksProtection` (branch protection)                                      |
+| Workflows        | Read and write (recommended) | the agent can edit any file; pushes touching `.github/workflows/*` are rejected without this |
 
 Then set:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Agents
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?project-name=open-agents&repository-name=open-agents&repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fopen-agents&demo-title=Open+Agents&demo-description=Open-source+reference+app+for+building+and+running+background+coding+agents+on+Vercel.&demo-url=https%3A%2F%2Fopen-agents.dev%2F&env=POSTGRES_URL%2CBETTER_AUTH_SECRET%2CNEXT_PUBLIC_VERCEL_APP_CLIENT_ID%2CVERCEL_APP_CLIENT_SECRET%2CNEXT_PUBLIC_GITHUB_CLIENT_ID%2CGITHUB_CLIENT_SECRET%2CGITHUB_APP_ID%2CGITHUB_APP_PRIVATE_KEY%2CNEXT_PUBLIC_GITHUB_APP_SLUG%2CGITHUB_WEBHOOK_SECRET&envDescription=Neon+can+provide+POSTGRES_URL+automatically.+Generate+BETTER_AUTH_SECRET+yourself%2C+then+add+your+Vercel+OAuth+and+GitHub+App+credentials+for+a+full+deployment.&products=%255B%257B%2522type%2522%253A%2522integration%2522%252C%2522protocol%2522%253A%2522storage%2522%252C%2522productSlug%2522%253A%2522neon%2522%252C%2522integrationSlug%2522%253A%2522neon%2522%257D%252C%257B%2522type%2522%253A%2522integration%2522%252C%2522protocol%2522%253A%2522storage%2522%252C%2522productSlug%2522%253A%2522upstash-kv%2522%252C%2522integrationSlug%2522%253A%2522upstash%2522%257D%255D&skippable-integrations=1)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?project-name=open-agents&repository-name=open-agents&repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fopen-agents&root-directory=apps%2Fweb&demo-title=Open+Agents&demo-description=Open-source+reference+app+for+building+and+running+background+coding+agents+on+Vercel.&demo-url=https%3A%2F%2Fopen-agents.dev%2F&env=POSTGRES_URL%2CBETTER_AUTH_SECRET%2CNEXT_PUBLIC_VERCEL_APP_CLIENT_ID%2CVERCEL_APP_CLIENT_SECRET%2CNEXT_PUBLIC_GITHUB_CLIENT_ID%2CGITHUB_CLIENT_SECRET%2CGITHUB_APP_ID%2CGITHUB_APP_PRIVATE_KEY%2CNEXT_PUBLIC_GITHUB_APP_SLUG%2CGITHUB_WEBHOOK_SECRET&envDescription=Neon+can+provide+POSTGRES_URL+automatically.+Generate+BETTER_AUTH_SECRET+yourself%2C+then+add+your+Vercel+OAuth+and+GitHub+App+credentials+for+a+full+deployment.&products=%255B%257B%2522type%2522%253A%2522integration%2522%252C%2522protocol%2522%253A%2522storage%2522%252C%2522productSlug%2522%253A%2522neon%2522%252C%2522integrationSlug%2522%253A%2522neon%2522%257D%252C%257B%2522type%2522%253A%2522integration%2522%252C%2522protocol%2522%253A%2522storage%2522%252C%2522productSlug%2522%253A%2522upstash-kv%2522%252C%2522integrationSlug%2522%253A%2522upstash%2522%257D%255D&skippable-integrations=1)
 
 Open Agents is an open-source reference app for building and running background coding agents on Vercel. It includes the web UI, the agent runtime, sandbox orchestration, and the GitHub integration needed to go from prompt to code changes without keeping your laptop involved.
 
@@ -99,7 +99,7 @@ ELEVENLABS_API_KEY=
 ## Deploy your own copy on Vercel
 
 1. Fork this repo.
-2. Import the repo into Vercel. Neon Postgres is auto-provisioned if you use the deploy button above.
+2. Import the repo into Vercel with **Root Directory** set to `apps/web`. Neon Postgres is auto-provisioned if you use the deploy button above.
 3. Generate a secret for session signing:
 
    ```bash

--- a/apps/web/app/api/github/app/install/route.test.ts
+++ b/apps/web/app/api/github/app/install/route.test.ts
@@ -109,7 +109,8 @@ describe("GET /api/github/app/install", () => {
     expect(location).toBeTruthy();
     const redirectUrl = new URL(location as string);
     expect(redirectUrl.origin).toBe("https://github.com");
-    expect(redirectUrl.pathname).toContain("open-agents");
+    expect(redirectUrl.pathname).toBe("/apps/open-agents/installations/new");
+    expect(redirectUrl.searchParams.get("target_id")).toBeNull();
   });
 
   test("blocks managed template trial users", async () => {

--- a/apps/web/app/api/github/app/install/route.ts
+++ b/apps/web/app/api/github/app/install/route.ts
@@ -116,9 +116,11 @@ export async function GET(req: NextRequest): Promise<Response> {
   }
 
   if (installations.length === 0) {
-    // no installations — route to install page
+    // no installations — route to the install account picker.
+    // Use /installations/new (not /installations/new/permissions): the
+    // /permissions variant requires a target_id and 404s without one.
     const installUrl = new URL(
-      `https://github.com/apps/${appSlug}/installations/new/permissions`,
+      `https://github.com/apps/${appSlug}/installations/new`,
     );
     installUrl.searchParams.set("state", state);
     return redirectWithInstallCookies(installUrl, redirectTo, state);

--- a/apps/web/app/deploy-your-own/page.tsx
+++ b/apps/web/app/deploy-your-own/page.tsx
@@ -37,6 +37,7 @@ const DEPLOY_TEMPLATE_URL = (() => {
     ["project-name", "open-agents"],
     ["repository-name", "open-agents"],
     ["repository-url", "https://github.com/vercel-labs/open-agents"],
+    ["root-directory", "apps/web"],
     ["demo-title", "Open Agents"],
     [
       "demo-description",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}

--- a/docs/agents/lessons-learned.md
+++ b/docs/agents/lessons-learned.md
@@ -96,9 +96,10 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 
 ## GitHub App / PR Flows
 
-- GitHub App install flow uses a three-path strategy: (1) no linked account -- OAuth authorize URL with explicit `redirect_uri`, callback chains to install with `target_id`; (2) linked account but no installations -- `installations/new/permissions?target_id={githubId}` directly; (3) linked account with installations -- `select_target` for the account/org picker. Disable "Request user authorization (OAuth) during installation" on the GitHub App -- it causes auto-redirect loops for already-authorized users on both `select_target` and `installations/new/permissions`.
+- GitHub App install flow uses a three-path strategy: (1) no linked account -- OAuth authorize URL with explicit `redirect_uri`, callback chains to install with `target_id`; (2) linked account but no installations -- `installations/new` for the account picker; (3) linked account with installations -- `select_target` for the account/org picker. Disable "Request user authorization (OAuth) during installation" on the GitHub App -- it causes auto-redirect loops for already-authorized users on both `select_target` and `installations/new/permissions`.
+- GitHub's `/installations/new/permissions` URL requires a `target_id`; without one it 404s for authenticated users. Use `/installations/new` when the account still needs to be selected.
 - GitHub App must be made **public** for the org picker to appear during installation. While the app is private, `/installations/select_target` only shows the owner's personal account -- users cannot install on organizations. Use "Make public" in the GitHub App's Danger Zone when ready.
-- Use `/installations/select_target` instead of `/installations/new` for the GitHub App install URL; the latter silently redirects to an existing personal installation's settings page instead of showing the account/org picker.
+- When local installations already exist, use `/installations/select_target` instead of `/installations/new`; the latter silently redirects to an existing personal installation's settings page instead of showing the account/org picker.
 - GitHub App callbacks that process OAuth `code` or `installation_id` must validate a server-stored `state` nonce before linking accounts or syncing installations; never trust callback query params without CSRF/state verification.
 - Installation sync that prunes DB records must fetch all GitHub API pages first (`per_page=100` + pagination); pruning from a partial page can silently remove valid installations.
 - In the GitHub App install flow, do a user-token installation sync before redirecting after OAuth-only callbacks or treating zero local installation rows as "not installed"; GitHub can skip callback emissions for pre-existing installs.
@@ -106,3 +107,7 @@ Hard-won knowledge from building this codebase. When you make a mistake or disco
 - GitHub fork creation can take longer than a few seconds to become pushable; PR fallback should retry fork push on transient `repository not found` errors instead of failing immediately.
 - Git push failures from Vercel sandboxes can return empty output even when auth/write is denied; PR fallback logic should not rely only on matching "permission" text before attempting fork fallback.
 - When the GitHub App lacks push access (e.g. repo removed from installation scope), fail fast with a 403 directing users to /settings/connections rather than silently forking.
+
+## Deployment
+
+- Vercel imports should set **Root Directory** to `apps/web`, and `apps/web/vercel.json` should pin `"framework": "nextjs"`. A null framework preset can let the build command succeed without invoking the Next.js builder, leaving every deployed route returning the platform `NOT_FOUND` response.

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,7 @@
         "REDIS_URL",
         "VERCEL_APP_CLIENT_SECRET"
       ],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "dev": { "cache": false, "persistent": true },
     "typecheck": { "dependsOn": ["^typecheck"], "outputs": [] },


### PR DESCRIPTION
Collection of fixes needed after trying to roll-out open-agents in a demo repository. Mostly suppressing warnings but also fixing an issue around personal GH apps.

- Set Turborepo outputs to Next.js artifacts
- Fix GH app installation url
- Add `apps/web` as deployment root for Deploy to Vercel
