### PR TITLE
Fix/harness session keying

### DIFF
--- a/apps/web/app/workflows/chat.test.ts
+++ b/apps/web/app/workflows/chat.test.ts
@@ -579,6 +579,19 @@ describe("runAgentWorkflow", () => {
     });
   });
 
+  test("keys the harness session to the chat, not the message", async () => {
+    await runAgentWorkflow(
+      makeOptions({ harnessId: "codex", chatId: "chat-1" }),
+    );
+
+    // Regression: the harness session id must be stable across messages within
+    // a chat. Including the message id here spun up a fresh Claude Code/Codex
+    // session every turn and orphaned the previous one.
+    expect(spies.runHarnessTurn.mock.calls[0]?.[0]).toMatchObject({
+      sessionId: "codex-chat-1",
+    });
+  });
+
   test("rejects a second external harness in the same sandbox", async () => {
     spies.claimHarnessOwnership.mockResolvedValueOnce("conflict");
 

--- a/apps/web/app/workflows/chat.ts
+++ b/apps/web/app/workflows/chat.ts
@@ -1171,7 +1171,7 @@ const runHarnessAgentStep = async (
       harnessId,
       sandboxState,
       workingDirectory,
-      sessionId: `${harnessId}-${chatId}-${messageId}`.slice(0, 128),
+      sessionId: `${harnessId}-${chatId}`.slice(0, 128),
       messageId,
       messages: messages as HarnessUIMessage[],
       originalMessages: originalMessages as HarnessUIMessage[],


### PR DESCRIPTION
- Harness session id included messageId
   - every turn spun up a fresh Claude Code/Codex session and orphaned the prev one
- Keyed to harness + chat so the session persists across messages
- adds a regression test.